### PR TITLE
Add option to filter active effects, move errors/warnings into CollapsingHeader

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -22,9 +22,6 @@ extern std::filesystem::path g_target_executable_path;
 const ImVec4 COLOR_RED = ImColor(240, 100, 100);
 const ImVec4 COLOR_YELLOW = ImColor(204, 204, 0);
 
-const ImVec4 COLOR_RED_HOVER = ImColor(240, 130, 130);
-const ImVec4 COLOR_YELLOW_HOVER = ImColor(204, 204, 100);
-
 void reshade::runtime::init_ui()
 {
 	// Default shortcut: Home
@@ -1184,21 +1181,18 @@ void reshade::runtime::draw_overlay_menu_statistics()
 			{
 				bool errors_found = effect.errors.find("error") != std::string::npos;
 
-				ImGui::PushStyleColor(ImGuiCol_Header, errors_found ? COLOR_RED : COLOR_YELLOW);
-				ImGui::PushStyleColor(ImGuiCol_HeaderHovered, errors_found ? COLOR_RED_HOVER : COLOR_YELLOW_HOVER);
-				ImGui::PushStyleColor(ImGuiCol_Text, errors_found ? _imgui_context->Style.Colors[ImGuiCol_Text] : _imgui_context->Style.Colors[ImGuiCol_WindowBg]);
+				ImVec4 color_override_header = ImGui::ColorConvertU32ToFloat4(_editor.get_palette_index(errors_found ? _editor.color_error_marker : _editor.color_warning_marker));
+				ImGui::PushStyleColor(ImGuiCol_Header, color_override_header);
 
 				if (ImGui::CollapsingHeader(errors_found ? "Errors" : "Warnings"))
 				{
-					ImGui::PushStyleColor(ImGuiCol_Text, errors_found ? COLOR_RED : COLOR_YELLOW);
 					ImGui::PushTextWrapPos();
 					ImGui::TextUnformatted(effect.errors.c_str());
 					ImGui::PopTextWrapPos();
-					ImGui::PopStyleColor();
 					ImGui::Spacing();
 				}
 
-				ImGui::PopStyleColor(3);
+				ImGui::PopStyleColor();
 			}
 
 			#pragma region Techniques

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1191,12 +1191,12 @@ void reshade::runtime::draw_overlay_menu_statistics()
 				if (ImGui::CollapsingHeader(errors_found ? "Errors" : "Warnings"))
 				{
 					ImGui::PushStyleColor(ImGuiCol_Text, errors_found ? COLOR_RED : COLOR_YELLOW);
-				ImGui::PushTextWrapPos();
-				ImGui::TextUnformatted(effect.errors.c_str());
-				ImGui::PopTextWrapPos();
-				ImGui::PopStyleColor();
-				ImGui::Spacing();
-			}
+					ImGui::PushTextWrapPos();
+					ImGui::TextUnformatted(effect.errors.c_str());
+					ImGui::PopTextWrapPos();
+					ImGui::PopStyleColor();
+					ImGui::Spacing();
+				}
 
 				ImGui::PopStyleColor(3);
 			}

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1118,12 +1118,14 @@ void reshade::runtime::draw_overlay_menu_statistics()
 		std::vector<const technique *> current_techniques;
 		current_techniques.reserve(_techniques.size());
 
+		ImGui::Checkbox("Show only active techniques", &_statistics_effects_show_enabled);
+
 		for (size_t index = 0; index < _loaded_effects.size(); ++index)
 		{
 			const effect_data &effect = _loaded_effects[index];
 
-			// Ignore unloaded effects
-			if (effect.source_file.empty())
+			// Ignore unloaded effects, filter for active effects if enabled
+			if (effect.source_file.empty() || (_statistics_effects_show_enabled && effect.rendering == 0))
 				continue;
 
 			ImGui::PushID(static_cast<int>(index));

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -22,6 +22,9 @@ extern std::filesystem::path g_target_executable_path;
 const ImVec4 COLOR_RED = ImColor(240, 100, 100);
 const ImVec4 COLOR_YELLOW = ImColor(204, 204, 0);
 
+const ImVec4 COLOR_RED_HOVER = ImColor(240, 130, 130);
+const ImVec4 COLOR_YELLOW_HOVER = ImColor(204, 204, 100);
+
 void reshade::runtime::init_ui()
 {
 	// Default shortcut: Home
@@ -1179,12 +1182,23 @@ void reshade::runtime::draw_overlay_menu_statistics()
 
 			if (!effect.errors.empty())
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, effect.errors.find("error") != std::string::npos ? COLOR_RED : COLOR_YELLOW);
+				bool errors_found = effect.errors.find("error") != std::string::npos;
+
+				ImGui::PushStyleColor(ImGuiCol_Header, errors_found ? COLOR_RED : COLOR_YELLOW);
+				ImGui::PushStyleColor(ImGuiCol_HeaderHovered, errors_found ? COLOR_RED_HOVER : COLOR_YELLOW_HOVER);
+				ImGui::PushStyleColor(ImGuiCol_Text, errors_found ? _imgui_context->Style.Colors[ImGuiCol_Text] : _imgui_context->Style.Colors[ImGuiCol_WindowBg]);
+
+				if (ImGui::CollapsingHeader(errors_found ? "Errors" : "Warnings"))
+				{
+					ImGui::PushStyleColor(ImGuiCol_Text, errors_found ? COLOR_RED : COLOR_YELLOW);
 				ImGui::PushTextWrapPos();
 				ImGui::TextUnformatted(effect.errors.c_str());
 				ImGui::PopTextWrapPos();
 				ImGui::PopStyleColor();
 				ImGui::Spacing();
+			}
+
+				ImGui::PopStyleColor(3);
 			}
 
 			#pragma region Techniques

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -271,6 +271,8 @@ namespace reshade
 		std::filesystem::path _configuration_path;
 		bool _screenshot_include_preset = false;
 
+		bool _statistics_effects_show_enabled = false;
+
 		size_t _current_preset = 0;
 		std::vector<std::filesystem::path> _preset_files;
 


### PR DESCRIPTION
Modified statistics->effects a bit.
- Added option to show only active effects
- Moved compiler errors/warnings into a collapsing header