### PR TITLE
fix parasite D3D9 depth buffers

### DIFF
--- a/source/d3d9/d3d9_device.cpp
+++ b/source/d3d9/d3d9_device.cpp
@@ -439,6 +439,10 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice9::MultiplyTransform(D3DTRANSFORMSTATETY
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice9::SetViewport(const D3DVIEWPORT9 *pViewport)
 {
+	assert(_implicit_swapchain != nullptr);
+	assert(_implicit_swapchain->_runtime != nullptr);
+	_implicit_swapchain->_runtime->on_set_viewport(pViewport);
+
 	return _orig->SetViewport(pViewport);
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice9::GetViewport(D3DVIEWPORT9 *pViewport)

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -1319,7 +1319,7 @@ void reshade::d3d9::runtime_d3d9::detect_depth_source()
 	if (_preserve_depth_buffer)
 	{
 		// check if we draw calls have been registered since the last cleaning
-		if (_depthstencil_replacement != nullptr && _current_db_drawcalls > 0 && _current_db_vertices > 0)
+		if (_is_good_viewport && _depthstencil_replacement != nullptr && _current_db_drawcalls > 0 && _current_db_vertices > 0)
 		{
 			D3DSURFACE_DESC desc;
 			_depthstencil_replacement->GetDesc(&desc);

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -301,6 +301,10 @@ void reshade::d3d9::runtime_d3d9::on_draw_call(D3DPRIMITIVETYPE type, unsigned i
 	com_ptr<IDirect3DSurface9> depthstencil;
 	_device->GetDepthStencilSurface(&depthstencil);
 
+	// remove parasite items
+	if (!_is_good_viewport)
+		return;
+
 	if (depthstencil != nullptr)
 	{
 		// Resolve pointer to original depth stencil
@@ -349,6 +353,10 @@ void reshade::d3d9::runtime_d3d9::on_clear_depthstencil_surface(IDirect3DSurface
 	D3DSURFACE_DESC desc;
 	depthstencil->GetDesc(&desc);
 	if (!check_depthstencil_size(desc)) // Ignore unlikely candidates
+		return;
+
+	// remove parasite items
+	if (!_is_good_viewport)
 		return;
 
 	// Check if any draw calls have been registered since the last clear operation
@@ -411,6 +419,17 @@ void reshade::d3d9::runtime_d3d9::capture_screenshot(uint8_t *buffer) const
 	}
 
 	intermediate->UnlockRect();
+}
+
+void reshade::d3d9::runtime_d3d9::on_set_viewport(const D3DVIEWPORT9 *pViewport)
+{
+	D3DSURFACE_DESC desc;
+
+	desc.Width = pViewport->Width;
+	desc.Height = pViewport->Height;
+	desc.MultiSampleType = D3DMULTISAMPLE_NONE;
+
+	_is_good_viewport = check_depthstencil_size(desc);
 }
 
 bool reshade::d3d9::runtime_d3d9::init_texture(texture &texture)

--- a/source/d3d9/runtime_d3d9.hpp
+++ b/source/d3d9/runtime_d3d9.hpp
@@ -28,6 +28,7 @@ namespace reshade::d3d9
 		void on_set_depthstencil_surface(IDirect3DSurface9 *&depthstencil);
 		void on_get_depthstencil_surface(IDirect3DSurface9 *&depthstencil);
 		void on_clear_depthstencil_surface(IDirect3DSurface9 *depthstencil);
+		void on_set_viewport(const D3DVIEWPORT9 *pViewport);
 
 		void capture_screenshot(uint8_t *buffer) const override;
 
@@ -86,6 +87,7 @@ namespace reshade::d3d9
 		bool _auto_preserve = true;
 		bool _auto_preserve_on_drawcalls = false;
 		bool _auto_preserve_on_vertices = true;
+		bool _is_good_viewport = true;
 		unsigned int _db_vertices = 0;
 		unsigned int _db_drawcalls = 0;
 		unsigned int _current_db_vertices = 0;


### PR DESCRIPTION
Found that, filtering the viewport, i can get rid of the parasite depth buffer drawcalls that can occur in some games (Outlast, Half-life 2, Mass Effect 2 cinematics...). Feel free to check it, Crosire ;-)