### PR TITLE
Dynamic menu

### DIFF
--- a/source/d3d11/d3d11.cpp
+++ b/source/d3d11/d3d11.cpp
@@ -22,7 +22,7 @@ HOOK_EXPORT HRESULT WINAPI D3D11CreateDeviceAndSwapChain(IDXGIAdapter *pAdapter,
 	LOG(INFO) << "Redirecting '" << "D3D11CreateDeviceAndSwapChain" << "(" << pAdapter << ", " << DriverType << ", " << Software << ", " << std::hex << Flags << std::dec << ", " << pFeatureLevels << ", " << FeatureLevels << ", " << SDKVersion << ", " << pSwapChainDesc << ", " << ppSwapChain << ", " << ppDevice << ", " << pFeatureLevel << ", " << ppImmediateContext << ")' ...";
 
 #ifdef _DEBUG
-	Flags |= D3D11_CREATE_DEVICE_DEBUG;
+	//Flags |= D3D11_CREATE_DEVICE_DEBUG;
 	Flags &= ~D3D11_CREATE_DEVICE_PREVENT_ALTERING_LAYER_SETTINGS_FROM_REGISTRY;
 #endif
 

--- a/source/d3d11/d3d11.cpp
+++ b/source/d3d11/d3d11.cpp
@@ -22,7 +22,7 @@ HOOK_EXPORT HRESULT WINAPI D3D11CreateDeviceAndSwapChain(IDXGIAdapter *pAdapter,
 	LOG(INFO) << "Redirecting '" << "D3D11CreateDeviceAndSwapChain" << "(" << pAdapter << ", " << DriverType << ", " << Software << ", " << std::hex << Flags << std::dec << ", " << pFeatureLevels << ", " << FeatureLevels << ", " << SDKVersion << ", " << pSwapChainDesc << ", " << ppSwapChain << ", " << ppDevice << ", " << pFeatureLevel << ", " << ppImmediateContext << ")' ...";
 
 #ifdef _DEBUG
-	//Flags |= D3D11_CREATE_DEVICE_DEBUG;
+	Flags |= D3D11_CREATE_DEVICE_DEBUG;
 	Flags &= ~D3D11_CREATE_DEVICE_PREVENT_ALTERING_LAYER_SETTINGS_FROM_REGISTRY;
 #endif
 

--- a/source/d3d11/d3d11_device_context.cpp
+++ b/source/d3d11/d3d11_device_context.cpp
@@ -79,7 +79,7 @@ void D3D11DeviceContext::track_active_depthstencil(ID3D11DepthStencilView *pDept
 
 	const auto runtime = _device->_runtimes.front();
 
-	if (pDepthStencilView != nullptr && !runtime->_depth_buffer_before_clear)
+	if (pDepthStencilView != nullptr && !runtime->depth_buffer_before_clear())
 	{
 		_draw_call_tracker.track_depthstencil(pDepthStencilView);
 	}
@@ -93,7 +93,7 @@ void D3D11DeviceContext::track_cleared_depthstencil(ID3D11DepthStencilView *pDep
 
 	const auto runtime = _device->_runtimes.front();
 
-	if (!runtime->_depth_buffer_before_clear)
+	if (!runtime->depth_buffer_before_clear())
 	{
 		return;
 	}

--- a/source/d3d11/d3d11_runtime.cpp
+++ b/source/d3d11/d3d11_runtime.cpp
@@ -987,8 +987,8 @@ namespace reshade::d3d11
 		}
 	}
 
-	void d3d11_runtime::draw_debug_menu() {
-
+	void d3d11_runtime::draw_debug_menu()
+	{
 		ImGui::PushID("DX11");
 
 		if (ImGui::CollapsingHeader("Buffer Detection", ImGuiTreeNodeFlags_DefaultOpen))
@@ -999,7 +999,7 @@ namespace reshade::d3d11
 
 			if (modified)
 			{
-				runtime::save_configuration();
+				runtime::save_config();
 			}
 
 			for (const auto &it : _current_tracker.depthstencil_counters())
@@ -1031,7 +1031,6 @@ namespace reshade::d3d11
 		}
 
 		ImGui::PopID();
-
 	}
 
 	void d3d11_runtime::detect_depth_source(draw_call_tracker &tracker)

--- a/source/d3d11/d3d11_runtime.cpp
+++ b/source/d3d11/d3d11_runtime.cpp
@@ -48,6 +48,14 @@ namespace reshade::d3d11
 		_device_id = adapter_desc.DeviceId;
 
 		subscribe_to_menu("DX11", [this]() { this->draw_debug_menu(); });
+		subscribe_to_load_config([this](const ini_file& config) {
+			config.get("DX11_BUFFER_DETECTION", "DepthBufferRetrievalMode", _depth_buffer_before_clear);
+			config.get("DX11_BUFFER_DETECTION", "DepthBufferTextureFormat", _depth_buffer_texture_format);
+		});
+		subscribe_to_save_config([this](ini_file& config) {
+			config.set("DX11_BUFFER_DETECTION", "DepthBufferRetrievalMode", _depth_buffer_before_clear);
+			config.set("DX11_BUFFER_DETECTION", "DepthBufferTextureFormat", _depth_buffer_texture_format);
+		});
 	}
 
 	bool d3d11_runtime::init_backbuffer_texture()
@@ -989,10 +997,10 @@ namespace reshade::d3d11
 			modified |= ImGui::Checkbox("Copy Depth Before Clearing", &_depth_buffer_before_clear);
 			modified |= ImGui::Combo("Depth Texture Format", &_depth_buffer_texture_format, "All\0D16\0D32F\0D24S8\0D32FS8\0");
 
-			//if (modified)
-			//{
-			//	save_configuration();
-			//}
+			if (modified)
+			{
+				runtime::save_configuration();
+			}
 
 			for (const auto &it : _current_tracker.depthstencil_counters())
 			{

--- a/source/d3d11/d3d11_runtime.hpp
+++ b/source/d3d11/d3d11_runtime.hpp
@@ -70,9 +70,13 @@ namespace reshade::d3d11
 		std::vector<com_ptr<ID3D11ShaderResourceView>> _effect_shader_resources;
 		std::vector<com_ptr<ID3D11Buffer>> _constant_buffers;
 
-		using runtime::_depth_buffer_before_clear;
+		bool depth_buffer_before_clear() { return _depth_buffer_before_clear; }
 
 	private:
+		int _depth_buffer_texture_format = 0; // No depth buffer texture format filter by default
+		bool _depth_buffer_debug = false;
+		bool _depth_buffer_before_clear = false;
+
 		bool init_backbuffer_texture();
 		bool init_default_depth_stencil();
 		bool init_fx_resources();

--- a/source/d3d11/d3d11_runtime.hpp
+++ b/source/d3d11/d3d11_runtime.hpp
@@ -79,6 +79,8 @@ namespace reshade::d3d11
 		bool init_imgui_resources();
 		bool init_imgui_font_atlas();
 
+		void draw_debug_menu();
+
 		void detect_depth_source(draw_call_tracker& tracker);
 		bool create_depthstencil_replacement(ID3D11DepthStencilView *depthstencil, ID3D11Texture2D *texture);
 
@@ -106,5 +108,6 @@ namespace reshade::d3d11
 		com_ptr<ID3D11BlendState> _imgui_blend_state;
 		com_ptr<ID3D11DepthStencilState> _imgui_depthstencil_state;
 		int _imgui_vertex_buffer_size = 0, _imgui_index_buffer_size = 0;
+		draw_call_tracker _current_tracker;
 	};
 }

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -91,6 +91,13 @@ namespace reshade
 			imgui_io.Fonts->AddFontDefault();
 
 		load_configuration();
