### PR TITLE
Fix Technique hotkeys "bleeding" between presets.

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -630,9 +630,15 @@ void reshade::runtime::draw_overlay_menu_home()
 
 					// Need to reload effects in performance mode, so values are applied
 					if (_performance_mode)
+					{
+						_techniques[i].toggle_key_data[0] = 0;
 						load_effects();
+					}
 					else
+					{
 						load_preset(_preset_files[_current_preset]);
+						_techniques[i].toggle_key_data[0] = 0;
+					}
 				}
 			}
 

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -636,8 +636,8 @@ void reshade::runtime::draw_overlay_menu_home()
 					}
 					else
 					{
-						load_preset(_preset_files[_current_preset]);
 						_techniques[i].toggle_key_data[0] = 0;
+						load_preset(_preset_files[_current_preset]);
 					}
 				}
 			}


### PR DESCRIPTION
Switching to a preset without hotkeys set, while having a preset with hotkeys loaded, would cause hotkeys to be saved to the preset being loaded. This caused endless bleeding of hotkeys between presets as every preset loaded would carry and save the hotkeys from the previous preset.