### PR TITLE
Add associated depthstencil check

### DIFF
--- a/source/d3d9/d3d9_device.cpp
+++ b/source/d3d9/d3d9_device.cpp
@@ -439,6 +439,10 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice9::MultiplyTransform(D3DTRANSFORMSTATETY
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice9::SetViewport(const D3DVIEWPORT9 *pViewport)
 {
+	assert(_implicit_swapchain != nullptr);
+	assert(_implicit_swapchain->_runtime != nullptr);
+	_implicit_swapchain->_runtime->on_set_viewport(pViewport);
+
 	return _orig->SetViewport(pViewport);
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice9::GetViewport(D3DVIEWPORT9 *pViewport)

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -1319,7 +1319,7 @@ void reshade::d3d9::runtime_d3d9::detect_depth_source()
 	if (_preserve_depth_buffer)
 	{
 		// check if we draw calls have been registered since the last cleaning
-		if (_depthstencil_replacement != nullptr && _current_db_drawcalls > 0 && _current_db_vertices > 0)
+		if (_is_good_viewport && _depthstencil_replacement != nullptr && _current_db_drawcalls > 0 && _current_db_vertices > 0)
 		{
 			D3DSURFACE_DESC desc;
 			_depthstencil_replacement->GetDesc(&desc);

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -229,6 +229,7 @@ void reshade::d3d9::runtime_d3d9::on_reset()
 	_current_db_drawcalls = 0;
 
 	_disable_depth_buffer_size_restriction = false;
+	_init_depthbuffer_detection = true;
 }
 
 void reshade::d3d9::runtime_d3d9::on_present()
@@ -251,6 +252,8 @@ void reshade::d3d9::runtime_d3d9::on_present()
 		_depth_source_table.clear();
 		_disable_depth_buffer_size_restriction = false;
 	}
+
+	_init_depthbuffer_detection = false;
 
 	_app_state.capture();
 	BOOL software_rendering_enabled = FALSE;
@@ -280,9 +283,14 @@ void reshade::d3d9::runtime_d3d9::on_present()
 	{
 		_depth_buffer_table.clear();
 
+		com_ptr<IDirect3DSurface9> depthstencil;
+		_device->GetDepthStencilSurface(&depthstencil);
+
 		// Ensure that the main depth buffer replacement surface (and texture) is cleared before the next frame
 		_device->SetDepthStencilSurface(_depthstencil_replacement.get());
 		_device->Clear(0, nullptr, D3DCLEAR_ZBUFFER, 0, 1.0f, 0);
+
+		_device->SetDepthStencilSurface(depthstencil.get());
 	}
 }
 
@@ -325,21 +333,25 @@ void reshade::d3d9::runtime_d3d9::on_draw_call(D3DPRIMITIVETYPE type, unsigned i
 			it->second.vertices_count += vertices;
 		}
 	}
+	else
+		depthstencil = _depthstencil;
 
 	if (_preserve_depth_buffer && _depthstencil_replacement != nullptr)
 	{
+		_device->SetDepthStencilSurface(depthstencil.get());
+
 		// remove parasite items
 		if (!_is_good_viewport)
 			return;
 
-		// check that the drawcall is done on the good depthstencil (the one from which the depthstencil_replacement was created)
+		// check that the drawcall is done on the good depthstencil (the one from which the depthstencil_replaceent was created)
 		if (!_is_good_depthstencil)
-			return;
+		 	return;
 
 		_current_db_vertices += vertices,
 		_current_db_drawcalls += 1;
 
-		if (_depthstencil_replacement != depthstencil)
+		if (_depthstencil_replacement != depthstencil && _depth_buffer_table.size() <= _preserve_starting_index)
 			_device->SetDepthStencilSurface(_depthstencil_replacement.get());
 	}
 }
@@ -355,7 +367,7 @@ void reshade::d3d9::runtime_d3d9::on_set_depthstencil_surface(IDirect3DSurface9 
 		if (!check_depthstencil_size(desc)) // Ignore unlikely candidates
 			return;
 
-		_depth_source_table.emplace(depthstencil, depth_source_info { nullptr, desc.Width, desc.Height });
+		_depth_source_table.emplace(depthstencil, depth_source_info{ nullptr, desc.Width, desc.Height });
 	}
 
 	if (_depthstencil_replacement != nullptr && depthstencil == _depthstencil)
