### PR TITLE
D3d9

### DIFF
--- a/source/d3d9/d3d9_device.cpp
+++ b/source/d3d9/d3d9_device.cpp
@@ -451,6 +451,8 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice9::EndScene()
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice9::Clear(DWORD Count, const D3DRECT *pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil)
 {
+	_implicit_swapchain->_runtime->on_clear(Flags);
+											
 	return _orig->Clear(Count, pRects, Flags, Color, Z, Stencil);
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice9::SetTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX *pMatrix)

--- a/source/d3d9/d3d9_runtime.cpp
+++ b/source/d3d9/d3d9_runtime.cpp
@@ -55,11 +55,11 @@ namespace reshade::d3d9
 			switch (_backbuffer_format)
 			{
 			        case D3DFMT_X8R8G8B8:
-				    _backbuffer_format = D3DFMT_A8R8G8B8;
-				    break;
+				        _backbuffer_format = D3DFMT_A8R8G8B8;
+			                break;
 			        case D3DFMT_X8B8G8R8:
-				    _backbuffer_format = D3DFMT_A8B8G8R8;
-				    break;
+			                _backbuffer_format = D3DFMT_A8B8G8R8;
+			                break;
 			}
 
 			hr = _device->CreateRenderTarget(_width, _height, _backbuffer_format, D3DMULTISAMPLE_NONE, 0, FALSE, &_backbuffer_resolved, nullptr);

--- a/source/d3d9/d3d9_runtime.cpp
+++ b/source/d3d9/d3d9_runtime.cpp
@@ -169,7 +169,7 @@ namespace reshade::d3d9
 
 		font_atlas->UnlockRect(0);
 
-		d3d9_tex_data obj = {};
+		d3d9_tex_data obj = { };
 		obj.texture = font_atlas;
 
 		_imgui_font_atlas_texture = std::make_unique<d3d9_tex_data>(obj);
