### PR TITLE
Fix a problem that key binding condition is wrong

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -234,7 +234,7 @@ bool reshade::input::is_key_pressed(unsigned int keycode) const
 }
 bool reshade::input::is_key_pressed(unsigned int keycode, bool ctrl, bool shift, bool alt) const
 {
-	return is_key_pressed(keycode) && (!ctrl || is_key_down(VK_CONTROL)) && (!shift || is_key_down(VK_SHIFT)) && (!alt || is_key_down(VK_MENU));
+	return is_key_pressed(keycode) && ctrl == is_key_down(VK_CONTROL) && shift == is_key_down(VK_SHIFT) && alt == is_key_down(VK_MENU);
 }
 bool reshade::input::is_key_released(unsigned int keycode) const
 {


### PR DESCRIPTION
If exist these settings

* S
* Ctrl + S
* Ctrl + Shift + S

If you pressed key combination "Ctrl + Shift + S", switches these effects at the same time.