@@ -393,8 +405,12 @@ void reshade::d3d9::runtime_d3d9::on_clear_depthstencil_surface(IDirect3DSurface
 	if (_depth_buffer_table.empty() || _depth_buffer_table.size() <= _preserve_starting_index)
 		return;
 
-	// If the current depth buffer replacement texture has to be preserved, replace the set surface with a dummy one, so that the replacement texture will not be cleared
-	_device->SetDepthStencilSurface(nullptr);
+	if (_depthstencil_replacement != _depthstencil)
+		// If the current depth buffer replacement texture has to be preserved, replace the set surface with the original one, so that the replacement texture will not be cleared
+		_device->SetDepthStencilSurface(_depthstencil.get());
+	else
+		// If the current depth buffer replacement texture has to be preserved, replace the set surface with a dummy one, so that the replacement texture will not be cleared
+		_device->SetDepthStencilSurface(nullptr);
 }
 
 void reshade::d3d9::runtime_d3d9::on_set_viewport(const D3DVIEWPORT9 *pViewport)
@@ -1229,6 +1245,7 @@ void reshade::d3d9::runtime_d3d9::draw_debug_menu()
 			_depth_buffer_table.clear();
 			_depth_source_table.clear();
 			_depthstencil_replacement.reset();
+			_init_depthbuffer_detection = true;
 
 			if (_preserve_depth_buffer)
 				_disable_intz = false;
@@ -1259,8 +1276,7 @@ void reshade::d3d9::runtime_d3d9::draw_debug_menu()
 			if (ImGui::Checkbox("Auto preserve", &_auto_preserve))
 			{
 				modified = true;
-				if (_auto_preserve)
-					_preserve_starting_index = std::numeric_limits<size_t>::max();
+				_preserve_starting_index = std::numeric_limits<size_t>::max();
 			}
 
 			ImGui::Spacing();
@@ -1303,6 +1319,7 @@ void reshade::d3d9::runtime_d3d9::draw_debug_menu()
 				_depth_buffer_table.clear();
 				_depth_source_table.clear();
 				_depthstencil_replacement.reset();
+				_init_depthbuffer_detection = true;
 			}
 		}
 		else
@@ -1342,7 +1359,7 @@ void reshade::d3d9::runtime_d3d9::detect_depth_source()
 			for (size_t i = 0; i != _depth_buffer_table.size(); i++)
 			{
 				const auto &it = _depth_buffer_table[i];
-				if (it.vertices_count >= _db_vertices)
+				if (it.drawcall_count >= _db_drawcalls)
 				{
 					_db_vertices = it.vertices_count;
 					_db_drawcalls = it.drawcall_count;
@@ -1352,7 +1369,7 @@ void reshade::d3d9::runtime_d3d9::detect_depth_source()
 		}
 	}
 
-	if (_framecount % 30 || _is_multisampling_enabled || _depth_source_table.empty())
+	if (!_init_depthbuffer_detection && (_framecount % 30 || _is_multisampling_enabled || _depth_source_table.empty()))
 		return;
 
 	if (_has_high_network_activity)
@@ -1487,10 +1504,10 @@ bool reshade::d3d9::runtime_d3d9::create_depthstencil_replacement(const com_ptr<
 			com_ptr<IDirect3DSurface9> current_depthstencil;
 			_device->GetDepthStencilSurface(&current_depthstencil);
 
-			if (current_depthstencil != nullptr && current_depthstencil == _depthstencil)
+			if (!_preserve_depth_buffer && current_depthstencil != nullptr && current_depthstencil == _depthstencil)
 				_device->SetDepthStencilSurface(_depthstencil_replacement.get());
 		}