@@ -434,19 +434,19 @@ namespace reshade::d3d9
 	{
 		switch (type)
 		{
-		case D3DPT_LINELIST:
-			vertices *= 2;
-			break;
-		case D3DPT_LINESTRIP:
-			vertices += 1;
-			break;
-		case D3DPT_TRIANGLELIST:
-			vertices *= 3;
-			break;
-		case D3DPT_TRIANGLESTRIP:
-		case D3DPT_TRIANGLEFAN:
-			vertices += 2;
-			break;
+			case D3DPT_LINELIST:
+				vertices *= 2;
+				break;
+			case D3DPT_LINESTRIP:
+				vertices += 1;
+				break;
+			case D3DPT_TRIANGLELIST:
+				vertices *= 3;
+				break;
+			case D3DPT_TRIANGLESTRIP:
+			case D3DPT_TRIANGLEFAN:
+				vertices += 2;
+				break;
 		}
 
 		_vertices += vertices;

--- a/source/d3d9/d3d9_runtime.cpp
+++ b/source/d3d9/d3d9_runtime.cpp
@@ -1,7 +1,7 @@
 /**
- * Copyright (C) 2014 Patrick Mours. All rights reserved.
- * License: https://github.com/crosire/reshade#license
- */
+* Copyright (C) 2014 Patrick Mours. All rights reserved.
+* License: https://github.com/crosire/reshade#license
+*/
 
 #include "log.hpp"
 #include "d3d9_runtime.hpp"
@@ -54,12 +54,12 @@ namespace reshade::d3d9
 		{
 			switch (_backbuffer_format)
 			{
-				case D3DFMT_X8R8G8B8:
-					_backbuffer_format = D3DFMT_A8R8G8B8;
-					break;
-				case D3DFMT_X8B8G8R8:
-					_backbuffer_format = D3DFMT_A8B8G8R8;
-					break;
+			case D3DFMT_X8R8G8B8:
+				_backbuffer_format = D3DFMT_A8R8G8B8;
+				break;
+			case D3DFMT_X8B8G8R8:
+				_backbuffer_format = D3DFMT_A8B8G8R8;
+				break;
 			}
 
 			hr = _device->CreateRenderTarget(_width, _height, _backbuffer_format, D3DMULTISAMPLE_NONE, 0, FALSE, &_backbuffer_resolved, nullptr);
@@ -169,7 +169,7 @@ namespace reshade::d3d9
 
 		font_atlas->UnlockRect(0);
 
-		d3d9_tex_data obj = { };
+		d3d9_tex_data obj = {};
 		obj.texture = font_atlas;
 
 		_imgui_font_atlas_texture = std::make_unique<d3d9_tex_data>(obj);
@@ -265,6 +265,8 @@ namespace reshade::d3d9
 
 		runtime::on_reset();
 
+		_clear_DSV_iter = 1;
+
 		// Destroy resources
 		_stateblock.reset();
 
@@ -273,10 +275,12 @@ namespace reshade::d3d9
 		_backbuffer_texture.reset();
 		_backbuffer_texture_surface.reset();
 
+		_best_depthstencil.reset();
 		_depthstencil.reset();
 		_depthstencil_replacement.reset();
 		_depthstencil_texture.reset();
 
+		_default_depthstencil->Release();
 		_default_depthstencil.reset();
 
 		_effect_triangle_buffer.reset();
@@ -308,7 +312,28 @@ namespace reshade::d3d9
 
 		runtime::on_frame();
 
-		detect_depth_source();
+		// refresh depth buffer after detection settings has changed
+		if (_depth_buffer_settings_changed)
+		{
+			create_depthstencil_replacement(nullptr, true);
+			_depth_buffer_settings_changed = false;
+		}
+		else
+		{
+			detect_depth_source(_depth_buffer_before_clear);
+		}
+
+		// fix for cinematics
+		if (_depth_buffer_before_clear)
+		{
+			if (_depth_buffer_retrieved_at_clearing_stage == false)
+			{
+				create_depthstencil_replacement(nullptr, true);
+			}
+		}
+
+		_clear_DSV_iter = 1;
+		_depth_buffer_retrieved_at_clearing_stage = false;
 
 		// Capture device state
 		_stateblock->Capture();
@@ -381,23 +406,47 @@ namespace reshade::d3d9
 		// End post processing
 		_device->EndScene();
 	}
+	void d3d9_runtime::on_clear(DWORD Flags)
+	{
+		if (_depth_buffer_before_clear)
+		{
+			if (_depth_buffer_clearing_number > 0)
+			{
+				if (_clear_DSV_iter == _depth_buffer_clearing_number)
+				{
+					_depth_buffer_retrieved_at_clearing_stage = true;
+					detect_depth_source(true);
+				}
+			}
+			else
+			{
+				if (_depth_buffer_clearing_flag_number == 0 || Flags == _depth_buffer_clearing_flag_number)
+				{
+					_depth_buffer_retrieved_at_clearing_stage = true;
+					detect_depth_source(true);
+				}
+			}
+		}
+
+		_clear_DSV_iter++;
+	}
 	void d3d9_runtime::on_draw_call(D3DPRIMITIVETYPE type, UINT vertices)
 	{
 		switch (type)
 		{
-			case D3DPT_LINELIST:
-				vertices *= 2;
-				break;
-			case D3DPT_LINESTRIP:
-				vertices += 1;
-				break;
-			case D3DPT_TRIANGLELIST:
-				vertices *= 3;
-				break;
-			case D3DPT_TRIANGLESTRIP:
-			case D3DPT_TRIANGLEFAN:
-				vertices += 2;
-				break;
+		case D3DPT_LINELIST:
+			vertices *= 2;
+			break;
+		case D3DPT_LINESTRIP:
+			vertices += 1;
+			break;
+		case D3DPT_TRIANGLELIST:
+			vertices *= 3;
+			break;
+		case D3DPT_TRIANGLESTRIP:
+		case D3DPT_TRIANGLEFAN:
+			vertices += 2;
+			break;
 		}
 
 		_vertices += vertices;
@@ -429,14 +478,26 @@ namespace reshade::d3d9
 			D3DSURFACE_DESC desc;
 			depthstencil->GetDesc(&desc);
 
-			// Early rejection
-			if ( desc.MultiSampleType != D3DMULTISAMPLE_NONE ||
-				(desc.Width < _width * 0.95 || desc.Width > _width * 1.05) ||
-				(desc.Height < _height * 0.95 || desc.Height > _height * 1.05))
+			if (_restrict_depth_buffer_dimensions)
 			{
-				return;
+				// Early rejection
+				if (desc.MultiSampleType != D3DMULTISAMPLE_NONE ||
+					(desc.Width < _width * 0.95 || desc.Width > _width * 1.05) ||
+					(desc.Height < _height * 0.95 || desc.Height > _height * 1.05))
+				{
+					return;
+				}
 			}
-	
+			else
+			{
+				if (desc.MultiSampleType != D3DMULTISAMPLE_NONE ||
+					(desc.Width < _width * 0.95) ||
+					(desc.Height < _height * 0.95))
+				{
+					return;
+				}
+			}
+
 			depthstencil->AddRef();
 
 			// Begin tracking
@@ -562,30 +623,30 @@ namespace reshade::d3d9
 
 		switch (texture.format)
 		{
-			case texture_format::r8:
-				for (UINT i = 0; i < size; i += 4, mapped_data += 4)
-					mapped_data[0] = 0,
-					mapped_data[1] = 0,
-					mapped_data[2] = data[i],
-					mapped_data[3] = 0;
-				break;
-			case texture_format::rg8:
-				for (UINT i = 0; i < size; i += 4, mapped_data += 4)
-					mapped_data[0] = 0,
-					mapped_data[1] = data[i + 1],
-					mapped_data[2] = data[i],
-					mapped_data[3] = 0;
-				break;
-			case texture_format::rgba8:
-				for (UINT i = 0; i < size; i += 4, mapped_data += 4)
-					mapped_data[0] = data[i + 2],
-					mapped_data[1] = data[i + 1],
-					mapped_data[2] = data[i],
-					mapped_data[3] = data[i + 3];
-				break;
-			default:
-				std::memcpy(mapped_data, data, size);
-				break;
+		case texture_format::r8:
+			for (UINT i = 0; i < size; i += 4, mapped_data += 4)
+				mapped_data[0] = 0,
+				mapped_data[1] = 0,
+				mapped_data[2] = data[i],
+				mapped_data[3] = 0;
+			break;
+		case texture_format::rg8:
+			for (UINT i = 0; i < size; i += 4, mapped_data += 4)
+				mapped_data[0] = 0,
+				mapped_data[1] = data[i + 1],
+				mapped_data[2] = data[i],
+				mapped_data[3] = 0;
+			break;
+		case texture_format::rgba8:
+			for (UINT i = 0; i < size; i += 4, mapped_data += 4)
+				mapped_data[0] = data[i + 2],
+				mapped_data[1] = data[i + 1],
+				mapped_data[2] = data[i],
+				mapped_data[3] = data[i + 3];
+			break;
+		default:
+			std::memcpy(mapped_data, data, size);
+			break;
 		}
 
 		mem_texture->UnlockRect(0);
@@ -606,14 +667,14 @@ namespace reshade::d3d9
 
 		switch (id)
 		{
-			case texture_reference::back_buffer:
-				new_reference = _backbuffer_texture;
-				break;
-			case texture_reference::depth_buffer:
-				new_reference = _depthstencil_texture;
-				break;
-			default:
-				return false;
+		case texture_reference::back_buffer:
+			new_reference = _backbuffer_texture;
+			break;
+		case texture_reference::depth_buffer:
+			new_reference = _depthstencil_texture;
+			break;
+		default:
+			return false;
 		}
 
 		texture.impl_reference = id;
@@ -845,14 +906,15 @@ namespace reshade::d3d9
 		}
 	}
 