+
+		_menu_items.push_back(std::make_pair("Home", [this]() { this->draw_overlay_menu_home(); }));
+		_selected_menu = _menu_items.back().second;
+
+		_menu_items.push_back(std::make_pair("Settings", [this]() { this->draw_overlay_menu_settings(); }));
+		_menu_items.push_back(std::make_pair("Statistics", [this]() {  this->draw_overlay_menu_statistics(); }));
+		_menu_items.push_back(std::make_pair("About", [this]() { this->draw_overlay_menu_about(); }));
 	}
 	runtime::~runtime()
 	{
@@ -1293,15 +1300,11 @@ namespace reshade
 		{
 			ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImGui::GetStyle().ItemSpacing * 2);
 
-			const char *const menu_items[] = { "Home", "Settings", "Statistics", "About" };
-
-			for (int i = 0; i < 4; i++)
-			{
-				if (ImGui::Selectable(menu_items[i], _menu_index == i, 0, ImVec2(ImGui::CalcTextSize(menu_items[i]).x, 0)))
+			for (auto &[label, function] : _menu_items) {
+				if (ImGui::Selectable(label.c_str(), &_selected_menu == &function, 0, ImVec2(ImGui::CalcTextSize(label.c_str()).x, 0)))
 				{
-					_menu_index = i;
+					_selected_menu = function;
 				}
-
 				ImGui::SameLine();
 			}
 
@@ -1309,21 +1312,7 @@ namespace reshade
 			ImGui::EndMenuBar();
 		}
 
-		switch (_menu_index)
-		{
-		case 0:
-			draw_overlay_menu_home();
-			break;
-		case 1:
-			draw_overlay_menu_settings();
-			break;
-		case 2:
-			draw_overlay_menu_statistics();
-			break;
-		case 3:
-			draw_overlay_menu_about();
-			break;
-		}
+		_selected_menu();
 	}
 	void runtime::draw_overlay_menu_home()
 	{

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -794,9 +794,6 @@ namespace reshade
 
 		_imgui_context->IO.IniFilename = _save_imgui_window_state ? "ReShadeGUI.ini" : nullptr;
 
-		config.get("BUFFER_DETECTION", "DepthBufferRetrievalMode", _depth_buffer_before_clear);
-		config.get("BUFFER_DETECTION", "DepthBufferTextureFormat", _depth_buffer_texture_format);
-
 		config.get("STYLE", "Alpha", _imgui_context->Style.Alpha);
 		config.get("STYLE", "ColBackground", _imgui_col_background);
 		config.get("STYLE", "ColItemBackground", _imgui_col_item_background);
@@ -878,6 +875,11 @@ namespace reshade
 		to_absolute(_effect_search_paths);
 		to_absolute(_texture_search_paths);
 #endif
+
+		for (auto &function : _load_config_callables) {
+			function(config);
+		}
+
 	}
 	void runtime::save_configuration() const
 	{
@@ -903,15 +905,16 @@ namespace reshade
 		config.set("GENERAL", "NoReloadOnInit", _no_reload_on_init);
 		config.set("GENERAL", "SaveWindowState", _save_imgui_window_state);
 
-		config.set("BUFFER_DETECTION", "DepthBufferRetrievalMode", _depth_buffer_before_clear);
-		config.set("BUFFER_DETECTION", "DepthBufferTextureFormat", _depth_buffer_texture_format);
-
 		config.set("STYLE", "Alpha", _imgui_context->Style.Alpha);
 		config.set("STYLE", "ColBackground", _imgui_col_background);
 		config.set("STYLE", "ColItemBackground", _imgui_col_item_background);
 		config.set("STYLE", "ColActive", _imgui_col_active);
 		config.set("STYLE", "ColText", _imgui_col_text);
 		config.set("STYLE", "ColFPSText", _imgui_col_text_fps);
+
+		for (auto &function : _save_config_callables) {
+			function(config);
+		}
 	}
 
 	void runtime::load_preset(const filesystem::path &path)

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -101,8 +101,6 @@ namespace reshade
 		subscribe_to_menu("Statistics", [this]() { draw_overlay_menu_statistics(); });
 		subscribe_to_menu("Log", [this]() { draw_overlay_menu_log(); });
 		subscribe_to_menu("About", [this]() { draw_overlay_menu_about(); });
