### PR TITLE
Add option to save preset and configuration at screenshot

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -747,6 +747,23 @@ namespace reshade
 			{
 				save_config();
 			}
+
+			if (ImGui::Checkbox("Include Preset (*.ini)",&_screenshot_include_preset))
+			{
+				_screenshot_include_configuration = false;
+
+				save_config();
+			}
+
+			if (_screenshot_include_preset)
+			{
+				ImGui::SameLine();
+
+				if (ImGui::Checkbox("Include Configuration (*.ini)", &_screenshot_include_configuration))
+				{
+					save_config();
+				}
+			}
 		}
 
 		if (ImGui::CollapsingHeader("User Interface", ImGuiTreeNodeFlags_DefaultOpen))

--- a/source/ini_file.cpp
+++ b/source/ini_file.cpp
@@ -20,7 +20,11 @@ namespace reshade
 		return res;
 	}
 
-	ini_file::ini_file(const filesystem::path &path) : _path(path)
+	ini_file::ini_file(const filesystem::path &path) : _path(path), _save_path(path)
+	{
+		load();
+	}
+	ini_file::ini_file(const filesystem::path &path, const filesystem::path &save_path) : _path(path), _save_path(save_path)
 	{
 		load();
 	}
@@ -84,7 +88,7 @@ namespace reshade
 			return;
 		}
 
-		std::ofstream file(_path.wstring());
+		std::ofstream file(_save_path.wstring());
 
 		const auto it = _sections.find("");
 

--- a/source/ini_file.hpp
+++ b/source/ini_file.hpp
@@ -15,6 +15,7 @@ namespace reshade
 	{
 	public:
 		explicit ini_file(const filesystem::path &path);
+		explicit ini_file(const filesystem::path &path, const filesystem::path &save_path);
 		~ini_file();
 
 		template <typename T>
@@ -107,6 +108,7 @@ namespace reshade
 
 		bool _modified = false;
 		filesystem::path _path;
+		filesystem::path _save_path;
 		using section = std::unordered_map<std::string, variant>;
 		std::unordered_map<std::string, section> _sections;
 	};

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1096,19 +1096,16 @@ namespace reshade
 			return;
 		}
 
-		if (_screenshot_include_preset)
+		if (_screenshot_include_preset && _current_preset >= 0)
 		{
-			if (_current_preset >= 0)
-			{
-				const auto preset_file = _preset_files[_current_preset];
-				const auto save_preset_path = _screenshot_path / (s_target_executable_path.filename_without_extension() + filename + " " + preset_file.filename_without_extension() + ".ini");
-				save_preset(preset_file, save_preset_path);
+			const auto preset_file = _preset_files[_current_preset];
+			const auto save_preset_path = _screenshot_path / (s_target_executable_path.filename_without_extension() + filename + " " + preset_file.filename_without_extension() + ".ini");
+			save_preset(preset_file, save_preset_path);
 
-				if (_screenshot_include_configuration)
-				{
-					const auto save_configuration_path = _screenshot_path / (s_target_executable_path.filename_without_extension() + filename + ".ini");
-					save_config(save_configuration_path);
-				}
+			if (_screenshot_include_configuration)
+			{
+				const auto save_configuration_path = _screenshot_path / (s_target_executable_path.filename_without_extension() + filename + ".ini");
+				save_config(save_configuration_path);
 			}
 		}
 	}

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1101,7 +1101,7 @@ namespace reshade
 			if (_current_preset >= 0)
 			{
 				const auto preset_file = _preset_files[_current_preset];
-				const auto save_preset_path = _screenshot_path / (s_target_executable_path.filename_without_extension() + filename + "." + preset_file.filename_without_extension() + ".ini");
+				const auto save_preset_path = _screenshot_path / (s_target_executable_path.filename_without_extension() + filename + " " + preset_file.filename_without_extension() + ".ini");
 				save_preset(preset_file, save_preset_path);
 
 				if (_screenshot_include_configuration)

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -207,6 +207,11 @@ namespace reshade
 		/// Save user configuration to disk.
 		/// </summary>
 		void save_config() const;
+		/// <summary>
+		/// Save user configuration to disk.
+		/// </summary>
+		/// <param name="path">Output configuration path.</param>
+		void save_config(const filesystem::path &path) const;
 
 		/// <summary>
 		/// Render all passes in a technique.
@@ -237,6 +242,7 @@ namespace reshade
 		void load_preset(const filesystem::path &path);
 		void load_current_preset();
 		void save_preset(const filesystem::path &path) const;
+		void save_preset(const filesystem::path &path, const filesystem::path &save_path) const;
 		void save_current_preset() const;
 		void save_screenshot() const;
 
@@ -287,6 +293,8 @@ namespace reshade
 		bool _show_framerate = false;
 		bool _effects_enabled = true;
 		bool _is_fast_loading = false;
+		bool _screenshot_include_preset = false;
+		bool _screenshot_include_configuration = false;
 		bool _no_font_scaling = false;
 		bool _no_reload_on_init = false;
 		bool _performance_mode = false;


### PR DESCRIPTION
![0205](https://user-images.githubusercontent.com/42232001/46905056-e4426c80-cf28-11e8-9a6d-b3e1d22e96d0.png)
![0206](https://user-images.githubusercontent.com/42232001/46905059-e5739980-cf28-11e8-9ba1-80aa0eae3027.png)
![0207](https://user-images.githubusercontent.com/42232001/46905240-659afe80-cf2b-11e8-97a2-56ad5845d323.png)

ReShade64 2018-10-13 20-55-14
**[x]** Include Preset (\*.ini)
**[ ]** Include Configuration (*.ini)

ReShade64 2018-10-13 20-55-17
**[x]** Include Preset (\*.ini)
**[x]** Include Configuration (*.ini)