### PR TITLE
Change default `active` color to contrast more

### DIFF
--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -225,7 +225,7 @@ namespace reshade
 		bool _show_clock = false, _show_framerate = false;
 		bool _overlay_key_setting_active = false, _screenshot_key_setting_active = false, _toggle_key_setting_active = false;
 		float _imgui_col_background[3] = { 0.275f, 0.275f, 0.275f }, _imgui_col_item_background[3] = { 0.447f, 0.447f, 0.447f };
-		float _imgui_col_active[3] = { 0.2f, 0.5f, 0.6f }, _imgui_col_text[3] = { 0.8f, 0.9f, 0.9f }, _imgui_col_text_fps[3] = { 1.0f, 1.0f, 0.0f };
+		float _imgui_col_active[3] = { 0.2f, 0.2f, 1.0f }, _imgui_col_text[3] = { 0.8f, 0.9f, 0.9f }, _imgui_col_text_fps[3] = { 1.0f, 1.0f, 0.0f };
 		float _variable_editor_height = 0.0f;
 		unsigned int _tutorial_index = 0, _effects_expanded_state = 2;
 		char _effect_filter_buffer[64] = { };


### PR DESCRIPTION
I'm color blind and was having a lot of trouble telling whether a checkbox was checked.
This is a contrast tweak.