### PR TITLE
Fix for games that use DXGI Present testing

### DIFF
--- a/.vs/ProjectSettings.json
+++ b/.vs/ProjectSettings.json
@@ -1,0 +1,3 @@
+{
+  "CurrentProjectSetting": "x86-Debug"
+}

--- a/.vs/VSWorkspaceState.json
+++ b/.vs/VSWorkspaceState.json
@@ -1,0 +1,13 @@
+{
+  "ExpandedNodes": [
+    "",
+    "\\source",
+    "\\source\\d3d10",
+    "\\source\\d3d11",
+    "\\source\\d3d9",
+    "\\source\\dxgi",
+    "\\source\\windows"
+  ],
+  "SelectedNode": "\\source\\dxgi\\dxgi_device.cpp",
+  "PreviewInSolutionExplorer": false
+}

--- a/source/dxgi/dxgi_swapchain.cpp
+++ b/source/dxgi/dxgi_swapchain.cpp
@@ -176,16 +176,24 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::GetDevice(REFIID riid, void **ppDevice)
 }
 HRESULT STDMETHODCALLTYPE DXGISwapChain::Present(UINT SyncInterval, UINT Flags)
 {
-	switch (_direct3d_version)
+	// Many new D3D11 games will test swapchain presentation for timing and composition purposes.
+	//
+	//  * These calls are NOT render-related, but rather a status request for the D3D runtime.
+	//  * They should not be reshaded or even counted when determining framerate.
+	//
+	if (! (Flags & DXGI_PRESENT_TEST))
 	{
-		case 10:
-			assert(_runtime != nullptr);
-			std::static_pointer_cast<reshade::d3d10::d3d10_runtime>(_runtime)->on_present();
-			break;
-		case 11:
-			assert(_runtime != nullptr);
-			std::static_pointer_cast<reshade::d3d11::d3d11_runtime>(_runtime)->on_present();
-			break;
+		switch (_direct3d_version)
+		{
+			case 10:
+				assert(_runtime != nullptr);
+				std::static_pointer_cast<reshade::d3d10::d3d10_runtime>(_runtime)->on_present();
+				break;
+			case 11:
+				assert(_runtime != nullptr);
+				std::static_pointer_cast<reshade::d3d11::d3d11_runtime>(_runtime)->on_present();
+				break;
+		}
 	}
 
 	return _orig->Present(SyncInterval, Flags);
@@ -307,16 +315,24 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::Present1(UINT SyncInterval, UINT Presen
 {
 	assert(_interface_version >= 1);
 
-	switch (_direct3d_version)
+	// Many new D3D11 games will test swapchain presentation for timing and composition purposes.
+	//
+	//  * These calls are NOT render-related, but rather a status request for the D3D runtime.
+	//  * They should not be reshaded or even counted when determining framerate.
+	//
+	if (! (PresentFlags & DXGI_PRESENT_TEST))
 	{
-		case 10:
-			assert(_runtime != nullptr);
-			std::static_pointer_cast<reshade::d3d10::d3d10_runtime>(_runtime)->on_present();
-			break;
-		case 11:
-			assert(_runtime != nullptr);
-			std::static_pointer_cast<reshade::d3d11::d3d11_runtime>(_runtime)->on_present();
-			break;
+		switch (_direct3d_version)
+		{
+			case 10:
+				assert(_runtime != nullptr);
+				std::static_pointer_cast<reshade::d3d10::d3d10_runtime>(_runtime)->on_present();
+				break;
+			case 11:
+				assert(_runtime != nullptr);
+				std::static_pointer_cast<reshade::d3d11::d3d11_runtime>(_runtime)->on_present();
+				break;
+		}
 	}
 
 	return static_cast<IDXGISwapChain1 *>(_orig)->Present1(SyncInterval, PresentFlags, pPresentParameters);


### PR DESCRIPTION
Some newer games will issue `IDXGISwapChain*::Present* (...)` using the flag `DXGI_PRESENT_TEST`.

When these calls are encountered, they are not actually presenting anything. This is a status inquiry similar to D3D9's cooperative level to check for device reset, and may be used to test swapchain latency, a partially covered window and various other  things prior to drawing anything.

These calls ***should not*** be passed through ReShade's render pipeline, they should be ignored and passed directly to the DXGI runtime. Framerate counting, performance and stability will suffer in games like Deus Ex: Mankind Divided if software fails to ignore these calls.