-		else
+		else 
 		{
 			_depthstencil_replacement = _depthstencil;
 

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -336,18 +336,18 @@ void reshade::d3d9::runtime_d3d9::on_draw_call(D3DPRIMITIVETYPE type, unsigned i
 
 	if (_preserve_depth_buffer && _depthstencil_replacement != nullptr)
 	{
-		_device->SetDepthStencilSurface(depthstencil.get());
-
 		// remove parasite items
 		if (!_is_good_viewport)
 			return;
 
 		// check that the drawcall is done on the good depthstencil (the one from which the depthstencil_replaceent was created)
 		if (!_is_good_depthstencil)
-		 	return;
+			return;
+
+		_device->SetDepthStencilSurface(depthstencil.get());
 
 		_current_db_vertices += vertices,
-		_current_db_drawcalls += 1;
+			_current_db_drawcalls += 1;
 
 		if (_depthstencil_replacement != depthstencil && _depth_buffer_table.size() <= _preserve_starting_index)
 			_device->SetDepthStencilSurface(_depthstencil_replacement.get());

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -386,7 +386,7 @@ void reshade::d3d9::runtime_d3d9::on_clear_depthstencil_surface(IDirect3DSurface
 	_current_db_vertices = 0;
 	_current_db_drawcalls = 0;
 
-	if (_depth_buffer_table.empty() || _depth_buffer_table.size() == _preserve_starting_index)
+	if (_depth_buffer_table.empty() || _depth_buffer_table.size() <= _preserve_starting_index)
 		return;
 
 	// If the current depth buffer replacement texture has to be preserved, replace the set surface with a dummy one, so that the replacement texture will not be cleared

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -245,12 +245,9 @@ void reshade::d3d9::runtime_d3d9::on_present()
 		_disable_depth_buffer_size_restriction = true;
 	// if the depthstencil_replacement surface detection succeeds by retrieving bigger resolutions candidates
 	// the texture is cropped to the actual viewport, so we can go back to the standard resolution filter
+	// and recheck for a depthstencil replacement candidate using the good resolution
 	else if (_disable_depth_buffer_size_restriction)
 	{
-		// Force depth-stencil replacement 
-		_depthstencil = _default_depthstencil;
-		// Force depth-stencil clearing table recreation
-		_depth_buffer_table.clear();
 		_depth_source_table.clear();
 		_disable_depth_buffer_size_restriction = false;
 	}

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -359,7 +359,7 @@ void reshade::d3d9::runtime_d3d9::on_set_depthstencil_surface(IDirect3DSurface9 
 	}
 
 	if (_depthstencil_replacement != nullptr && depthstencil == _depthstencil)
-			depthstencil = _depthstencil_replacement.get(); // Replace application depth stencil surface with our custom one
+		depthstencil = _depthstencil_replacement.get(); // Replace application depth stencil surface with our custom one
 }
 void reshade::d3d9::runtime_d3d9::on_get_depthstencil_surface(IDirect3DSurface9 *&depthstencil)
 {
@@ -393,7 +393,7 @@ void reshade::d3d9::runtime_d3d9::on_clear_depthstencil_surface(IDirect3DSurface
 	if (_depth_buffer_table.empty() || _depth_buffer_table.size() <= _preserve_starting_index)
 		return;
 
-	// If the current depth buffer replacement texture has to be preserved, replace the set surface with the original one, so that the replacement texture will not be cleared
+	// If the current depth buffer replacement texture has to be preserved, replace the set surface with a dummy one, so that the replacement texture will not be cleared
 	_device->SetDepthStencilSurface(nullptr);
 }
 

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -74,20 +74,14 @@ reshade::d3d9::runtime_d3d9::runtime_d3d9(IDirect3DDevice9 *device, IDirect3DSwa
 	subscribe_to_load_config([this](const ini_file &config) {
 		config.get("DX9_BUFFER_DETECTION", "DisableINTZ", _disable_intz);
 		config.get("DX9_BUFFER_DETECTION", "PreserveDepthBuffer", _preserve_depth_buffer);
-		config.get("DX9_BUFFER_DETECTION", "DisableDepthBufferSizeRestriction", _disable_depth_buffer_size_restriction);
 		config.get("DX9_BUFFER_DETECTION", "PreserveDepthBufferIndex", _preserve_starting_index);
 		config.get("DX9_BUFFER_DETECTION", "AutoPreserve", _auto_preserve);
-		config.get("DX9_BUFFER_DETECTION", "AutoPreserveOnVertices", _auto_preserve_on_vertices);
-		config.get("DX9_BUFFER_DETECTION", "AutoPreserveOnDrawcalls", _auto_preserve_on_drawcalls);
 	});
 	subscribe_to_save_config([this](ini_file &config) {
 		config.set("DX9_BUFFER_DETECTION", "DisableINTZ", _disable_intz);
 		config.set("DX9_BUFFER_DETECTION", "PreserveDepthBuffer", _preserve_depth_buffer);
-		config.set("DX9_BUFFER_DETECTION", "DisableDepthBufferSizeRestriction", _disable_depth_buffer_size_restriction);
 		config.set("DX9_BUFFER_DETECTION", "PreserveDepthBufferIndex", _preserve_starting_index);
 		config.set("DX9_BUFFER_DETECTION", "AutoPreserve", _auto_preserve);
-		config.set("DX9_BUFFER_DETECTION", "AutoPreserveOnVertices", _auto_preserve_on_vertices);
-		config.set("DX9_BUFFER_DETECTION", "AutoPreserveOnDrawcalls", _auto_preserve_on_drawcalls);
 	});
 }
 reshade::d3d9::runtime_d3d9::~runtime_d3d9()
@@ -233,6 +227,8 @@ void reshade::d3d9::runtime_d3d9::on_reset()
 	_db_drawcalls = 0;
 	_current_db_vertices = 0;
 	_current_db_drawcalls = 0;
+
+	_disable_depth_buffer_size_restriction = false;
 }
 
 void reshade::d3d9::runtime_d3d9::on_present()
@@ -241,6 +237,23 @@ void reshade::d3d9::runtime_d3d9::on_present()
 		return;
 
 	detect_depth_source();
+
+	/** Vanquish fix (and other games using bigger depth buffer surface than the viewport) **/
+	// if the depthstencil_replacement surface detection fails on the first attempt, try to detect it
+	// in some bigger resolutions
+	if (_depthstencil_replacement == nullptr)
+		_disable_depth_buffer_size_restriction = true;
+	// if the depthstencil_replacement surface detection succeeds by retrieving bigger resolutions candidates
+	// the texture is cropped to the actual viewport, so we can go back to the standard resolution filter
+	else if (_disable_depth_buffer_size_restriction)
+	{
+		// Force depth-stencil replacement 
+		_depthstencil = _default_depthstencil;
+		// Force depth-stencil clearing table recreation
+		_depth_buffer_table.clear();
+		_depth_source_table.clear();
+		_disable_depth_buffer_size_restriction = false;
+	}
 
 	_app_state.capture();
 	BOOL software_rendering_enabled = FALSE;
@@ -305,6 +318,13 @@ void reshade::d3d9::runtime_d3d9::on_draw_call(D3DPRIMITIVETYPE type, unsigned i
 	if (!_is_good_viewport)
 		return;
 
+	if (_preserve_depth_buffer && _depthstencil_replacement != nullptr)
+	{
+		// ensure that the draw calls are targetted to the depthstencil replacement surface 
+		if(_depthstencil_replacement != depthstencil)
+			_device->SetDepthStencilSurface(_depthstencil_replacement.get());
+	}
+
 	if (depthstencil != nullptr)
 	{
 		// Resolve pointer to original depth stencil
@@ -355,10 +375,6 @@ void reshade::d3d9::runtime_d3d9::on_clear_depthstencil_surface(IDirect3DSurface
 	if (!check_depthstencil_size(desc)) // Ignore unlikely candidates
 		return;
 
-	// remove parasite items
-	if (!_is_good_viewport)
-		return;
-
 	// Check if any draw calls have been registered since the last clear operation
 	if (_current_db_drawcalls > 0 && _current_db_vertices > 0)
 	{
@@ -373,12 +389,12 @@ void reshade::d3d9::runtime_d3d9::on_clear_depthstencil_surface(IDirect3DSurface
 	_current_db_vertices = 0;
 	_current_db_drawcalls = 0;
 
-	if (_depth_buffer_table.empty() || _depth_buffer_table.size() <= _preserve_starting_index)
+	if (_depth_buffer_table.empty() || _depth_buffer_table.size() == _preserve_starting_index)
 		return;
 
-	// If the current depth buffer replacement texture has to be preserved, replace the set surface with the original one, so that the replacement texture will not be cleared
-	_device->SetDepthStencilSurface(_depthstencil.get());
-}
+	// If the current depth buffer replacement texture has to be preserved, replace the set surface with a dummy one, so that the replacement texture will not be cleared
+	_device->SetDepthStencilSurface(nullptr);
+}	
 
 void reshade::d3d9::runtime_d3d9::capture_screenshot(uint8_t *buffer) const
 {
@@ -423,13 +439,26 @@ void reshade::d3d9::runtime_d3d9::capture_screenshot(uint8_t *buffer) const
 
 void reshade::d3d9::runtime_d3d9::on_set_viewport(const D3DVIEWPORT9 *pViewport)
 {
-	D3DSURFACE_DESC desc;
+	D3DSURFACE_DESC desc, depthstencil_desc;
 
 	desc.Width = pViewport->Width;
 	desc.Height = pViewport->Height;
 	desc.MultiSampleType = D3DMULTISAMPLE_NONE;
+	_is_good_viewport = true;
 
-	_is_good_viewport = check_depthstencil_size(desc);
+	if (_preserve_depth_buffer)
+	{
+		// if there is no depthstencil replacement surface, check the viewport with the actual back buffer size
+		if (_depthstencil_replacement == nullptr)
+			_is_good_viewport = check_depthstencil_size(desc);
+		// if there is a depthstencil replacement surface, check the viewport with this one,
+		// in order to remove the parasite depth buffers that have a different size from the correct one
+		else
+		{
+			_depthstencil_replacement->GetDesc(&depthstencil_desc);
+			_is_good_viewport = check_depthstencil_size(desc, depthstencil_desc);
+		}
+	}
 }
 
 bool reshade::d3d9::runtime_d3d9::init_texture(texture &texture)
@@ -1225,19 +1254,6 @@ void reshade::d3d9::runtime_d3d9::draw_debug_menu()
 			}
 		}
 
-		ImGui::Spacing();
-
-		if (ImGui::Checkbox("Disable the depth buffer size restriction", &_disable_depth_buffer_size_restriction))
-		{
-			runtime::save_config();
-
-			// Force depth-stencil replacement 
-			_depthstencil = _default_depthstencil;
-			// Force depth-stencil clearing table recreation
-			_depth_buffer_table.clear();
-			_depth_source_table.clear();
-		}
-
 		if (_preserve_depth_buffer)
 		{
 			ImGui::Spacing();
@@ -1249,20 +1265,6 @@ void reshade::d3d9::runtime_d3d9::draw_debug_menu()
 				modified = true;
 				if (_auto_preserve)
 					_preserve_starting_index = std::numeric_limits<size_t>::max();
-			}
-
-			if (_auto_preserve)
-			{
-				if (ImGui::Checkbox("find best depthstencil based on vertices", &_auto_preserve_on_vertices))
-				{
-					modified = true;
-					_auto_preserve_on_drawcalls = !_auto_preserve_on_vertices;
-				}
-				if (ImGui::Checkbox("find best depthstencil based on drawcalls", &_auto_preserve_on_drawcalls))
-				{
-					modified = true;
-					_auto_preserve_on_vertices = !_auto_preserve_on_drawcalls;
-				}
 			}
 
 			ImGui::Spacing();
@@ -1319,7 +1321,7 @@ void reshade::d3d9::runtime_d3d9::detect_depth_source()
 	if (_preserve_depth_buffer)
 	{
 		// check if we draw calls have been registered since the last cleaning
-		if (_is_good_viewport && _depthstencil_replacement != nullptr && _current_db_drawcalls > 0 && _current_db_vertices > 0)
+		if (_depthstencil_replacement != nullptr && _current_db_drawcalls > 0 && _current_db_vertices > 0)
 		{
 			D3DSURFACE_DESC desc;
 			_depthstencil_replacement->GetDesc(&desc);
@@ -1340,8 +1342,7 @@ void reshade::d3d9::runtime_d3d9::detect_depth_source()
 			for (size_t i = 0; i != _depth_buffer_table.size(); i++)
 			{
 				const auto &it = _depth_buffer_table[i];
-				if (_auto_preserve_on_drawcalls ?
-					it.drawcall_count >= _db_drawcalls : it.vertices_count >= _db_vertices)
+				if (it.vertices_count >= _db_vertices)
 				{
 					_db_vertices = it.vertices_count;
 					_db_drawcalls = it.drawcall_count;
@@ -1410,6 +1411,23 @@ bool reshade::d3d9::runtime_d3d9::check_depthstencil_size(const D3DSURFACE_DESC 
 	{
 		return (desc.Width >= _width * 0.95 && desc.Width <= _width * 1.05)
 			&& (desc.Height >= _height * 0.95 && desc.Height <= _height * 1.05);
+	}
+}
+
+bool reshade::d3d9::runtime_d3d9::check_depthstencil_size(const D3DSURFACE_DESC &desc, const D3DSURFACE_DESC &compared_desc)
+{
+	if (desc.MultiSampleType != D3DMULTISAMPLE_NONE)
+		return false; // MSAA depth buffers are not supported since they would have to be moved into a plain surface before attaching to a shader slot
+
+	if (_disable_depth_buffer_size_restriction)
+	{
+		// Allow depth buffers with greater dimensions than the viewport (e.g. in games like Vanquish)
+		return desc.Width >= compared_desc.Width * 0.95 && desc.Height >= compared_desc.Height * 0.95;
+	}
+	else
+	{
+		return (desc.Width >= compared_desc.Width * 0.95 && desc.Width <= compared_desc.Width * 1.05)
+			&& (desc.Height >= compared_desc.Height * 0.95 && desc.Height <= compared_desc.Height * 1.05);
 	}
 }
 

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -375,10 +375,6 @@ void reshade::d3d9::runtime_d3d9::on_clear_depthstencil_surface(IDirect3DSurface
 	if (!check_depthstencil_size(desc)) // Ignore unlikely candidates
 		return;
 
-	// remove parasite items
-	if (!_is_good_viewport)
-		return;
-
 	// Check if any draw calls have been registered since the last clear operation
 	if (_current_db_drawcalls > 0 && _current_db_vertices > 0)
 	{
@@ -1325,7 +1321,7 @@ void reshade::d3d9::runtime_d3d9::detect_depth_source()
 	if (_preserve_depth_buffer)
 	{
 		// check if we draw calls have been registered since the last cleaning
-		if (_is_good_viewport && _depthstencil_replacement != nullptr && _current_db_drawcalls > 0 && _current_db_vertices > 0)
+		if (_depthstencil_replacement != nullptr && _current_db_drawcalls > 0 && _current_db_vertices > 0)
 		{
 			D3DSURFACE_DESC desc;
 			_depthstencil_replacement->GetDesc(&desc);

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -333,8 +333,6 @@ void reshade::d3d9::runtime_d3d9::on_draw_call(D3DPRIMITIVETYPE type, unsigned i
 			it->second.vertices_count += vertices;
 		}
 	}
-	else
-		depthstencil = _depthstencil;
 
 	if (_preserve_depth_buffer && _depthstencil_replacement != nullptr)
 	{

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -301,6 +301,10 @@ void reshade::d3d9::runtime_d3d9::on_draw_call(D3DPRIMITIVETYPE type, unsigned i
 	com_ptr<IDirect3DSurface9> depthstencil;
 	_device->GetDepthStencilSurface(&depthstencil);
 
+	// remove parasite items
+	if (!_is_good_viewport)
+		return;
+
 	if (depthstencil != nullptr)
 	{
 		// Resolve pointer to original depth stencil
@@ -349,6 +353,10 @@ void reshade::d3d9::runtime_d3d9::on_clear_depthstencil_surface(IDirect3DSurface
 	D3DSURFACE_DESC desc;
 	depthstencil->GetDesc(&desc);
 	if (!check_depthstencil_size(desc)) // Ignore unlikely candidates
+		return;
+
+	// remove parasite items
+	if (!_is_good_viewport)
 		return;
 
 	// Check if any draw calls have been registered since the last clear operation
@@ -411,6 +419,17 @@ void reshade::d3d9::runtime_d3d9::capture_screenshot(uint8_t *buffer) const
 	}
 
 	intermediate->UnlockRect();
+}
+
+void reshade::d3d9::runtime_d3d9::on_set_viewport(const D3DVIEWPORT9 *pViewport)
+{
+	D3DSURFACE_DESC desc;
+
+	desc.Width = pViewport->Width;
+	desc.Height = pViewport->Height;
+	desc.MultiSampleType = D3DMULTISAMPLE_NONE;
+
+	_is_good_viewport = check_depthstencil_size(desc);
 }
 
 bool reshade::d3d9::runtime_d3d9::init_texture(texture &texture)

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -332,7 +332,7 @@ void reshade::d3d9::runtime_d3d9::on_draw_call(D3DPRIMITIVETYPE type, unsigned i
 		if (!_is_good_viewport)
 			return;
 
-		// check that the drawcall is done on the good depthstencil (the one from which the depthstencil_replaceent was created)
+		// check that the drawcall is done on the good depthstencil (the one from which the depthstencil_replacement was created)
 		if (!_is_good_depthstencil)
 			return;
 

--- a/source/d3d9/runtime_d3d9.hpp
+++ b/source/d3d9/runtime_d3d9.hpp
@@ -85,6 +85,7 @@ namespace reshade::d3d9
 		bool _preserve_depth_buffer = false;
 		bool _disable_depth_buffer_size_restriction = false;
 		size_t _preserve_starting_index = 0;
+		bool _init_depthbuffer_detection = true;
 		bool _auto_preserve = true;
 		bool _is_good_viewport = true;
 		bool _is_good_depthstencil = true;

--- a/source/d3d9/runtime_d3d9.hpp
+++ b/source/d3d9/runtime_d3d9.hpp
@@ -87,6 +87,7 @@ namespace reshade::d3d9
 		size_t _preserve_starting_index = 0;
 		bool _auto_preserve = true;
 		bool _is_good_viewport = true;
+		bool _is_good_depthstencil = true;
 		unsigned int _db_vertices = 0;
 		unsigned int _db_drawcalls = 0;
 		unsigned int _current_db_vertices = 0;

--- a/source/d3d9/runtime_d3d9.hpp
+++ b/source/d3d9/runtime_d3d9.hpp
@@ -28,6 +28,7 @@ namespace reshade::d3d9
 		void on_set_depthstencil_surface(IDirect3DSurface9 *&depthstencil);
 		void on_get_depthstencil_surface(IDirect3DSurface9 *&depthstencil);
 		void on_clear_depthstencil_surface(IDirect3DSurface9 *depthstencil);
+		void on_set_viewport(const D3DVIEWPORT9 *pViewport);
 
 		void capture_screenshot(uint8_t *buffer) const override;
 
@@ -86,6 +87,7 @@ namespace reshade::d3d9
 		bool _auto_preserve = true;
 		bool _auto_preserve_on_drawcalls = false;
 		bool _auto_preserve_on_vertices = true;
+		bool _is_good_viewport = true;
 		unsigned int _db_vertices = 0;
 		unsigned int _db_drawcalls = 0;
 		unsigned int _current_db_vertices = 0;

--- a/source/d3d9/runtime_d3d9.hpp
+++ b/source/d3d9/runtime_d3d9.hpp
@@ -57,6 +57,7 @@ namespace reshade::d3d9
 		void render_technique(technique &technique) override;
 
 		bool check_depthstencil_size(const D3DSURFACE_DESC &desc);
+		bool check_depthstencil_size(const D3DSURFACE_DESC &desc, const D3DSURFACE_DESC &compared_desc);
 
 #if RESHADE_GUI
 		bool init_imgui_resources();
@@ -85,8 +86,6 @@ namespace reshade::d3d9
 		bool _disable_depth_buffer_size_restriction = false;
 		size_t _preserve_starting_index = 0;
 		bool _auto_preserve = true;
-		bool _auto_preserve_on_drawcalls = false;
-		bool _auto_preserve_on_vertices = true;
 		bool _is_good_viewport = true;
 		unsigned int _db_vertices = 0;
 		unsigned int _db_drawcalls = 0;


### PR DESCRIPTION
Check that the drawcall is done on the good depthstencil (the one from which the depthstencil_replaceent was created)