### PR TITLE
Fix for KOF CBT black screen + more

### DIFF
--- a/source/com_ptr.hpp
+++ b/source/com_ptr.hpp
@@ -20,6 +20,11 @@ public:
 	{
 		reset(copy._object);
 	}
+	com_ptr(com_ptr<T> &&move) : _object(nullptr)
+	{
+		std::swap(_object, move._object);
+	}
+
 	~com_ptr()
 	{
 		reset();
@@ -76,6 +81,18 @@ public:
 	com_ptr<T> &operator=(const com_ptr<T> &copy)
 	{
 		reset(copy._object);
+
+		return *this;
+	}
+	com_ptr<T> &operator=(com_ptr<T> &&move)
+	{
+		if (_object != nullptr)
+		{
+			_object->Release();
+		}
+
+		_object = move._object;
+		move._object = nullptr;
 
 		return *this;
 	}

--- a/source/d3d10/d3d10_effect_compiler.cpp
+++ b/source/d3d10/d3d10_effect_compiler.cpp
@@ -231,7 +231,7 @@ namespace reshade::d3d10
 			com_ptr<ID3D10Buffer> constant_buffer;
 			_runtime->_device->CreateBuffer(&globals_desc, &globals_initial, &constant_buffer);
 
-			_runtime->_constant_buffers.push_back(constant_buffer);
+			_runtime->_constant_buffers.push_back(std::move(constant_buffer));
 		}
 
 		FreeLibrary(_d3dcompiler_module);

--- a/source/d3d10/d3d10_effect_compiler.cpp
+++ b/source/d3d10/d3d10_effect_compiler.cpp
@@ -15,7 +15,7 @@ namespace reshade::d3d10
 	using namespace reshadefx;
 	using namespace reshadefx::nodes;
 
-	static inline UINT roundto16(UINT size)
+	static inline size_t roundto16(size_t size)
 	{
 		return (size + 15) & ~15;
 	}
@@ -225,8 +225,8 @@ namespace reshade::d3d10
 			_constant_buffer_size = roundto16(_constant_buffer_size);
 			_runtime->get_uniform_value_storage().resize(_uniform_storage_offset + _constant_buffer_size);
 
-			const CD3D10_BUFFER_DESC globals_desc(_constant_buffer_size, D3D10_BIND_CONSTANT_BUFFER, D3D10_USAGE_DYNAMIC, D3D10_CPU_ACCESS_WRITE);
-			const D3D10_SUBRESOURCE_DATA globals_initial = { _runtime->get_uniform_value_storage().data(), _constant_buffer_size };
+			const CD3D10_BUFFER_DESC globals_desc(static_cast<UINT>(_constant_buffer_size), D3D10_BIND_CONSTANT_BUFFER, D3D10_USAGE_DYNAMIC, D3D10_CPU_ACCESS_WRITE);
+			const D3D10_SUBRESOURCE_DATA globals_initial = { _runtime->get_uniform_value_storage().data(), static_cast<UINT>(_constant_buffer_size) };
 
 			com_ptr<ID3D10Buffer> constant_buffer;
 			_runtime->_device->CreateBuffer(&globals_desc, &globals_initial, &constant_buffer);

--- a/source/d3d11/d3d11_effect_compiler.cpp
+++ b/source/d3d11/d3d11_effect_compiler.cpp
@@ -231,7 +231,7 @@ namespace reshade::d3d11
 			com_ptr<ID3D11Buffer> constant_buffer;
 			_runtime->_device->CreateBuffer(&globals_desc, &globals_initial, &constant_buffer);
 
-			_runtime->_constant_buffers.push_back(constant_buffer);
+			_runtime->_constant_buffers.push_back(std::move(constant_buffer));
 		}
 
 		FreeLibrary(_d3dcompiler_module);

--- a/source/d3d11/d3d11_effect_compiler.cpp
+++ b/source/d3d11/d3d11_effect_compiler.cpp
@@ -15,7 +15,7 @@ namespace reshade::d3d11
 	using namespace reshadefx;
 	using namespace reshadefx::nodes;
 
-	static inline UINT roundto16(UINT size)
+	static inline size_t roundto16(size_t size)
 	{
 		return (size + 15) & ~15;
 	}
@@ -225,8 +225,8 @@ namespace reshade::d3d11
 			_constant_buffer_size = roundto16(_constant_buffer_size);
 			_runtime->get_uniform_value_storage().resize(_uniform_storage_offset + _constant_buffer_size);
 
