### PR TITLE
draw_call_tracker now tracks intermediate buffers (normals, motion vectors, etc) and constant buffers

### DIFF
--- a/source/d3d11/d3d11.cpp
+++ b/source/d3d11/d3d11.cpp
@@ -22,7 +22,7 @@ HOOK_EXPORT HRESULT WINAPI D3D11CreateDeviceAndSwapChain(IDXGIAdapter *pAdapter,
 	LOG(INFO) << "Redirecting '" << "D3D11CreateDeviceAndSwapChain" << "(" << pAdapter << ", " << DriverType << ", " << Software << ", " << std::hex << Flags << std::dec << ", " << pFeatureLevels << ", " << FeatureLevels << ", " << SDKVersion << ", " << pSwapChainDesc << ", " << ppSwapChain << ", " << ppDevice << ", " << pFeatureLevel << ", " << ppImmediateContext << ")' ...";
 
 #ifdef _DEBUG
-	Flags |= D3D11_CREATE_DEVICE_DEBUG;
+	//Flags |= D3D11_CREATE_DEVICE_DEBUG;
 	Flags &= ~D3D11_CREATE_DEVICE_PREVENT_ALTERING_LAYER_SETTINGS_FROM_REGISTRY;
 #endif
 

--- a/source/d3d11/d3d11.cpp
+++ b/source/d3d11/d3d11.cpp
@@ -22,7 +22,7 @@ HOOK_EXPORT HRESULT WINAPI D3D11CreateDeviceAndSwapChain(IDXGIAdapter *pAdapter,
 	LOG(INFO) << "Redirecting '" << "D3D11CreateDeviceAndSwapChain" << "(" << pAdapter << ", " << DriverType << ", " << Software << ", " << std::hex << Flags << std::dec << ", " << pFeatureLevels << ", " << FeatureLevels << ", " << SDKVersion << ", " << pSwapChainDesc << ", " << ppSwapChain << ", " << ppDevice << ", " << pFeatureLevel << ", " << ppImmediateContext << ")' ...";
 
 #ifdef _DEBUG
-	//Flags |= D3D11_CREATE_DEVICE_DEBUG;
+	Flags |= D3D11_CREATE_DEVICE_DEBUG;
 	Flags &= ~D3D11_CREATE_DEVICE_PREVENT_ALTERING_LAYER_SETTINGS_FROM_REGISTRY;
 #endif
 

--- a/source/d3d11/d3d11_device_context.cpp
+++ b/source/d3d11/d3d11_device_context.cpp
@@ -280,7 +280,8 @@ void STDMETHODCALLTYPE D3D11DeviceContext::Draw(UINT VertexCount, UINT StartVert
 }
 HRESULT STDMETHODCALLTYPE D3D11DeviceContext::Map(ID3D11Resource *pResource, UINT Subresource, D3D11_MAP MapType, UINT MapFlags, D3D11_MAPPED_SUBRESOURCE *pMappedResource)
 {
-	_draw_call_tracker.on_map(this, pResource);
+	_draw_call_tracker.on_map(pResource);
+
 	return _orig->Map(pResource, Subresource, MapType, MapFlags, pMappedResource);
 }
 void STDMETHODCALLTYPE D3D11DeviceContext::Unmap(ID3D11Resource *pResource, UINT Subresource)

--- a/source/d3d11/d3d11_device_context.cpp
+++ b/source/d3d11/d3d11_device_context.cpp
@@ -7,19 +7,9 @@
 #include "d3d11_device.hpp"
 #include "d3d11_device_context.hpp"
 
-void D3D11DeviceContext::log_drawcall(UINT vertices)
-{
-	_draw_call_tracker.log_drawcalls(1, vertices);
-
-	if (_active_depthstencil != nullptr)
-	{
-		_draw_call_tracker.log_drawcalls(_active_depthstencil.get(), 1, vertices);
-	}
-}
 void D3D11DeviceContext::clear_drawcall_stats()
 {
 	_draw_call_tracker.reset();
-	_active_depthstencil.reset();
 }
 
 static inline com_ptr<ID3D11Texture2D> copy_texture(D3D11DeviceContext *devicecontext, D3D11_TEXTURE2D_DESC &texture_desc, ID3D11Texture2D *depth_texture)
@@ -63,15 +53,8 @@ static inline com_ptr<ID3D11Texture2D> copy_texture(D3D11DeviceContext *deviceco
 	return depth_texture_copy;
 }
 
-void D3D11DeviceContext::track_active_depthstencil(ID3D11DepthStencilView *pDepthStencilView)
+void D3D11DeviceContext::track_active_rendertargets(UINT NumViews, ID3D11RenderTargetView *const *ppRenderTargetViews, ID3D11DepthStencilView *pDepthStencilView)
 {
-	if (pDepthStencilView == _active_depthstencil)
-	{
-		return;
-	}
-
-	_active_depthstencil = pDepthStencilView;
-
 	if (_device->_runtimes.empty())
 	{
 		return;
@@ -81,7 +64,7 @@ void D3D11DeviceContext::track_active_depthstencil(ID3D11DepthStencilView *pDept
 
 	if (pDepthStencilView != nullptr && !runtime->depth_buffer_before_clear())
 	{
-		_draw_call_tracker.track_depthstencil(pDepthStencilView);
+		_draw_call_tracker.track_rendertargets(pDepthStencilView, nullptr, NumViews, ppRenderTargetViews);
 	}
 }
 void D3D11DeviceContext::track_cleared_depthstencil(ID3D11DepthStencilView *pDepthStencilView)
@@ -125,13 +108,13 @@ void D3D11DeviceContext::track_cleared_depthstencil(ID3D11DepthStencilView *pDep
 	// Ignore depth stencils that were not used much during rendering or are tracked already
 	const UINT VERTICES_THRESHOLD = 10000;
 
-	if (_draw_call_tracker.vertices() < VERTICES_THRESHOLD || _draw_call_tracker.check_depthstencil(pDepthStencilView))
+	if (_draw_call_tracker.total_vertices() < VERTICES_THRESHOLD || _draw_call_tracker.check_depthstencil(pDepthStencilView))
 	{
 		return;
 	}
 
 	// Copy the depth stencil texture and track the associated depth stencil
-	_draw_call_tracker.track_depthstencil(pDepthStencilView, copy_texture(this, desc, texture.get()));
+	_draw_call_tracker.update_tracked_depthtexture(pDepthStencilView, copy_texture(this, desc, texture.get()));
 }
 
 // ID3D11DeviceContext
@@ -288,15 +271,16 @@ void STDMETHODCALLTYPE D3D11DeviceContext::VSSetShader(ID3D11VertexShader *pVert
 void STDMETHODCALLTYPE D3D11DeviceContext::DrawIndexed(UINT IndexCount, UINT StartIndexLocation, INT BaseVertexLocation)
 {
 	_orig->DrawIndexed(IndexCount, StartIndexLocation, BaseVertexLocation);
-	log_drawcall(IndexCount);
+	_draw_call_tracker.on_draw(this, IndexCount);
 }
 void STDMETHODCALLTYPE D3D11DeviceContext::Draw(UINT VertexCount, UINT StartVertexLocation)
 {
 	_orig->Draw(VertexCount, StartVertexLocation);
-	log_drawcall(VertexCount);
+	_draw_call_tracker.on_draw(this, VertexCount);
 }
 HRESULT STDMETHODCALLTYPE D3D11DeviceContext::Map(ID3D11Resource *pResource, UINT Subresource, D3D11_MAP MapType, UINT MapFlags, D3D11_MAPPED_SUBRESOURCE *pMappedResource)
 {
+	_draw_call_tracker.on_map(this, pResource);
 	return _orig->Map(pResource, Subresource, MapType, MapFlags, pMappedResource);
 }
 void STDMETHODCALLTYPE D3D11DeviceContext::Unmap(ID3D11Resource *pResource, UINT Subresource)
@@ -322,12 +306,12 @@ void STDMETHODCALLTYPE D3D11DeviceContext::IASetIndexBuffer(ID3D11Buffer *pIndex
 void STDMETHODCALLTYPE D3D11DeviceContext::DrawIndexedInstanced(UINT IndexCountPerInstance, UINT InstanceCount, UINT StartIndexLocation, INT BaseVertexLocation, UINT StartInstanceLocation)
 {
 	_orig->DrawIndexedInstanced(IndexCountPerInstance, InstanceCount, StartIndexLocation, BaseVertexLocation, StartInstanceLocation);
-	log_drawcall(IndexCountPerInstance * InstanceCount);
+	_draw_call_tracker.on_draw(this, IndexCountPerInstance * InstanceCount);
 }
 void STDMETHODCALLTYPE D3D11DeviceContext::DrawInstanced(UINT VertexCountPerInstance, UINT InstanceCount, UINT StartVertexLocation, UINT StartInstanceLocation)
 {
 	_orig->DrawInstanced(VertexCountPerInstance, InstanceCount, StartVertexLocation, StartInstanceLocation);
-	log_drawcall(VertexCountPerInstance * InstanceCount);
+	_draw_call_tracker.on_draw(this, VertexCountPerInstance * InstanceCount);
 }
 void STDMETHODCALLTYPE D3D11DeviceContext::GSSetConstantBuffers(UINT StartSlot, UINT NumBuffers, ID3D11Buffer *const *ppConstantBuffers)
 {
@@ -375,13 +359,13 @@ void STDMETHODCALLTYPE D3D11DeviceContext::GSSetSamplers(UINT StartSlot, UINT Nu
 }
 void STDMETHODCALLTYPE D3D11DeviceContext::OMSetRenderTargets(UINT NumViews, ID3D11RenderTargetView *const *ppRenderTargetViews, ID3D11DepthStencilView *pDepthStencilView)
 {
-	track_active_depthstencil(pDepthStencilView);
+	track_active_rendertargets(NumViews, ppRenderTargetViews, pDepthStencilView);
 
 	_orig->OMSetRenderTargets(NumViews, ppRenderTargetViews, pDepthStencilView);
 }
 void STDMETHODCALLTYPE D3D11DeviceContext::OMSetRenderTargetsAndUnorderedAccessViews(UINT NumRTVs, ID3D11RenderTargetView *const *ppRenderTargetViews, ID3D11DepthStencilView *pDepthStencilView, UINT UAVStartSlot, UINT NumUAVs, ID3D11UnorderedAccessView *const *ppUnorderedAccessViews, const UINT *pUAVInitialCounts)
 {
-	track_active_depthstencil(pDepthStencilView);
+	track_active_rendertargets(NumRTVs, ppRenderTargetViews, pDepthStencilView);
 
 	_orig->OMSetRenderTargetsAndUnorderedAccessViews(NumRTVs, ppRenderTargetViews, pDepthStencilView, UAVStartSlot, NumUAVs, ppUnorderedAccessViews, pUAVInitialCounts);
 }
@@ -400,17 +384,17 @@ void STDMETHODCALLTYPE D3D11DeviceContext::SOSetTargets(UINT NumBuffers, ID3D11B
 void STDMETHODCALLTYPE D3D11DeviceContext::DrawAuto()
 {
 	_orig->DrawAuto();
-	log_drawcall(0);
+	_draw_call_tracker.on_draw(this, 0);
 }
 void STDMETHODCALLTYPE D3D11DeviceContext::DrawIndexedInstancedIndirect(ID3D11Buffer *pBufferForArgs, UINT AlignedByteOffsetForArgs)
 {
 	_orig->DrawIndexedInstancedIndirect(pBufferForArgs, AlignedByteOffsetForArgs);
-	log_drawcall(0);
+	_draw_call_tracker.on_draw(this, 0);
 }
 void STDMETHODCALLTYPE D3D11DeviceContext::DrawInstancedIndirect(ID3D11Buffer *pBufferForArgs, UINT AlignedByteOffsetForArgs)
 {
 	_orig->DrawInstancedIndirect(pBufferForArgs, AlignedByteOffsetForArgs);
-	log_drawcall(0);
+	_draw_call_tracker.on_draw(this, 0);
 }
 void STDMETHODCALLTYPE D3D11DeviceContext::Dispatch(UINT ThreadGroupCountX, UINT ThreadGroupCountY, UINT ThreadGroupCountZ)
 {
@@ -711,13 +695,12 @@ HRESULT STDMETHODCALLTYPE D3D11DeviceContext::FinishCommandList(BOOL RestoreDefe
 {
 	const HRESULT hr = _orig->FinishCommandList(RestoreDeferredContextState, ppCommandList);
 
-	if (SUCCEEDED(hr) && ppCommandList != nullptr && _draw_call_tracker.drawcalls() > 0)
+	if (SUCCEEDED(hr) && ppCommandList != nullptr && _draw_call_tracker.total_drawcalls() > 0)
 	{
 		_device->add_commandlist_trackers(*ppCommandList, _draw_call_tracker);
 	}
 
 	_draw_call_tracker.reset();
-	_active_depthstencil.reset();
 
 	return hr;
 }

--- a/source/d3d11/d3d11_device_context.hpp
+++ b/source/d3d11/d3d11_device_context.hpp
@@ -191,16 +191,14 @@ struct D3D11DeviceContext : ID3D11DeviceContext3
 	virtual void STDMETHODCALLTYPE GetHardwareProtectionState(BOOL *pHwProtectionEnable) override;
 	#pragma endregion
 
-	void log_drawcall(UINT vertices);
 	void clear_drawcall_stats();
 
-	void track_active_depthstencil(ID3D11DepthStencilView* pDepthStencilView);
+	void track_active_rendertargets(UINT NumViews, ID3D11RenderTargetView *const *ppRenderTargetViews, ID3D11DepthStencilView *pDepthStencilView);
 	void track_cleared_depthstencil(ID3D11DepthStencilView* pDepthStencilView);
 
 	LONG _ref = 1;
 	ID3D11DeviceContext *_orig;
 	unsigned int _interface_version;
 	D3D11Device *const _device;
-	com_ptr<ID3D11DepthStencilView> _active_depthstencil;
 	reshade::d3d11::draw_call_tracker _draw_call_tracker;
 };

--- a/source/d3d11/d3d11_runtime.cpp
+++ b/source/d3d11/d3d11_runtime.cpp
@@ -1049,7 +1049,7 @@ namespace reshade::d3d11
 					likely_camera_transform_buffer = true;
 				}
 
-				ImGui::Text("%s 0x%p | used in %3u vertexshaders and %3u pixelshaders, mapped %3u times, %3u bytes", likely_camera_transform_buffer ? ">" : " ", buffer, counter.vertexshaders, counter.pixelshaders, counter.mapped, desc.ByteWidth);
+				ImGui::Text("%s 0x%p | used in %3u vertex shaders and %3u pixel shaders, mapped %3u times, %3u bytes", likely_camera_transform_buffer ? ">" : " ", buffer.get(), counter.vertexshaders, counter.pixelshaders, counter.mapped, desc.ByteWidth);
 			}
 		}
 	}

--- a/source/d3d11/d3d11_runtime.cpp
+++ b/source/d3d11/d3d11_runtime.cpp
@@ -1022,31 +1022,7 @@ namespace reshade::d3d11
 
 				ImGui::SameLine();
 
-				std::string additional_view_label = it.second.additional_views.size() > 0 ? "(" : "";
-				unsigned int i = 1;
-				for (auto const&[key, val] : it.second.additional_views) {
-					additional_view_label += std::to_string(val.drawcalls) + (i < it.second.additional_views.size() ? ", " : "");
-					i++;
-				}
-				additional_view_label += it.second.additional_views.size() > 0 ? ")" : "";
-
-				ImGui::Text("| %u draw calls ==> %u vertices, %u additional rendertargets %s", it.second.counter.drawcalls, it.second.counter.vertices, it.second.additional_views.size(), additional_view_label.c_str());
-			}
-
-			ImGui::Text("Is Multisampled : %s", _is_multisampling_enabled ? "true" : "false");
-
-			for (const auto &[buffer, counter] : tracker.constant_counters())
-			{
-				if (counter.pixelshaders > 0 && counter.vertexshaders > 0 && counter.mapped < .10 * counter.vertexshaders) {
-					D3D11_BUFFER_DESC desc;
-					buffer->GetDesc(&desc);
-
-					if (desc.ByteWidth > 1000) {
-						continue;
-					}
-
-					ImGui::Text("cbuffer %p, vertexshaders: %5u pixelshaders: %5u mapped: %5u bytewidth: %5u", buffer, counter.vertexshaders, counter.pixelshaders, counter.mapped, desc.ByteWidth);
-				}
+				ImGui::Text("| %u draw calls ==> %u vertices", it.second.counter.drawcalls, it.second.counter.vertices);
 			}
 		}
 	}

--- a/source/d3d11/d3d11_runtime.cpp
+++ b/source/d3d11/d3d11_runtime.cpp
@@ -1099,11 +1099,11 @@ namespace reshade::d3d11
 
 		assert(_depth_buffer_texture_format >= 0 && _depth_buffer_texture_format < ARRAYSIZE(depth_texture_formats));
 
-		const auto [best_match, best_match_texture] = tracker.find_best_depth_stencil(_width, _height, depth_texture_formats[_depth_buffer_texture_format]);
+		auto best_snapshot = tracker.find_best_snapshot(_width, _height, depth_texture_formats[_depth_buffer_texture_format]);
 
-		if (best_match != nullptr)
+		if (best_snapshot.depthstencil != nullptr)
 		{
-			create_depthstencil_replacement(best_match, best_match_texture);
+			create_depthstencil_replacement(best_snapshot.depthstencil.get(), best_snapshot.texture.get());
 		}
 	}
 

--- a/source/d3d11/d3d11_runtime.cpp
+++ b/source/d3d11/d3d11_runtime.cpp
@@ -1022,7 +1022,7 @@ namespace reshade::d3d11
 
 				ImGui::SameLine();
 
-				ImGui::Text("| %u draw calls ==> %u vertices", it.second.counter.drawcalls, it.second.counter.vertices);
+				ImGui::Text("| %u draw calls ==> %u vertices", it.second.stats.drawcalls, it.second.stats.vertices);
 			}
 		}
 	}