-	void d3d9_runtime::detect_depth_source()
+	void d3d9_runtime::detect_depth_source(bool on_clear)
 	{
 		static int cooldown = 0, traffic = 0;
 
 		if (cooldown-- > 0)
 		{
 			traffic += g_network_traffic > 0;
-			return;
+			if (!on_clear)
+				return;
 		}
 		else
 		{
@@ -861,7 +923,7 @@ namespace reshade::d3d9
 			if (traffic > 10)
 			{
 				traffic = 0;
-				create_depthstencil_replacement(nullptr);
+				create_depthstencil_replacement(nullptr, false);
 				return;
 			}
 			else
@@ -876,7 +938,7 @@ namespace reshade::d3d9
 		}
 
 		depth_source_info best_info = { 0 };
-		IDirect3DSurface9 *best_match = nullptr;
+		_best_depthstencil.reset();
 
 		for (auto it = _depth_source_table.begin(); it != _depth_source_table.end();)
 		{
@@ -900,22 +962,30 @@ namespace reshade::d3d9
 				continue;
 			}
 
-			if ((depthstencil_info.vertices_count * (1.2f - float(depthstencil_info.drawcall_count) / _drawcalls)) >= (best_info.vertices_count * (1.2f - float(best_info.drawcall_count) / _drawcalls)))
+			if (!_depth_buffer_before_clear)
 			{
-				best_match = depthstencil;
+				if ((depthstencil_info.vertices_count * (1.2f - float(depthstencil_info.drawcall_count) / _drawcalls)) >= (best_info.vertices_count * (1.2f - float(best_info.drawcall_count) / _drawcalls)))
+				{
+					_best_depthstencil = depthstencil;
+					best_info = depthstencil_info;
+				}
+			}
+			else if (depthstencil_info.vertices_count >= best_info.vertices_count)
+			{
+				_best_depthstencil = depthstencil;
 				best_info = depthstencil_info;
 			}
 
 			depthstencil_info.drawcall_count = depthstencil_info.vertices_count = 0;
 		}
 