-			const CD3D11_BUFFER_DESC globals_desc(_constant_buffer_size, D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
-			const D3D11_SUBRESOURCE_DATA globals_initial = { _runtime->get_uniform_value_storage().data() + _uniform_storage_offset, _constant_buffer_size };
+			const CD3D11_BUFFER_DESC globals_desc(static_cast<UINT>(_constant_buffer_size), D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
+			const D3D11_SUBRESOURCE_DATA globals_initial = { _runtime->get_uniform_value_storage().data() + _uniform_storage_offset, static_cast<UINT>(_constant_buffer_size) };
 
 			com_ptr<ID3D11Buffer> constant_buffer;
 			_runtime->_device->CreateBuffer(&globals_desc, &globals_initial, &constant_buffer);

--- a/source/d3d9/d3d9_runtime.cpp
+++ b/source/d3d9/d3d9_runtime.cpp
@@ -605,8 +605,8 @@ namespace reshade::d3d9
 		if (technique.uniform_storage_index >= 0)
 		{
 			const auto uniform_storage_data = reinterpret_cast<const float *>(get_uniform_value_storage().data() + technique.uniform_storage_offset);
-			_device->SetVertexShaderConstantF(0, uniform_storage_data, technique.uniform_storage_index);
-			_device->SetPixelShaderConstantF(0, uniform_storage_data, technique.uniform_storage_index);
+			_device->SetVertexShaderConstantF(0, uniform_storage_data, static_cast<UINT>(technique.uniform_storage_index));
+			_device->SetPixelShaderConstantF(0, uniform_storage_data, static_cast<UINT>(technique.uniform_storage_index));
 		}
 
 		for (const auto &pass_object : technique.passes)

--- a/source/directory_watcher.cpp
+++ b/source/directory_watcher.cpp
@@ -18,7 +18,7 @@ namespace reshade::filesystem
 		_completion_handle = CreateIoCompletionPort(_file_handle, nullptr, reinterpret_cast<ULONG_PTR>(_file_handle), 1);
 
 		OVERLAPPED overlapped = { };
-		ReadDirectoryChangesW(_file_handle, _buffer.data(), _buffer.size(), TRUE, FILE_NOTIFY_CHANGE_LAST_WRITE, nullptr, &overlapped, nullptr);
+		ReadDirectoryChangesW(_file_handle, _buffer.data(), static_cast<DWORD>(_buffer.size()), TRUE, FILE_NOTIFY_CHANGE_LAST_WRITE, nullptr, &overlapped, nullptr);
 	}
 	directory_watcher::~directory_watcher()
 	{
@@ -67,7 +67,7 @@ namespace reshade::filesystem
 
 		overlapped->hEvent = nullptr;
 
-		ReadDirectoryChangesW(_file_handle, _buffer.data(), _buffer.size(), TRUE, FILE_NOTIFY_CHANGE_LAST_WRITE, nullptr, overlapped, nullptr);
+		ReadDirectoryChangesW(_file_handle, _buffer.data(), static_cast<DWORD>(_buffer.size()), TRUE, FILE_NOTIFY_CHANGE_LAST_WRITE, nullptr, overlapped, nullptr);
 
 		return true;
 	}

--- a/source/filesystem.hpp
+++ b/source/filesystem.hpp
@@ -23,7 +23,7 @@ namespace reshade::filesystem
 	public:
 		path() { }
 		path(const char *data) : _data(data) { }
-		path(const std::string &data) : _data(data) { }
+		path(std::string data) : _data(std::move(data)) { }
 
 		bool operator==(const path &other) const;
 		bool operator!=(const path &other) const;

--- a/source/lexer.cpp
+++ b/source/lexer.cpp
@@ -535,7 +535,7 @@ namespace reshadefx
 	void lexer::skip(size_t length)
 	{
 		_cur += length;
-		_cur_location.column += length;
+		_cur_location.column += static_cast<unsigned int>(length);
 	}
 	void lexer::skip_space()
 	{

--- a/source/opengl/opengl_effect_compiler.cpp
+++ b/source/opengl/opengl_effect_compiler.cpp
@@ -428,7 +428,7 @@ namespace reshade::opengl
 
 			glBindBuffer(GL_UNIFORM_BUFFER, previous);
 
-			_runtime->_effect_ubos.push_back(std::make_pair(ubo, _uniform_buffer_size));
+			_runtime->_effect_ubos.emplace_back(ubo, _uniform_buffer_size);
 		}
 
 		return _success;

--- a/source/opengl/opengl_effect_compiler.cpp
+++ b/source/opengl/opengl_effect_compiler.cpp
@@ -2226,7 +2226,7 @@ namespace reshade::opengl
 
 		auto &uniform_storage = _runtime->get_uniform_value_storage();
 
-		if (_uniform_storage_offset + _uniform_buffer_size >= uniform_storage.size())
+		if (_uniform_storage_offset + _uniform_buffer_size >= static_cast<ptrdiff_t>(uniform_storage.size()))
 		{
 			uniform_storage.resize(uniform_storage.size() + 128);
 		}

--- a/source/opengl/opengl_effect_compiler.hpp
+++ b/source/opengl/opengl_effect_compiler.hpp
@@ -78,6 +78,6 @@ namespace reshade::opengl
 		std::stringstream _global_code, _global_uniforms;
 		const reshadefx::nodes::function_declaration_node *_current_function;
 		std::unordered_map<const reshadefx::nodes::function_declaration_node *, function> _functions;
-		int _uniform_storage_offset = 0, _uniform_buffer_size = 0;
+		GLintptr _uniform_storage_offset = 0, _uniform_buffer_size = 0;
 	};
 }