--- a/source/d3d11/draw_call_tracker.cpp
+++ b/source/d3d11/draw_call_tracker.cpp
@@ -10,18 +10,14 @@ namespace reshade::d3d11
 		_global_counter.vertices += source.total_vertices();
 		_global_counter.drawcalls += source.total_drawcalls();
 
-		for (auto &[depthstencil, snapshot] : source._counters_per_used_depthstencil)
+		for (const auto &[depthstencil, snapshot] : source._counters_per_used_depthstencil)
 		{
-			const auto destination_entry = _counters_per_used_depthstencil.find(depthstencil);
-
-			_counters_per_used_depthstencil[depthstencil].counter.vertices += snapshot.counter.vertices;
-			_counters_per_used_depthstencil[depthstencil].counter.drawcalls += snapshot.counter.drawcalls;
+			_counters_per_used_depthstencil[depthstencil].stats.vertices += snapshot.stats.vertices;
+			_counters_per_used_depthstencil[depthstencil].stats.drawcalls += snapshot.stats.drawcalls;
 		}
 
-		for (auto &[buffer, snapshot] : source._counters_per_constant_buffer)
+		for (const auto &[buffer, snapshot] : source._counters_per_constant_buffer)
 		{
-			const auto destination_entry = _counters_per_constant_buffer.find(buffer);
-
 			_counters_per_constant_buffer[buffer].vertices += snapshot.vertices;
 			_counters_per_constant_buffer[buffer].drawcalls += snapshot.drawcalls;
 			_counters_per_constant_buffer[buffer].pixelshaders += snapshot.pixelshaders;
@@ -37,14 +33,15 @@ namespace reshade::d3d11
 		_counters_per_constant_buffer.clear();
 	}
 