-		if (best_match != nullptr && _depthstencil != best_match)
+		if (_best_depthstencil != nullptr)
 		{
-			create_depthstencil_replacement(best_match);
+			if (on_clear || _depthstencil != _best_depthstencil)
+				create_depthstencil_replacement(_best_depthstencil.get(), on_clear);
 		}
 	}
-
-	bool d3d9_runtime::create_depthstencil_replacement(IDirect3DSurface9 *depthstencil)
+	bool d3d9_runtime::create_depthstencil_replacement(IDirect3DSurface9 *depthstencil, bool on_clear)
 	{
 		_depthstencil.reset();
 		_depthstencil_replacement.reset();
@@ -928,12 +998,14 @@ namespace reshade::d3d9
 			D3DSURFACE_DESC desc;
 			_depthstencil->GetDesc(&desc);
 
-			if (desc.Format != D3DFMT_INTZ && desc.Format != D3DFMT_DF16 && desc.Format != D3DFMT_DF24)
+			if (on_clear || (desc.Format != D3DFMT_INTZ && desc.Format != D3DFMT_DF16 && desc.Format != D3DFMT_DF24))
 			{
 				D3DDISPLAYMODE displaymode;
 				_swapchain->GetDisplayMode(&displaymode);
 				D3DDEVICE_CREATION_PARAMETERS creation_params;
 				_device->GetCreationParameters(&creation_params);
+				float depthBufferWidth = _width;
+				float depthBufferHeight = _height;
 
 				desc.Format = D3DFMT_UNKNOWN;
 				const D3DFORMAT formats[] = { D3DFMT_INTZ, D3DFMT_DF24, D3DFMT_DF16 };
@@ -954,7 +1026,13 @@ namespace reshade::d3d9
 					return false;
 				}
 
-				const HRESULT hr = _device->CreateTexture(desc.Width, desc.Height, 1, D3DUSAGE_DEPTHSTENCIL, desc.Format, D3DPOOL_DEFAULT, &_depthstencil_texture, nullptr);
+				if (_restrict_depth_buffer_dimensions)
+				{
+					depthBufferWidth = desc.Width;
+					depthBufferHeight = desc.Height;
+				}
+
+				const HRESULT hr = _device->CreateTexture(depthBufferWidth, depthBufferHeight, 1, D3DUSAGE_DEPTHSTENCIL, desc.Format, D3DPOOL_DEFAULT, &_depthstencil_texture, nullptr);
 
 				if (SUCCEEDED(hr))
 				{
@@ -966,7 +1044,7 @@ namespace reshade::d3d9
 
 					if (current_depthstencil != nullptr)
 					{
-						if (current_depthstencil == _depthstencil)
+						if (on_clear || current_depthstencil == _depthstencil)
 						{
 							_device->SetDepthStencilSurface(_depthstencil_replacement.get());
 						}

--- a/source/d3d9/d3d9_runtime.cpp
+++ b/source/d3d9/d3d9_runtime.cpp
@@ -667,14 +667,14 @@ namespace reshade::d3d9
 
 		switch (id)
 		{
-		case texture_reference::back_buffer:
-			new_reference = _backbuffer_texture;
-			break;
-		case texture_reference::depth_buffer:
-			new_reference = _depthstencil_texture;
-			break;
-		default:
-			return false;
+			case texture_reference::back_buffer:
+				new_reference = _backbuffer_texture;
+				break;
+			case texture_reference::depth_buffer:
+				new_reference = _depthstencil_texture;
+				break;
+			default:
+				return false;
 		}
 
 		texture.impl_reference = id;

--- a/source/d3d9/d3d9_runtime.cpp
+++ b/source/d3d9/d3d9_runtime.cpp
@@ -54,12 +54,12 @@ namespace reshade::d3d9
 		{
 			switch (_backbuffer_format)
 			{
-			        case D3DFMT_X8R8G8B8:
-				        _backbuffer_format = D3DFMT_A8R8G8B8;
-			                break;
-			        case D3DFMT_X8B8G8R8:
-			                _backbuffer_format = D3DFMT_A8B8G8R8;
-			                break;
+				case D3DFMT_X8R8G8B8:
+					_backbuffer_format = D3DFMT_A8R8G8B8;
+					break;
+				case D3DFMT_X8B8G8R8:
+					_backbuffer_format = D3DFMT_A8B8G8R8;
+					break;
 			}
 
 			hr = _device->CreateRenderTarget(_width, _height, _backbuffer_format, D3DMULTISAMPLE_NONE, 0, FALSE, &_backbuffer_resolved, nullptr);

--- a/source/d3d9/d3d9_runtime.cpp
+++ b/source/d3d9/d3d9_runtime.cpp
@@ -1,7 +1,7 @@
 /**
-* Copyright (C) 2014 Patrick Mours. All rights reserved.
-* License: https://github.com/crosire/reshade#license
-*/
+ * Copyright (C) 2014 Patrick Mours. All rights reserved.
+ * License: https://github.com/crosire/reshade#license
+ */
 
 #include "log.hpp"
 #include "d3d9_runtime.hpp"
@@ -54,12 +54,12 @@ namespace reshade::d3d9
 		{
 			switch (_backbuffer_format)
 			{
-			    case D3DFMT_X8R8G8B8:
-				_backbuffer_format = D3DFMT_A8R8G8B8;
-				break;
-			    case D3DFMT_X8B8G8R8:
-				_backbuffer_format = D3DFMT_A8B8G8R8;
-				break;
+			        case D3DFMT_X8R8G8B8:
+				    _backbuffer_format = D3DFMT_A8R8G8B8;
+				    break;
+			        case D3DFMT_X8B8G8R8:
+				    _backbuffer_format = D3DFMT_A8B8G8R8;
+				    break;
 			}
 
 			hr = _device->CreateRenderTarget(_width, _height, _backbuffer_format, D3DMULTISAMPLE_NONE, 0, FALSE, &_backbuffer_resolved, nullptr);

--- a/source/d3d9/d3d9_runtime.cpp
+++ b/source/d3d9/d3d9_runtime.cpp
@@ -54,10 +54,10 @@ namespace reshade::d3d9
 		{
 			switch (_backbuffer_format)
 			{
-			case D3DFMT_X8R8G8B8:
+			    case D3DFMT_X8R8G8B8:
 				_backbuffer_format = D3DFMT_A8R8G8B8;
 				break;
-			case D3DFMT_X8B8G8R8:
+			    case D3DFMT_X8B8G8R8:
 				_backbuffer_format = D3DFMT_A8B8G8R8;
 				break;
 			}
@@ -623,28 +623,28 @@ namespace reshade::d3d9
 
 		switch (texture.format)
 		{
-		case texture_format::r8:
+		    case texture_format::r8:
 			for (UINT i = 0; i < size; i += 4, mapped_data += 4)
 				mapped_data[0] = 0,
 				mapped_data[1] = 0,
 				mapped_data[2] = data[i],
 				mapped_data[3] = 0;
 			break;
-		case texture_format::rg8:
+		    case texture_format::rg8:
 			for (UINT i = 0; i < size; i += 4, mapped_data += 4)
 				mapped_data[0] = 0,
 				mapped_data[1] = data[i + 1],
 				mapped_data[2] = data[i],
 				mapped_data[3] = 0;
 			break;
-		case texture_format::rgba8:
+		    case texture_format::rgba8:
 			for (UINT i = 0; i < size; i += 4, mapped_data += 4)
 				mapped_data[0] = data[i + 2],
 				mapped_data[1] = data[i + 1],
 				mapped_data[2] = data[i],
 				mapped_data[3] = data[i + 3];
 			break;
-		default:
+		    default:
 			std::memcpy(mapped_data, data, size);
 			break;
 		}

--- a/source/d3d9/d3d9_runtime.cpp
+++ b/source/d3d9/d3d9_runtime.cpp
@@ -497,7 +497,7 @@ namespace reshade::d3d9
 					return;
 				}
 			}
-
+	
 			depthstencil->AddRef();
 
 			// Begin tracking
@@ -623,30 +623,30 @@ namespace reshade::d3d9
 
 		switch (texture.format)
 		{
-		    case texture_format::r8:
-			for (UINT i = 0; i < size; i += 4, mapped_data += 4)
-				mapped_data[0] = 0,
-				mapped_data[1] = 0,
-				mapped_data[2] = data[i],
-				mapped_data[3] = 0;
-			break;
-		    case texture_format::rg8:
-			for (UINT i = 0; i < size; i += 4, mapped_data += 4)
-				mapped_data[0] = 0,
-				mapped_data[1] = data[i + 1],
-				mapped_data[2] = data[i],
-				mapped_data[3] = 0;
-			break;
-		    case texture_format::rgba8:
-			for (UINT i = 0; i < size; i += 4, mapped_data += 4)
-				mapped_data[0] = data[i + 2],
-				mapped_data[1] = data[i + 1],
-				mapped_data[2] = data[i],
-				mapped_data[3] = data[i + 3];
-			break;
-		    default:
-			std::memcpy(mapped_data, data, size);
-			break;
+			case texture_format::r8:
+				for (UINT i = 0; i < size; i += 4, mapped_data += 4)
+					mapped_data[0] = 0,
+					mapped_data[1] = 0,
+					mapped_data[2] = data[i],
+					mapped_data[3] = 0;
+				break;
+			case texture_format::rg8:
+				for (UINT i = 0; i < size; i += 4, mapped_data += 4)
+					mapped_data[0] = 0,
+					mapped_data[1] = data[i + 1],
+					mapped_data[2] = data[i],
+					mapped_data[3] = 0;
+				break;
+			case texture_format::rgba8:
+				for (UINT i = 0; i < size; i += 4, mapped_data += 4)
+					mapped_data[0] = data[i + 2],
+					mapped_data[1] = data[i + 1],
+					mapped_data[2] = data[i],
+					mapped_data[3] = data[i + 3];
+				break;
+			default:
+				std::memcpy(mapped_data, data, size);
+				break;
 		}
 
 		mem_texture->UnlockRect(0);

--- a/source/d3d9/d3d9_runtime.hpp
+++ b/source/d3d9/d3d9_runtime.hpp
@@ -1,7 +1,7 @@
 /**
- * Copyright (C) 2014 Patrick Mours. All rights reserved.
- * License: https://github.com/crosire/reshade#license
- */
+* Copyright (C) 2014 Patrick Mours. All rights reserved.
+* License: https://github.com/crosire/reshade#license
+*/
 
 #pragma once
 
@@ -26,11 +26,11 @@ namespace reshade::d3d9
 	{
 		com_ptr<IDirect3DVertexShader9> vertex_shader;
 		com_ptr<IDirect3DPixelShader9> pixel_shader;
-		d3d9_sampler samplers[16] = { };
+		d3d9_sampler samplers[16] = {};
 		DWORD sampler_count = 0;
 		com_ptr<IDirect3DStateBlock9> stateblock;
 		bool clear_render_targets = false;
-		IDirect3DSurface9 *render_targets[8] = { };
+		IDirect3DSurface9 *render_targets[8] = {};
 	};
 
 	class d3d9_runtime : public runtime
@@ -41,6 +41,7 @@ namespace reshade::d3d9
 		bool on_init(const D3DPRESENT_PARAMETERS &pp);
 		void on_reset();
 		void on_present();
+		void on_clear(DWORD Flags);
 		void on_draw_call(D3DPRIMITIVETYPE type, UINT count);
 		void on_set_depthstencil_surface(IDirect3DSurface9 *&depthstencil);
 		void on_get_depthstencil_surface(IDirect3DSurface9 *&depthstencil);
@@ -74,14 +75,14 @@ namespace reshade::d3d9
 		bool init_fx_resources();
 		bool init_imgui_font_atlas();
 
-		void detect_depth_source();
-		bool create_depthstencil_replacement(IDirect3DSurface9 *depthstencil);
+		void detect_depth_source(bool on_clear);
+		bool create_depthstencil_replacement(IDirect3DSurface9 *depthstencil, bool on_clear);
 
 		UINT _behavior_flags, _num_simultaneous_rendertargets, _num_samplers;
 		bool _is_multisampling_enabled = false;
 		D3DFORMAT _backbuffer_format = D3DFMT_UNKNOWN;
 		com_ptr<IDirect3DStateBlock9> _stateblock, _imgui_state;
-		com_ptr<IDirect3DSurface9> _depthstencil, _depthstencil_replacement, _default_depthstencil;
+		com_ptr<IDirect3DSurface9> _best_depthstencil, _depthstencil, _depthstencil_replacement, _default_depthstencil;
 		std::unordered_map<IDirect3DSurface9 *, depth_source_info> _depth_source_table;
 
 		com_ptr<IDirect3DVertexBuffer9> _effect_triangle_buffer;
@@ -90,5 +91,7 @@ namespace reshade::d3d9
 		com_ptr<IDirect3DVertexBuffer9> _imgui_vertex_buffer;
 		com_ptr<IDirect3DIndexBuffer9> _imgui_index_buffer;
 		int _imgui_vertex_buffer_size = 0, _imgui_index_buffer_size = 0;
+		unsigned int _clear_DSV_iter = 1;
+		bool _depth_buffer_retrieved_at_clearing_stage = false;
 	};
 }

--- a/source/d3d9/d3d9_runtime.hpp
+++ b/source/d3d9/d3d9_runtime.hpp
@@ -1,7 +1,7 @@
 /**
-* Copyright (C) 2014 Patrick Mours. All rights reserved.
-* License: https://github.com/crosire/reshade#license
-*/
+ * Copyright (C) 2014 Patrick Mours. All rights reserved.
+ * License: https://github.com/crosire/reshade#license
+ */
 
 #pragma once
 
@@ -26,11 +26,11 @@ namespace reshade::d3d9
 	{
 		com_ptr<IDirect3DVertexShader9> vertex_shader;
 		com_ptr<IDirect3DPixelShader9> pixel_shader;
-		d3d9_sampler samplers[16] = {};
+		d3d9_sampler samplers[16] = { };
 		DWORD sampler_count = 0;
 		com_ptr<IDirect3DStateBlock9> stateblock;
 		bool clear_render_targets = false;
-		IDirect3DSurface9 *render_targets[8] = {};
+		IDirect3DSurface9 *render_targets[8] = { };
 	};
 
 	class d3d9_runtime : public runtime

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -782,6 +782,9 @@ namespace reshade
 
 		config.get("BUFFER_DETECTION", "DepthBufferRetrievalMode", _depth_buffer_before_clear);
 		config.get("BUFFER_DETECTION", "DepthBufferTextureFormat", _depth_buffer_texture_format);
+		config.get("BUFFER_DETECTION", "DepthBufferClearingNumber", _depth_buffer_clearing_number);
+		config.get("BUFFER_DETECTION", "DepthBufferClearingFlagNumber", _depth_buffer_clearing_flag_number);
+		config.get("BUFFER_DETECTION", "RestrictDepthBufferDimensions", _restrict_depth_buffer_dimensions);
 
 		config.get("STYLE", "Alpha", _imgui_context->Style.Alpha);
 		config.get("STYLE", "ColBackground", _imgui_col_background);
@@ -885,6 +888,9 @@ namespace reshade
 
 		config.set("BUFFER_DETECTION", "DepthBufferRetrievalMode", _depth_buffer_before_clear);
 		config.set("BUFFER_DETECTION", "DepthBufferTextureFormat", _depth_buffer_texture_format);
+		config.set("BUFFER_DETECTION", "DepthBufferClearingNumber", _depth_buffer_clearing_number);
+		config.set("BUFFER_DETECTION", "DepthBufferClearingFlagNumber", _depth_buffer_clearing_flag_number);
+		config.set("BUFFER_DETECTION", "RestrictDepthBufferDimensions", _restrict_depth_buffer_dimensions);
 
 		config.set("STYLE", "Alpha", _imgui_context->Style.Alpha);
 		config.set("STYLE", "ColBackground", _imgui_col_background);
@@ -1777,17 +1783,30 @@ namespace reshade
 		}
 
 		const bool is_d3d11 = _renderer_id >= 0xb000 && _renderer_id < 0xc000;;
+		const bool is_d3d9 = _renderer_id >= 0x9000 && _renderer_id < 0xa000;;
 
-		if (is_d3d11 && ImGui::CollapsingHeader("Buffer Detection", ImGuiTreeNodeFlags_DefaultOpen))
+		if (ImGui::CollapsingHeader("Buffer Detection", ImGuiTreeNodeFlags_DefaultOpen))
 		{
 			assert(_menu_key_data[0] < 256);
 
 			bool modified = false;
-			modified |= ImGui::Checkbox("Copy Depth Before Clearing", &_depth_buffer_before_clear);
-			modified |= ImGui::Combo("Depth Texture Format", &_depth_buffer_texture_format, "All\0D16\0D32F\0D24S8\0D32FS8\0");
+
+			if (is_d3d11 || is_d3d9)
+			{
+				modified |= ImGui::Checkbox("Copy Depth Before Clearing", &_depth_buffer_before_clear);
+				modified |= ImGui::Combo("Depth Texture Format", &_depth_buffer_texture_format, "All\0D16\0D32F\0D24S8\0D32FS8\0");
+			}
+
+			if (is_d3d9)
+			{
+				modified |= ImGui::Combo("Depth buffer clearing number", &_depth_buffer_clearing_number, "None\0First\0Second\0Third\0Fourth\0Fifth\0Sixth\0Seventh\0Eighth\0Ninth\0");
+				modified |= ImGui::Combo("Depth buffer clearing flag number", &_depth_buffer_clearing_flag_number, "None\0 1\0 2\0 3\0 4\0 5\0 6\0 7\0 8\0 9\0");
+				modified |= ImGui::Checkbox("Restrict depth buffer dimensions", &_restrict_depth_buffer_dimensions);
+			}
 
 			if (modified)
 			{
+				_depth_buffer_settings_changed = true;
 				save_configuration();
 			}
 

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -188,8 +188,12 @@ namespace reshade
 		std::vector<uniform> _uniforms;
 		std::vector<technique> _techniques;
 		int _depth_buffer_texture_format = 0; // No depth buffer texture format filter by default
+		int _depth_buffer_clearing_number = 0;
+		int _depth_buffer_clearing_flag_number = 6;
 		bool _depth_buffer_debug = false;
 		bool _depth_buffer_before_clear = false;
+		bool _depth_buffer_settings_changed = false;
+		bool _restrict_depth_buffer_dimensions = true;
 
 	private:
 		static bool check_for_update(unsigned long latest_version[3]);


### PR DESCRIPTION
New buffer detection techniques for d3d9. i revert back input.hpp and input.cpp, because in some d3d9 games (Dark messiah, for instance), the gui doesn't appear when pressing the shortcut (alt+F2 in my case)