--- a/source/opengl/opengl_runtime.cpp
+++ b/source/opengl/opengl_runtime.cpp
@@ -475,7 +475,7 @@ namespace reshade::opengl
 		_stateblock.apply();
 
 		if (gl3wClipControl != nullptr
-			&& (clip_origin != GL_LOWER_LEFT && clip_depthmode != GL_ZERO_TO_ONE))
+			&& (clip_origin != GL_LOWER_LEFT || clip_depthmode != GL_ZERO_TO_ONE))
 		{
 			glClipControl(clip_origin, clip_depthmode);
 		}

--- a/source/opengl/opengl_runtime.hpp
+++ b/source/opengl/opengl_runtime.hpp
@@ -77,7 +77,7 @@ namespace reshade::opengl
 		GLuint _depth_source_fbo = 0, _depth_source = 0, _depth_texture = 0, _blit_fbo = 0;
 		std::vector<struct opengl_sampler> _effect_samplers;
 		GLuint _default_vao = 0;
-		std::vector<std::pair<GLuint, GLsizei>> _effect_ubos;
+		std::vector<std::pair<GLuint, GLsizeiptr>> _effect_ubos;
 
 	private:
 		struct depth_source_info

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -755,7 +755,7 @@ namespace reshade
 		const filesystem::path parent_path = s_reshade_dll_path.parent_path();
 		auto preset_files2 = filesystem::list_files(parent_path, "*.ini");
 		auto preset_files3 = filesystem::list_files(parent_path, "*.txt");
-		preset_files2.insert(preset_files2.end(), preset_files3.begin(), preset_files3.end());
+		preset_files2.insert(preset_files2.end(), std::make_move_iterator(preset_files3.begin()), std::make_move_iterator(preset_files3.end()));
 
 		for (const auto &preset_file : preset_files2)
 		{

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -747,7 +747,7 @@ namespace reshade
 		imgui_style.Colors[ImGuiCol_PopupBg] = ImVec4(_imgui_col_item_background[0], _imgui_col_item_background[1], _imgui_col_item_background[2], 0.92f);
 
 
-		if (_current_preset >= _preset_files.size())
+		if (_current_preset >= static_cast<ptrdiff_t>(_preset_files.size()))
 		{
 			_current_preset = -1;
 		}
@@ -1230,7 +1230,7 @@ namespace reshade
 
 			ImGui::PushItemWidth(-(30 + ImGui::GetStyle().ItemSpacing.x) * 2 - 1);
 
-			if (ImGui::Combo("##presets", &_current_preset, get_preset_file, this, _preset_files.size()))
+			if (ImGui::Combo("##presets", &_current_preset, get_preset_file, this, static_cast<int>(_preset_files.size())))
 			{
 				save_configuration();
 
@@ -1266,7 +1266,7 @@ namespace reshade
 					{
 						_preset_files.push_back(path);
 
-						_current_preset = _preset_files.size() - 1;
+						_current_preset = static_cast<int>(_preset_files.size()) - 1;
 
 						load_preset(path);
 						save_configuration();
@@ -1300,7 +1300,7 @@ namespace reshade
 					{
 						_preset_files.erase(_preset_files.begin() + _current_preset);
 
-						if (_current_preset == _preset_files.size())
+						if (_current_preset == static_cast<ptrdiff_t>(_preset_files.size()))
 						{
 							_current_preset -= 1;
 						}

--- a/source/runtime_objects.hpp
+++ b/source/runtime_objects.hpp
@@ -107,6 +107,6 @@ namespace reshade
 		int timeout = 0, timeleft = 0, toggle_key = 0;
 		bool toggle_key_ctrl = false, toggle_key_shift = false, toggle_key_alt = false;
 		moving_average<uint64_t, 60> average_duration;
-		int uniform_storage_offset = 0, uniform_storage_index = -1;
+		ptrdiff_t uniform_storage_offset = 0, uniform_storage_index = -1;
 	};
 }


### PR DESCRIPTION
I changed quite a few things:

1. Changed uniform storage variables to GL*ptr variables - they are created from natural word size variables (used to be truncated) and used as parameters where GL functions expect GLptr variables - so figured this will make 32-bit and 64-bit OpenGL implementation more consistent.
2. Added more move semantics.
3. Merged and altered a fix from @bacondither, as mentioned in KOF topic on ReShade forums:
https://github.com/bacondither/reshade/commit/81c607e49269f843c7b02f494b62de0e9a9d9463
I preserved the check, albeit with fixed conditions.

I also planned to port some of the changes made in d3d8to9 over the last couple of months - mainly interlocked refcounting. However, I guess I'll push this separately given 3. is a quite major bugfix, making ReShade usable in more games.

Cheers!