-	void draw_call_tracker::on_draw(ID3D11DeviceContext *context, UINT vertices) {
+	void draw_call_tracker::on_draw(ID3D11DeviceContext *context, UINT vertices)
+	{
 		_global_counter.vertices += vertices;
 		_global_counter.drawcalls += 1;
 
 		ID3D11RenderTargetView *rendertargets[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT] = { nullptr };
 		ID3D11DepthStencilView *depthstencil = nullptr;
 
-		context->OMGetRenderTargetsAndUnorderedAccessViews(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, rendertargets, &depthstencil, 0, 0, nullptr);
+		context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, rendertargets, &depthstencil);
 
 		if (depthstencil == nullptr) {
 			// this is a draw call with no depthstencil
@@ -55,14 +52,16 @@ namespace reshade::d3d11
 
 		if (intermediate_snapshot != _counters_per_used_depthstencil.end())
 		{
-			intermediate_snapshot->second.counter.vertices += vertices;
-			intermediate_snapshot->second.counter.drawcalls += 1;
+			intermediate_snapshot->second.stats.vertices += vertices;
+			intermediate_snapshot->second.stats.drawcalls += 1;
 
 			// Find the render targets, if they exist, and update their counts
-			for (unsigned int i = 0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++) {
+			for (unsigned int i = 0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++)
+			{
 				if (rendertargets[i] != nullptr) {
 					auto it = intermediate_snapshot->second.additional_views.find(rendertargets[i]);
-					if (it != intermediate_snapshot->second.additional_views.end()) {
+					if (it != intermediate_snapshot->second.additional_views.end())
+					{
 						it->second.vertices += vertices;
 						it->second.drawcalls += 1;
 					}
@@ -78,9 +77,11 @@ namespace reshade::d3d11
 		ID3D11Buffer *vscbuffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT] = { nullptr };
 		context->VSGetConstantBuffers(0, D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT, vscbuffers);
 
-		for (unsigned int i = 0; i < D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT; i++) {
+		for (unsigned int i = 0; i < D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT; i++)
+		{
 			// uses the default drawcalls = 0 the first time around.
-			if (vscbuffers[i] != nullptr) {
+			if (vscbuffers[i] != nullptr)
+			{
 				_counters_per_constant_buffer[vscbuffers[i]].vertexshaders += 1;
 			}
 		}
@@ -88,22 +89,26 @@ namespace reshade::d3d11
 		ID3D11Buffer *pscbuffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT] = { nullptr };
 		context->PSGetConstantBuffers(0, D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT, pscbuffers);
 
-		for (unsigned int i = 0; i < D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT; i++) {
+		for (unsigned int i = 0; i < D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT; i++)
+		{
 			// uses the default drawcalls = 0 the first time around.
-			if (pscbuffers[i] != nullptr) {
+			if (pscbuffers[i] != nullptr)
+			{
 				_counters_per_constant_buffer[pscbuffers[i]].pixelshaders += 1;
 			}
 		}
 
 	}
 
-	void draw_call_tracker::on_map(ID3D11DeviceContext *context, ID3D11Resource *pResource) {
+	void draw_call_tracker::on_map(ID3D11DeviceContext *context, ID3D11Resource *pResource)
+	{
 
 		D3D11_RESOURCE_DIMENSION dim;
 		pResource->GetType(&dim);
 
-		if (dim == D3D11_RESOURCE_DIMENSION::D3D11_RESOURCE_DIMENSION_BUFFER) {
-			_counters_per_constant_buffer[reinterpret_cast<ID3D11Buffer*>(pResource)].mapped += 1;
+		if (dim == D3D11_RESOURCE_DIMENSION_BUFFER)
+		{
+			_counters_per_constant_buffer[static_cast<ID3D11Buffer*>(pResource)].mapped += 1;
 		}
 	}
 
@@ -120,16 +125,19 @@ namespace reshade::d3d11
 		_counters_per_used_depthstencil[depthstencil].depthstencil = _counters_per_used_depthstencil[depthstencil].depthstencil == nullptr ? depthstencil : _counters_per_used_depthstencil[depthstencil].depthstencil;
 		_counters_per_used_depthstencil[depthstencil].texture = _counters_per_used_depthstencil[depthstencil].texture == nullptr ? texture : _counters_per_used_depthstencil[depthstencil].texture;
 
-		for (unsigned int i = 0; i < numviews; i++) {
+		for (unsigned int i = 0; i < numviews; i++)
+		{
 			// if the rendertarget isn't being tracked, this will create it
 			_counters_per_used_depthstencil[depthstencil].additional_views[ppRenderTargetViews[i]].drawcalls += 1;
 		}
 
 	}
 
-	void draw_call_tracker::update_tracked_depthtexture(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture) {
+	void draw_call_tracker::update_tracked_depthtexture(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture)
+	{
 		auto it = _counters_per_used_depthstencil.find(depthstencil);
-		if (it != _counters_per_used_depthstencil.end()) {
+		if (it != _counters_per_used_depthstencil.end())
+		{
 			it->second.texture = texture;
 		}
 	}
@@ -142,23 +150,20 @@ namespace reshade::d3d11
 
 		for (auto &[depthstencil, snapshot] : _counters_per_used_depthstencil)
 		{
-			if (snapshot.counter.drawcalls == 0 || snapshot.counter.vertices == 0)
+			if (snapshot.stats.drawcalls == 0 || snapshot.stats.vertices == 0)
 			{
 				continue;
 			}
 
 			if (snapshot.texture == nullptr)
 			{
-				com_ptr<ID3D11Texture2D> texture;
 				com_ptr<ID3D11Resource> resource;
 				depthstencil->GetResource(&resource);
 
-				if (FAILED(resource->QueryInterface(&texture)))
+				if (FAILED(resource->QueryInterface(&snapshot.texture)))
 				{
 					continue;
 				}
-
-				snapshot.texture = texture;
 			}
 
 			D3D11_TEXTURE2D_DESC desc;
@@ -184,7 +189,7 @@ namespace reshade::d3d11
 				continue;
 			}
 
-			if (snapshot.counter.drawcalls >= best_snapshot.counter.drawcalls)
+			if (snapshot.stats.drawcalls >= best_snapshot.stats.drawcalls)
 			{
 				best_snapshot = snapshot;
 			}

--- a/source/d3d11/draw_call_tracker.cpp
+++ b/source/d3d11/draw_call_tracker.cpp
@@ -14,8 +14,8 @@ namespace reshade::d3d11
 		{
 			_counters_per_constant_buffer[buffer].vertices += snapshot.vertices;
 			_counters_per_constant_buffer[buffer].drawcalls += snapshot.drawcalls;
-			_counters_per_constant_buffer[buffer].pixelshaders += snapshot.pixelshaders;
-			_counters_per_constant_buffer[buffer].vertexshaders += snapshot.vertexshaders;
+			_counters_per_constant_buffer[buffer].ps_uses += snapshot.ps_uses;
+			_counters_per_constant_buffer[buffer].vs_uses += snapshot.vs_uses;
 		}
 
 		for (const auto &[depthstencil, snapshot] : source._counters_per_used_depthstencil)
@@ -77,7 +77,7 @@ namespace reshade::d3d11
 				}
 				else
 				{
-					// This shouldn't happen - it means somehow someone has called "draw" with a render target without calling track_rendertargets first
+					// This shouldn't happen - it means somehow someone has called 'on_draw' with a render target without calling 'track_rendertargets' first
 					LOG(ERROR) << "Draw has been called on an untracked render target.";
 				}
 			}
@@ -92,7 +92,7 @@ namespace reshade::d3d11
 			// Uses the default drawcalls = 0 the first time around.
 			if (vscbuffers[i] != nullptr)
 			{
-				_counters_per_constant_buffer[vscbuffers[i]].vertexshaders += 1;
+				_counters_per_constant_buffer[vscbuffers[i]].vs_uses += 1;
 			}
 		}
 
@@ -104,7 +104,7 @@ namespace reshade::d3d11
 			// Uses the default drawcalls = 0 the first time around.
 			if (pscbuffers[i] != nullptr)
 			{
-				_counters_per_constant_buffer[pscbuffers[i]].pixelshaders += 1;
+				_counters_per_constant_buffer[pscbuffers[i]].ps_uses += 1;
 			}
 		}
 	}

--- a/source/d3d11/draw_call_tracker.cpp
+++ b/source/d3d11/draw_call_tracker.cpp
@@ -70,7 +70,7 @@ namespace reshade::d3d11
 				if (targets[i] == nullptr)
 					continue;
 
-				if (const auto it = intermediate_snapshot->second.additional_views.find(targets[i]); it != intermediate_snapshot->second.additional_views.end())
+				if (const auto it = intermediate_snapshot->second.additional_views.find(targets[i].get()); it != intermediate_snapshot->second.additional_views.end())
 				{
 					it->second.vertices += vertices;
 					it->second.drawcalls += 1;

--- a/source/d3d11/draw_call_tracker.cpp
+++ b/source/d3d11/draw_call_tracker.cpp
@@ -6,47 +6,103 @@ namespace reshade::d3d11
 {
 	void draw_call_tracker::merge(const draw_call_tracker& source)
 	{
-		_counters.vertices += source.vertices();
-		_counters.drawcalls += source.drawcalls();
+		_global_counter.vertices += source.total_vertices();
+		_global_counter.drawcalls += source.total_drawcalls();
 
-		for (auto source_entry : source._counters_per_used_depthstencil)
+		for (auto &[depthstencil, snapshot] : source._counters_per_used_depthstencil)
 		{
-			const auto destination_entry = _counters_per_used_depthstencil.find(source_entry.first);
+			const auto destination_entry = _counters_per_used_depthstencil.find(depthstencil);
 
-			if (destination_entry == _counters_per_used_depthstencil.end())
-			{
-				_counters_per_used_depthstencil.emplace(source_entry.first, source_entry.second);
-			}
-			else
-			{
-				destination_entry->second.vertices += source_entry.second.vertices;
-				destination_entry->second.drawcalls += source_entry.second.drawcalls;
-			}
+			_counters_per_used_depthstencil[depthstencil].counter.vertices += snapshot.counter.vertices;
+			_counters_per_used_depthstencil[depthstencil].counter.drawcalls += snapshot.counter.drawcalls;
+		}
+
+		for (auto &[buffer, snapshot] : source._counters_per_constant_buffer)
+		{
+			const auto destination_entry = _counters_per_constant_buffer.find(buffer);
+
+			_counters_per_constant_buffer[buffer].vertices += snapshot.vertices;
+			_counters_per_constant_buffer[buffer].drawcalls += snapshot.drawcalls;
+			_counters_per_constant_buffer[buffer].pixelshaders += snapshot.pixelshaders;
+			_counters_per_constant_buffer[buffer].vertexshaders += snapshot.vertexshaders;
 		}
 	}
 
 	void draw_call_tracker::reset()
 	{
-		_counters.vertices = 0;
-		_counters.drawcalls = 0;
+		_global_counter.vertices = 0;
+		_global_counter.drawcalls = 0;
 		_counters_per_used_depthstencil.clear();
+		_counters_per_constant_buffer.clear();
 	}
 
-	void draw_call_tracker::log_drawcalls(UINT drawcalls, UINT vertices)
-	{
-		_counters.vertices += vertices;
-		_counters.drawcalls += drawcalls;
-	}
-	void draw_call_tracker::log_drawcalls(ID3D11DepthStencilView* depthstencil, UINT drawcalls, UINT vertices)
-	{
-		assert(depthstencil != nullptr && drawcalls > 0);
+	void draw_call_tracker::on_draw(ID3D11DeviceContext *context, UINT vertices) {
+		_global_counter.vertices += vertices;
+		_global_counter.drawcalls += 1;
 
-		const auto counters = _counters_per_used_depthstencil.find(depthstencil);
+		ID3D11RenderTargetView *rendertargets[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT] = { nullptr };
+		ID3D11DepthStencilView *depthstencil = nullptr;
 
-		if (counters != _counters_per_used_depthstencil.end())
+		context->OMGetRenderTargetsAndUnorderedAccessViews(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, rendertargets, &depthstencil, 0, 0, nullptr);
+
+		if (depthstencil == nullptr) {
+			// this is a draw call with no depthstencil
+			return;
+		}
+
+		const auto intermediate_snapshot = _counters_per_used_depthstencil.find(depthstencil);
+
+		if (intermediate_snapshot != _counters_per_used_depthstencil.end())
 		{
-			counters->second.vertices += vertices;
-			counters->second.drawcalls += drawcalls;
+			intermediate_snapshot->second.counter.vertices += vertices;
+			intermediate_snapshot->second.counter.drawcalls += 1;
+
+			// Find the render targets, if they exist, and update their counts
+			for (unsigned int i = 0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++) {
+				if (rendertargets[i] != nullptr) {
+					auto it = intermediate_snapshot->second.additional_views.find(rendertargets[i]);
+					if (it != intermediate_snapshot->second.additional_views.end()) {
+						it->second.vertices += vertices;
+						it->second.drawcalls += 1;
+					}
+					else {
+						// This shouldn't happen - it means somehow someone has called "draw" with a rendertarget without calling track_rendertargets first
+						assert(false);
+					}
+				}
+			}
+		}
+
+		// Capture constant buffers that are used when depthstencils are drawn
+		ID3D11Buffer *vscbuffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT] = { nullptr };
+		context->VSGetConstantBuffers(0, D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT, vscbuffers);
+
+		for (unsigned int i = 0; i < D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT; i++) {
+			// uses the default drawcalls = 0 the first time around.
+			if (vscbuffers[i] != nullptr) {
+				_counters_per_constant_buffer[vscbuffers[i]].vertexshaders += 1;
+			}
+		}
+
+		ID3D11Buffer *pscbuffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT] = { nullptr };
+		context->PSGetConstantBuffers(0, D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT, pscbuffers);
+
+		for (unsigned int i = 0; i < D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT; i++) {
+			// uses the default drawcalls = 0 the first time around.
+			if (pscbuffers[i] != nullptr) {
+				_counters_per_constant_buffer[pscbuffers[i]].pixelshaders += 1;
+			}
+		}
+
+	}
+
+	void draw_call_tracker::on_map(ID3D11DeviceContext *context, ID3D11Resource *pResource) {
+
+		D3D11_RESOURCE_DIMENSION dim;
+		pResource->GetType(&dim);
+
+		if (dim == D3D11_RESOURCE_DIMENSION::D3D11_RESOURCE_DIMENSION_BUFFER) {
+			_counters_per_constant_buffer[reinterpret_cast<ID3D11Buffer*>(pResource)].mapped += 1;
 		}
 	}
 
@@ -54,13 +110,26 @@ namespace reshade::d3d11
 	{
 		return _counters_per_used_depthstencil.find(depthstencil) != _counters_per_used_depthstencil.end();
 	}
-	void draw_call_tracker::track_depthstencil(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture)
+
+	void draw_call_tracker::track_rendertargets(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture, UINT numviews, ID3D11RenderTargetView *const *ppRenderTargetViews)
 	{
 		assert(depthstencil != nullptr);
 
-		if (!check_depthstencil(depthstencil))
-		{
-			_counters_per_used_depthstencil.emplace(depthstencil, depthstencil_counter_info { 0, 0, texture });
+		// if depthstencil is not already being tracked, this will create it
+		_counters_per_used_depthstencil[depthstencil].depthstencil = _counters_per_used_depthstencil[depthstencil].depthstencil == nullptr ? depthstencil : _counters_per_used_depthstencil[depthstencil].depthstencil;
+		_counters_per_used_depthstencil[depthstencil].texture = _counters_per_used_depthstencil[depthstencil].texture == nullptr ? texture : _counters_per_used_depthstencil[depthstencil].texture;
+
+		for (unsigned int i = 0; i < numviews; i++) {
+			// if the rendertarget isn't being tracked, this will create it
+			_counters_per_used_depthstencil[depthstencil].additional_views[ppRenderTargetViews[i]].drawcalls += 1;
+		}
+
+	}
+
+	void draw_call_tracker::update_tracked_depthtexture(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture) {
+		auto it = _counters_per_used_depthstencil.find(depthstencil);
+		if (it != _counters_per_used_depthstencil.end()) {
+			it->second.texture = texture;
 		}
 	}
 
@@ -68,27 +137,21 @@ namespace reshade::d3d11
 	{
 		const float aspect_ratio = float(width) / float(height);
 
-		depthstencil_counter_info best_info = { };
+		intermediate_snapshot_info  best_info = { };
 		std::pair<ID3D11DepthStencilView *, ID3D11Texture2D *> best_match = { };
 
-		for (const auto &it : _counters_per_used_depthstencil)
+		for (const auto &[depthstencil, snapshot] : _counters_per_used_depthstencil)
 		{
-			const auto depthstencil = it.first;
-			auto &depthstencil_info = it.second;
 
-			if (depthstencil_info.drawcalls == 0 || depthstencil_info.vertices == 0)
+			if (snapshot.counter.drawcalls == 0 || snapshot.counter.vertices == 0)
 			{
 				continue;
 			}
 
-			com_ptr<ID3D11Texture2D> texture;
 
-			if (depthstencil_info.texture != nullptr)
+			if (snapshot.texture == nullptr)
 			{
-				texture = depthstencil_info.texture;
-			}
-			else
-			{
+				com_ptr<ID3D11Texture2D> texture;
 				com_ptr<ID3D11Resource> resource;
 				depthstencil->GetResource(&resource);
 
@@ -96,11 +159,12 @@ namespace reshade::d3d11
 				{
 					continue;
 				}
+
+				best_info.texture = texture;
 			}
 
 			D3D11_TEXTURE2D_DESC desc;
-			texture->GetDesc(&desc);
-
+			best_info.texture->GetDesc(&desc);
 			assert((desc.BindFlags & D3D11_BIND_DEPTH_STENCIL) != 0);
 
 			// Check aspect ratio
@@ -121,18 +185,16 @@ namespace reshade::d3d11
 				continue;
 			}
 
-			if (depthstencil_info.drawcalls >= best_info.drawcalls)
+			if (snapshot.counter.drawcalls >= best_info.counter.drawcalls)
 			{
-				best_match.first = depthstencil.get();
-				// Warning: Reference to this object is lost after leaving the scope.
-				// But that should be fine since either this tracker or the depth stencil should still have a reference on it left so that it stays alive.
-				best_match.second = texture.get();
-
-				best_info.vertices = depthstencil_info.vertices;
-				best_info.drawcalls = depthstencil_info.drawcalls;
+				best_info = snapshot;
 			}
 		}
 
-		return best_match;
+		// Warning: Reference to this object is lost after leaving the scope.
+		// But that should be fine since either this tracker or the depth stencil should still have a reference on it left so that it stays alive.
+		std::pair<ID3D11DepthStencilView *, ID3D11Texture2D *> response = {best_info.depthstencil.get(), best_info.texture.get()};
+
+		return response;
 	}
 }

--- a/source/d3d11/draw_call_tracker.hpp
+++ b/source/d3d11/draw_call_tracker.hpp
@@ -9,7 +9,8 @@ namespace reshade::d3d11
 	class draw_call_tracker
 	{
 	public:
-		struct draw_counter {
+		struct draw_stats
+		{
 			UINT vertices = 0;
 			UINT drawcalls = 0;
 			UINT mapped = 0;
@@ -19,9 +20,9 @@ namespace reshade::d3d11
 		struct intermediate_snapshot_info
 		{
 			com_ptr<ID3D11DepthStencilView> depthstencil;
-			draw_counter counter;
+			draw_stats stats;
 			com_ptr<ID3D11Texture2D> texture;
-			std::map<com_ptr<ID3D11RenderTargetView>, draw_counter> additional_views;
+			std::map<com_ptr<ID3D11RenderTargetView>, draw_stats> additional_views;
 		};
 
 		UINT total_vertices() const { return _global_counter.vertices; }
@@ -43,9 +44,9 @@ namespace reshade::d3d11
 		intermediate_snapshot_info find_best_snapshot(UINT width, UINT height, DXGI_FORMAT format);
 
 	private:
-		draw_counter _global_counter;
+		draw_stats _global_counter;
 
 		std::map<com_ptr<ID3D11DepthStencilView>, intermediate_snapshot_info> _counters_per_used_depthstencil;
-		std::map<com_ptr<ID3D11Buffer>, draw_counter> _counters_per_constant_buffer;
+		std::map<com_ptr<ID3D11Buffer>, draw_stats> _counters_per_constant_buffer;
 	};
 }

--- a/source/d3d11/draw_call_tracker.hpp
+++ b/source/d3d11/draw_call_tracker.hpp
@@ -14,12 +14,12 @@ namespace reshade::d3d11
 			UINT vertices = 0;
 			UINT drawcalls = 0;
 			UINT mapped = 0;
-			UINT vertexshaders = 0;
-			UINT pixelshaders = 0;
+			UINT vs_uses = 0;
+			UINT ps_uses = 0;
 		};
 		struct intermediate_snapshot_info
 		{
-			com_ptr<ID3D11DepthStencilView> depthstencil;
+			ID3D11DepthStencilView *depthstencil = nullptr; // No need to use a 'com_ptr' here since '_counters_per_used_depthstencil' already keeps a reference
 			draw_stats stats;
 			com_ptr<ID3D11Texture2D> texture;
 			std::map<ID3D11RenderTargetView *, draw_stats> additional_views;

--- a/source/d3d11/draw_call_tracker.hpp
+++ b/source/d3d11/draw_call_tracker.hpp
@@ -40,7 +40,7 @@ namespace reshade::d3d11
 		void track_rendertargets(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture, UINT numviews, ID3D11RenderTargetView *const *ppRenderTargetViews);
 		void update_tracked_depthtexture(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture);
 
-		std::pair<ID3D11DepthStencilView *, ID3D11Texture2D *> find_best_depth_stencil(UINT width, UINT height, DXGI_FORMAT format);
+		intermediate_snapshot_info find_best_snapshot(UINT width, UINT height, DXGI_FORMAT format);
 
 	private:
 		draw_counter _global_counter;

--- a/source/d3d11/draw_call_tracker.hpp
+++ b/source/d3d11/draw_call_tracker.hpp
@@ -9,32 +9,43 @@ namespace reshade::d3d11
 	class draw_call_tracker
 	{
 	public:
-		UINT vertices() const { return _counters.vertices; }
-		UINT drawcalls() const { return _counters.drawcalls; }
+		struct draw_counter {
+			UINT vertices = 0;
+			UINT drawcalls = 0;
+			UINT mapped = 0;
+			UINT vertexshaders = 0;
+			UINT pixelshaders = 0;
+		};
+		struct intermediate_snapshot_info
+		{
+			com_ptr<ID3D11DepthStencilView> depthstencil;
+			draw_counter counter;
+			com_ptr<ID3D11Texture2D> texture;
+			std::map<com_ptr<ID3D11RenderTargetView>, draw_counter> additional_views;
+		};
+
+		UINT total_vertices() const { return _global_counter.vertices; }
+		UINT total_drawcalls() const { return _global_counter.drawcalls; }
 
 		const auto &depthstencil_counters() const { return _counters_per_used_depthstencil; }
+		const auto &constant_counters() const { return _counters_per_constant_buffer; }
 
 		void merge(const draw_call_tracker &source);
 		void reset();
 
-		void log_drawcalls(UINT drawcalls, UINT vertices);
-		void log_drawcalls(ID3D11DepthStencilView *depthstencil, UINT drawcalls, UINT vertices);
+		void on_draw(ID3D11DeviceContext *context, UINT vertices);
+		void on_map(ID3D11DeviceContext *context, ID3D11Resource *pResource);
 
 		bool check_depthstencil(ID3D11DepthStencilView *depthstencil) const;
-		void track_depthstencil(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture = nullptr);
+		void track_rendertargets(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture, UINT numviews, ID3D11RenderTargetView *const *ppRenderTargetViews);
+		void update_tracked_depthtexture(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture);
 
 		std::pair<ID3D11DepthStencilView *, ID3D11Texture2D *> find_best_depth_stencil(UINT width, UINT height, DXGI_FORMAT format);
 
 	private:
-		struct depthstencil_counter_info
-		{
-			UINT vertices = 0;
-			UINT drawcalls = 0;
-			com_ptr<ID3D11Texture2D> texture;
-		};
+		draw_counter _global_counter;
 
-		depthstencil_counter_info _counters;
-		// Use "std::map" instead of "std::unordered_map" so that the iteration order is guaranteed
-		std::map<com_ptr<ID3D11DepthStencilView>, depthstencil_counter_info> _counters_per_used_depthstencil;
+		std::map<com_ptr<ID3D11DepthStencilView>, intermediate_snapshot_info> _counters_per_used_depthstencil;
+		std::map<com_ptr<ID3D11Buffer>, draw_counter> _counters_per_constant_buffer;
 	};
 }

--- a/source/d3d11/draw_call_tracker.hpp
+++ b/source/d3d11/draw_call_tracker.hpp
@@ -34,11 +34,11 @@ namespace reshade::d3d11
 		void merge(const draw_call_tracker &source);
 		void reset();
 
+		void on_map(ID3D11Resource *pResource);
 		void on_draw(ID3D11DeviceContext *context, UINT vertices);
-		void on_map(ID3D11DeviceContext *context, ID3D11Resource *pResource);
 
 		bool check_depthstencil(ID3D11DepthStencilView *depthstencil) const;
-		void track_rendertargets(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture, UINT numviews, ID3D11RenderTargetView *const *ppRenderTargetViews);
+		void track_rendertargets(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture, UINT num_views, ID3D11RenderTargetView *const *views);
 		void update_tracked_depthtexture(ID3D11DepthStencilView *depthstencil, com_ptr<ID3D11Texture2D> texture);
 
 		intermediate_snapshot_info find_best_snapshot(UINT width, UINT height, DXGI_FORMAT format);

--- a/source/d3d11/draw_call_tracker.hpp
+++ b/source/d3d11/draw_call_tracker.hpp
@@ -22,7 +22,7 @@ namespace reshade::d3d11
 			com_ptr<ID3D11DepthStencilView> depthstencil;
 			draw_stats stats;
 			com_ptr<ID3D11Texture2D> texture;
-			std::map<com_ptr<ID3D11RenderTargetView>, draw_stats> additional_views;
+			std::map<ID3D11RenderTargetView *, draw_stats> additional_views;
 		};
 
 		UINT total_vertices() const { return _global_counter.vertices; }


### PR DESCRIPTION
The primary goal of this pull request is to set the groundwork for capturing additional buffers useful for post processing shaders. In the future, Reshade could pass surface normals and/or camera transforms to the post processing shaders for things like ambient occlusion and temporal aliasing. A little more work needs to be done to this effect (heuristics and config options) - but this represents the back-end component

- I wasn't able to test this on deferred context pipelines... but I don't think there should be any issues. It would be ideal if we could test that before merging into master
- pointers to intermediate buffers that are drawn along side depth buffers are stored in a "snapshot"
- pointers to constant buffers that are mapped along side depth buffers are stored
- the  `draw_call_tracker::find_best_snapshot()` function now (changed from `draw_call_tracker::find_best_depthstencil()` returns an object which contains rendertargets as well as the depthstencil
- these additional buffers are not used anywhere yet
- rather than keep track of rendertargets and depthstencils as they are drawn (with an `_active_depthstencil` variable) the rendertargets are queried during an `on_draw`. I don't think this causes any performance issues and it GREATLY enhances the ability of the draw_call_tracker to collect data
- `draw_call_tracker::verticies` and `draw_call_tracker::drawcalls` are now `total_verticies` and `total_drawcalls`
- the additional data about render targets and constant buffers should be displayed in the dx11 configuration/menu .... after we merge the new menu changes in and rebase this pull request, it will be easy to add those