### PR TITLE
Add support of annotation "ui_label" for technique

### DIFF
--- a/source/effect_expression.hpp
+++ b/source/effect_expression.hpp
@@ -359,6 +359,7 @@ namespace reshadefx
 	struct technique_info
 	{
 		std::string name;
+		std::string display_name;
 		std::vector<pass_info> passes;
 		std::unordered_map<std::string, std::pair<type, constant>> annotations;
 	};

--- a/source/effect_parser.cpp
+++ b/source/effect_parser.cpp
@@ -2697,6 +2697,10 @@ bool reshadefx::parser::parse_technique()
 	if (!parse_annotations(info.annotations) || !expect('{'))
 		return false;
 
+	info.display_name = std::move(info.annotations["ui_label"].second.string_data);
+	if (info.display_name.empty())
+		info.display_name = info.name;
+
 	while (!peek('}'))
 	{
 		if (pass_info pass; parse_technique_pass(pass))

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -768,7 +768,7 @@ void reshade::runtime::draw_overlay_menu_home()
 					for (size_t k = i + 1; k < _techniques.size(); ++k)
 					{
 						if (!_techniques[k].enabled && _techniques[k].toggle_key_data[0] == 0
-							&& _techniques[i].name.compare(_techniques[k].name) > 0)
+							&& _techniques[i].display_name.compare(_techniques[k].display_name) > 0)
 						{
 							std::swap(_techniques[i], _techniques[k]);
 							i = 0;
@@ -1901,7 +1901,11 @@ void reshade::runtime::draw_overlay_technique_editor()
 		// Gray out disabled techniques and mark techniques which failed to compile red
 		ImGui::PushStyleColor(ImGuiCol_Text, compile_success ? _imgui_context->Style.Colors[technique.enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled] : COLOR_RED);
 
-		const std::string label = technique.name + " [" + _loaded_effects[technique.effect_index].source_file.filename().u8string() + ']' + (!compile_success ? " (failed to compile)" : "");
+		std::string label;
+		if (!compile_success || technique.name == technique.display_name)
+			label = technique.name + " [" + _loaded_effects[technique.effect_index].source_file.filename().u8string() + ']' + (!compile_success ? " (failed to compile)" : "");
+		else
+			label = technique.display_name;
 
 		if (bool status = technique.enabled; ImGui::Checkbox(label.c_str(), &status))
 		{


### PR DESCRIPTION
When you create BackColor and BackImage with added annotation "ui_label":
![replace_1](https://user-images.githubusercontent.com/42232001/53063976-70812380-3509-11e9-8891-5aa0cc662cbc.png)

Error case:
![replace_2](https://user-images.githubusercontent.com/42232001/53063980-7414aa80-3509-11e9-8192-fcd237900b3d.png)
