### PR TITLE
Only load enabled effects in performance mode

### DIFF
--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -801,7 +801,7 @@ namespace reshade
 		{
 			for (auto &path : paths)
 			{
-				path = std::move(filesystem::absolute(path, parent_path));
+				path = filesystem::absolute(path, parent_path);
 			}
 		};
 		to_absolute(_preset_files);

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -195,7 +195,9 @@ namespace reshade
 		void load_configuration();
 		void save_configuration() const;
 		void load_preset(const filesystem::path &path);
+		void load_current_preset();
 		void save_preset(const filesystem::path &path) const;
+		void save_current_preset() const;
 		void save_screenshot() const;
 
 		void draw_overlay();

--- a/source/variant.hpp
+++ b/source/variant.hpp
@@ -24,6 +24,9 @@ namespace reshade
 		variant(const std::string &value) : _values(1, value) { }
 		template <>
 		variant(const std::vector<std::string> &values) : _values(values) { }
+		variant(const std::vector<std::string> &&values) : _values(std::move(values)) { }
+		template<class InputIt>
+		variant(InputIt first, InputIt last) : _values(first, last) { }
 		template <>
 		variant(const filesystem::path &value) : variant(value.string()) { }
 		template <>


### PR DESCRIPTION
Significantly improves startup time in performance mode with a full shaders checkout.
This makes it more feasible to share a single shaders directory for all games since unused effects won't get loaded.

I did change the preset file format slightly though, so newer versions wouldn't properly load with an old preset file. The solution would be to simply turn off performance mode once, re-enable the desired effects, then turn performance mode back on.

I'll remove the cleanup commit if you want. It was originally part of some changes that were relevant to the PR, but the final solution didn't use them. I left it in because I still think it improves the code, but it doesn't really matter.