-
-		_selected_menu_callback = _menu_callables[0].second;
 	}
 	runtime::~runtime()
 	{
@@ -1261,11 +1259,13 @@ namespace reshade
 		{
 			ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImGui::GetStyle().ItemSpacing * 2);
 
-			for (const auto &[label, function] : _menu_callables)
+			for (size_t i = 0; i < _menu_callables.size(); ++i)
 			{
-				if (ImGui::Selectable(label.c_str(), &_selected_menu_callback == &function, 0, ImVec2(ImGui::CalcTextSize(label.c_str()).x, 0)))
+				const std::string &label = _menu_callables[i].first;
+
+				if (ImGui::Selectable(label.c_str(), _menu_index == i, 0, ImVec2(ImGui::CalcTextSize(label.c_str()).x, 0)))
 				{
-					_selected_menu_callback = function;
+					_menu_index = i;
 				}
 
 				ImGui::SameLine();
@@ -1275,9 +1275,7 @@ namespace reshade
 			ImGui::EndMenuBar();
 		}
 
-		assert(_selected_menu_callback != nullptr);
-
-		_selected_menu_callback();
+		_menu_callables[_menu_index].second();
 	}
 	void runtime::draw_overlay_menu_home()
 	{

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -92,12 +92,12 @@ namespace reshade
 
 		load_configuration();
 
-		_menu_items.push_back(std::make_pair("Home", [this]() { this->draw_overlay_menu_home(); }));
-		_selected_menu = _menu_items.back().second;
+		subscribe_to_menu("Home", [this]() { this->draw_overlay_menu_home(); });
+		_selected_menu = _menu_callables.back().second;
 
-		_menu_items.push_back(std::make_pair("Settings", [this]() { this->draw_overlay_menu_settings(); }));
-		_menu_items.push_back(std::make_pair("Statistics", [this]() {  this->draw_overlay_menu_statistics(); }));
-		_menu_items.push_back(std::make_pair("About", [this]() { this->draw_overlay_menu_about(); }));
+		subscribe_to_menu("Settings", [this]() { this->draw_overlay_menu_settings(); });
+		subscribe_to_menu("Statistics", [this]() { this->draw_overlay_menu_statistics(); });
+		subscribe_to_menu("About", [this]() { this->draw_overlay_menu_about(); });
 	}
 	runtime::~runtime()
 	{
@@ -1300,7 +1300,7 @@ namespace reshade
 		{
 			ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImGui::GetStyle().ItemSpacing * 2);
 
-			for (auto &[label, function] : _menu_items) {
+			for (auto &[label, function] : _menu_callables) {
 				if (ImGui::Selectable(label.c_str(), &_selected_menu == &function, 0, ImVec2(ImGui::CalcTextSize(label.c_str()).x, 0)))
 				{
 					_selected_menu = function;
@@ -1780,27 +1780,6 @@ namespace reshade
 				save_configuration();
 				// Style is applied in "load_configuration".
 				load_configuration();
-			}
-		}
-
-		const bool is_d3d11 = _renderer_id >= 0xb000 && _renderer_id < 0xc000;;
-
-		if (is_d3d11 && ImGui::CollapsingHeader("Buffer Detection", ImGuiTreeNodeFlags_DefaultOpen))
-		{
-			assert(_menu_key_data[0] < 256);
-
-			bool modified = false;
-			modified |= ImGui::Checkbox("Copy Depth Before Clearing", &_depth_buffer_before_clear);
-			modified |= ImGui::Combo("Depth Texture Format", &_depth_buffer_texture_format, "All\0D16\0D32F\0D24S8\0D32FS8\0");
-
-			if (modified)
-			{
-				save_configuration();
-			}
-
-			if (ImGui::Button("Show Debug Window", ImVec2(ImGui::CalcItemWidth(), 0)))
-			{
-				_depth_buffer_debug = true;
 			}
 		}
 

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -269,7 +269,7 @@ namespace reshade
 		std::vector<std::pair<std::string, std::function<void()>>> _menu_callables;
 		std::vector<std::function<void(const ini_file &)>> _load_config_callables;
 		std::vector<std::function<void(ini_file &)>> _save_config_callables;
-		std::function<void()> _selected_menu_callback;
+		size_t _menu_index = 0;
 		int _screenshot_format = 0;
 		int _current_preset = -1;
 		int _selected_technique = -1;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -7,6 +7,9 @@
 
 #include <chrono>
 #include "filesystem.hpp"
+#include <map>
+#include <functional>
+#include <string>
 #include "runtime_objects.hpp"
 
 #pragma region Forward Declarations
@@ -28,6 +31,8 @@ extern volatile long g_network_traffic;
 
 namespace reshade
 {
+	typedef std::function<void()> void_callable;
+
 	class runtime abstract
 	{
 	public:
@@ -191,6 +196,8 @@ namespace reshade
 		bool _depth_buffer_debug = false;
 		bool _depth_buffer_before_clear = false;
 
+		std::vector<std::pair<std::string, void_callable>> _menu_items;
+
 	private:
 		static bool check_for_update(unsigned long latest_version[3]);
 
@@ -228,7 +235,7 @@ namespace reshade
 		int _date[4] = { };
 		std::string _errors;
 		std::vector<std::string> _preprocessor_definitions;
-		int _menu_index = 0;
+		void_callable _selected_menu;
 		int _screenshot_format = 0;
 		int _current_preset = -1;
 		int _selected_technique = -1;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -123,6 +123,8 @@ namespace reshade
 		void set_uniform_value(uniform &variable, const unsigned int *values, size_t count);
 		void set_uniform_value(uniform &variable, const float *values, size_t count);
 
+		void subscribe_to_menu(std::string label, void_callable function) { _menu_callables.push_back(std::make_pair(label, function)); };
+
 	protected:
 		/// <summary>
 		/// Callback function called when the runtime is initialized.
@@ -196,7 +198,7 @@ namespace reshade
 		bool _depth_buffer_debug = false;
 		bool _depth_buffer_before_clear = false;
 
-		std::vector<std::pair<std::string, void_callable>> _menu_items;
+		std::vector<std::pair<std::string, void_callable>> _menu_callables;
 
 	private:
 		static bool check_for_update(unsigned long latest_version[3]);


### PR DESCRIPTION
Moves the tabs in the menu into a dynamic list. Subclasses, or other objects with a reference to runtime can call a function to add a label (like "DX11") and function (`dx11_runtime::draw_dx11_menu()`) to draw the menu. This will allows library-specific configuration displays.

In addition, the load_configuration and save_configuration functions can be subscribed to. This allows subclasses (and plugins) to have specific configuration. In the case of DX11, it allows the debug buffer menu to be drawn to a special tab, and the two dx11 specific settings to be housed in the dx11_runtime class.

A possible breaking change (that isn't that important) is I renamed the BUFFER_DETECTION section in the config file to DX11_BUFFER_DETECTION to be more accurate.