### PR TITLE
Add prev/next buttons for preset explorer

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2179,7 +2179,13 @@ void reshade::runtime::draw_preset_explorer()
 			}
 
 			if (not_found)
-				condition = condition::pass;
+				if (preset_paths.size() > 0)
+					if (condition == condition::backward)
+						_preset_working_path = preset_paths[preset_paths.size() - 1];
+					else
+						_preset_working_path = preset_paths[0];
+				else
+					condition = condition::pass;
 			else
 				_current_preset_path = std::filesystem::absolute(_preset_working_path);
 		}

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2025,45 +2025,45 @@ void reshade::runtime::draw_preset_explorer()
 	condition condition = condition::pass;
 
 	if (ImGui::ButtonEx("<", ImVec2(button_size, 0), ImGuiButtonFlags_NoNavFocus))
-		condition = condition::backward, _preset_working_path = _current_preset_path;
+		condition = condition::backward, _current_browse_path = _current_preset_path;
 
 	if (ImGui::SameLine(0, button_spacing);
 		ImGui::ButtonEx(">", ImVec2(button_size, 0), ImGuiButtonFlags_NoNavFocus))
-		condition = condition::forward, _preset_working_path = _current_preset_path;
+		condition = condition::forward, _current_browse_path = _current_preset_path;
 
 	ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
 	if (ImGui::SameLine(0, button_spacing);
 		ImGui::ButtonEx(_current_preset_path.stem().u8string().c_str(), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0), ImGuiButtonFlags_NoNavFocus))
 		if (ImGui::OpenPopup("##explore"), _imgui_context->IO.KeyCtrl)
-			_preset_path_input_mode = true;
+			_browse_path_is_input_mode = true;
 	ImGui::PopStyleVar();
 
 	if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_NoNavFocus))
-		condition = condition::popup_add, _preset_working_path = _current_preset_path.parent_path();
+		condition = condition::popup_add, _current_browse_path = _current_preset_path.parent_path();
 
 	ImGui::SetNextWindowPos(cursor_pos - _imgui_context->Style.WindowPadding);
 	const bool is_explore_open = ImGui::BeginPopup("##explore");
 	if (is_explore_open)
 	{
 		if (ImGui::ButtonEx("<", ImVec2(button_size, 0), ImGuiButtonFlags_NoNavFocus))
-			condition = condition::backward, _preset_working_path = _current_preset_path;
+			condition = condition::backward, _current_browse_path = _current_preset_path;
 
 		if (ImGui::SameLine(0, button_spacing);
 			ImGui::ButtonEx(">", ImVec2(button_size, 0), ImGuiButtonFlags_NoNavFocus))
-			condition = condition::forward, _preset_working_path = _current_preset_path;
+			condition = condition::forward, _current_browse_path = _current_preset_path;
 
 		ImGui::SameLine(0, button_spacing);
-		if (_preset_path_input_mode)
+		if (_browse_path_is_input_mode)
 		{
 			char buf[_MAX_PATH]{};
-			_preset_working_path.u8string().copy(buf, sizeof(buf) - 1);
+			_current_browse_path.u8string().copy(buf, sizeof(buf) - 1);
 
 			const bool is_edited = ImGui::InputTextEx("##path", buf, sizeof(buf), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0), ImGuiInputTextFlags_None);
 
 			if (ImGui::IsWindowAppearing())
 				ImGui::SetKeyboardFocusHere();
 			else if (!ImGui::IsItemActive())
-				_preset_path_input_mode = false;
+				_browse_path_is_input_mode = false;
 
 			if (const bool is_returned = ImGui::IsKeyPressedMap(ImGuiKey_Enter); is_edited || is_returned)
 			{
@@ -2071,11 +2071,11 @@ void reshade::runtime::draw_preset_explorer()
 				std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / input_preset_path, ec).type();
 
 				if (is_edited && ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
-					_preset_working_path = std::move(input_preset_path);
+					_current_browse_path = std::move(input_preset_path);
 
 				if (is_returned)
 				{
-					if (_preset_working_path.empty())
+					if (_current_browse_path.empty())
 						condition = condition::cancel;
 					else
 					{
@@ -2085,17 +2085,17 @@ void reshade::runtime::draw_preset_explorer()
 							condition = condition::popup_add;
 						else
 						{
-							if (_preset_working_path.has_filename())
-								if (const std::wstring extension(_preset_working_path.extension()); extension != L".ini" && extension != L".txt")
-									_preset_working_path += L".ini",
-									file_type = std::filesystem::status(reshade_container_path / _preset_working_path, ec).type();
+							if (_current_browse_path.has_filename())
+								if (const std::wstring extension(_current_browse_path.extension()); extension != L".ini" && extension != L".txt")
+									_current_browse_path += L".ini",
+									file_type = std::filesystem::status(reshade_container_path / _current_browse_path, ec).type();
 
 							if (ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
 								condition = condition::pass;
 							else if (file_type == std::filesystem::file_type::directory)
 								condition = condition::popup_add;
 							else if (file_type == std::filesystem::file_type::not_found)
-								if (_preset_working_path.has_filename())
+								if (_current_browse_path.has_filename())
 									condition = condition::create;
 								else
 									condition = condition::popup_add;
@@ -2111,12 +2111,12 @@ void reshade::runtime::draw_preset_explorer()
 			ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
 			if (ImGui::ButtonEx(_current_preset_path.stem().u8string().c_str(), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0), ImGuiButtonFlags_NoNavFocus))
 				if (_imgui_context->IO.KeyCtrl)
-					ImGui::ActivateItem(ImGui::GetID("##path")), _preset_path_input_mode = true;
+					ImGui::ActivateItem(ImGui::GetID("##path")), _browse_path_is_input_mode = true;
 				else
 					condition = condition::cancel;
 			else if (ImGui::IsKeyPressedMap(ImGuiKey_Enter))
-				if (_preset_working_path.has_filename())
-					if (const std::wstring extension(_preset_working_path.extension()); extension == L".ini" || extension == L".txt")
+				if (_current_browse_path.has_filename())
+					if (const std::wstring extension(_current_browse_path.extension()); extension == L".ini" || extension == L".txt")
 						if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _current_preset_path, ec).type();
 							ec.value() != 0x7b && file_type != std::filesystem::file_type::directory) // 0x7b: ERROR_INVALID_NAME
 							if (file_type == std::filesystem::file_type::not_found)
@@ -2129,7 +2129,7 @@ void reshade::runtime::draw_preset_explorer()
 
 	if (is_explore_open || condition == condition::backward || condition == condition::forward)
 	{
-		std::filesystem::path preset_container_path = std::filesystem::absolute(reshade_container_path / _preset_working_path);
+		std::filesystem::path preset_container_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
 		if (!std::filesystem::is_directory(preset_container_path, ec) && preset_container_path.has_filename())
 			preset_container_path = preset_container_path.parent_path();
 
@@ -2153,23 +2153,23 @@ void reshade::runtime::draw_preset_explorer()
 				const std::filesystem::path reshade_preset_path = reshade_container_path / _current_preset_path;
 				if (auto it = std::find_if(preset_paths.begin(), preset_paths.end(), [&ec, &reshade_preset_path](const std::filesystem::directory_entry &entry) { return std::filesystem::equivalent(entry, reshade_container_path / reshade_preset_path, ec); }); it == preset_paths.end())
 					if (condition == condition::backward)
-						_current_preset_path = _preset_working_path = preset_paths.back();
+						_current_preset_path = _current_browse_path = preset_paths.back();
 					else
-						_current_preset_path = _preset_working_path = preset_paths.front();
+						_current_preset_path = _current_browse_path = preset_paths.front();
 				else
 					if (condition == condition::backward)
-						_current_preset_path = _preset_working_path = it == preset_paths.begin() ? preset_paths.back() : *--it;
+						_current_preset_path = _current_browse_path = it == preset_paths.begin() ? preset_paths.back() : *--it;
 					else
-						_current_preset_path = _preset_working_path = it == preset_paths.end() - 1 ? preset_paths.front() : *++it;
+						_current_preset_path = _current_browse_path = it == preset_paths.end() - 1 ? preset_paths.front() : *++it;
 			}
 		}
 
 		if (is_explore_open)
 		{
 			if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_NoNavFocus))
-				if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _preset_working_path, ec).type(); ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
+				if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _current_browse_path, ec).type(); ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
 					if (condition = condition::popup_add; file_type == std::filesystem::file_type::not_found || file_type != std::filesystem::file_type::directory)
-						_preset_working_path = _preset_working_path.parent_path();
+						_current_browse_path = _current_browse_path.parent_path();
 
 			if (ImGui::IsWindowAppearing() || condition == condition::backward || condition == condition::forward)
 				ImGui::SetNextWindowFocus();
@@ -2178,15 +2178,15 @@ void reshade::runtime::draw_preset_explorer()
 			{
 				if (ImGui::Selectable(".."))
 				{
-					for (_preset_working_path = std::filesystem::absolute(reshade_container_path / _preset_working_path);
-						!std::filesystem::is_directory(_preset_working_path, ec) && _preset_working_path.parent_path() != _preset_working_path;)
-						_preset_working_path = _preset_working_path.parent_path();
-					_preset_working_path = _preset_working_path.parent_path();
+					for (_current_browse_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
+						!std::filesystem::is_directory(_current_browse_path, ec) && _current_browse_path.parent_path() != _current_browse_path;)
+						_current_browse_path = _current_browse_path.parent_path();
+					_current_browse_path = _current_browse_path.parent_path();
 
-					if (std::filesystem::equivalent(reshade_container_path, _preset_working_path))
-						_preset_working_path = L".";
-					else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), _preset_working_path.begin()))
-						_preset_working_path = _preset_working_path.lexically_proximate(reshade_container_path);
+					if (std::filesystem::equivalent(reshade_container_path, _current_browse_path))
+						_current_browse_path = L".";
+					else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), _current_browse_path.begin()))
+						_current_browse_path = _current_browse_path.lexically_proximate(reshade_container_path);
 				}
 
 				std::vector<std::filesystem::directory_entry> preset_paths;
@@ -2194,11 +2194,11 @@ void reshade::runtime::draw_preset_explorer()
 					if (const std::filesystem::file_type file_type = entry.status(ec).type(); file_type == std::filesystem::file_type::directory)
 						if (ImGui::Selectable((entry.path().filename().u8string() + '\\').c_str()))
 							if (std::filesystem::equivalent(reshade_container_path, entry))
-								_preset_working_path = L".";
+								_current_browse_path = L".";
 							else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), entry.path().begin()))
-								_preset_working_path = entry.path().lexically_proximate(reshade_container_path);
+								_current_browse_path = entry.path().lexically_proximate(reshade_container_path);
 							else
-								_preset_working_path = entry;
+								_current_browse_path = entry;
 						else {}
 					else if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
 						preset_paths.push_back(entry);
@@ -2206,14 +2206,14 @@ void reshade::runtime::draw_preset_explorer()
 				const std::filesystem::path current_preset_path = reshade_container_path / _current_preset_path;
 				for (const auto &entry : preset_paths)
 				{
-					const bool is_current_preset = entry == current_preset_path;
+					const bool is_current_preset = std::filesystem::equivalent(entry, current_preset_path, ec);
 
 					if (ImGui::Selectable(entry.path().filename().u8string().c_str(), static_cast<bool>(is_current_preset)))
-						condition = condition::select, _preset_working_path = entry.path().lexically_proximate(reshade_container_path);
+						condition = condition::select, _current_browse_path = entry.path().lexically_proximate(reshade_container_path);
 
 					if (is_current_preset)
-						if (_preset_selectable_item_is_covered && !ImGui::IsWindowAppearing())
-							_preset_selectable_item_is_covered = false, ImGui::SetScrollHereY();
+						if (_current_preset_is_covered && !ImGui::IsWindowAppearing())
+							_current_preset_is_covered = false, ImGui::SetScrollHereY();
 						else if (condition == condition::backward || condition == condition::forward)
 							ImGui::SetScrollHereY();
 				}
@@ -2223,7 +2223,7 @@ void reshade::runtime::draw_preset_explorer()
 	}
 
 	if (condition == condition::select)
-		if (const reshade::ini_file preset(reshade_container_path / _preset_working_path); !preset.has("", "TechniqueSorting"))
+		if (const reshade::ini_file preset(reshade_container_path / _current_browse_path); !preset.has("", "TechniqueSorting"))
 			condition = condition::pass;
 
 	if (condition == condition::popup_add)
@@ -2244,19 +2244,19 @@ void reshade::runtime::draw_preset_explorer()
 			{
 				if (const std::wstring extension(input_preset_path.extension()); extension != L".ini" && extension != L".txt")
 					input_preset_path += L".ini";
-				if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _preset_working_path / input_preset_path, ec).type(); ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
+				if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _current_browse_path / input_preset_path, ec).type(); ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
 					condition = condition::pass;
 				else if (file_type == std::filesystem::file_type::directory)
 					condition = condition::pass;
 				else if (file_type == std::filesystem::file_type::not_found)
 					condition = condition::create;
-				else if (const reshade::ini_file preset(reshade_container_path / _preset_working_path / input_preset_path); preset.has("", "TechniqueSorting"))
+				else if (const reshade::ini_file preset(reshade_container_path / _current_browse_path / input_preset_path); preset.has("", "TechniqueSorting"))
 					condition = condition::select;
 				else
 					condition = condition::pass;
 
 				if (condition != condition::pass)
-					_preset_working_path = _preset_working_path / input_preset_path;
+					_current_browse_path /= input_preset_path;
 			}
 		}
 
@@ -2282,8 +2282,8 @@ void reshade::runtime::draw_preset_explorer()
 
 	if (is_explore_open)
 		ImGui::EndPopup();
-	else if (!_preset_selectable_item_is_covered)
-		_preset_selectable_item_is_covered = true;
+	else if (!_current_preset_is_covered)
+		_current_preset_is_covered = true;
 }
 
 #endif

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2023,11 +2023,11 @@ void reshade::runtime::draw_preset_explorer()
 	enum class condition { pass, select, popup_add, create, backward, forward, cancel };
 	condition condition = condition::pass;
 
-	if (ImGui::ButtonEx("<", ImVec2(button_size, 0)))
+	if (ImGui::ButtonEx("<", ImVec2(button_size, 0), ImGuiButtonFlags_NoNavFocus))
 		_preset_working_path = _current_preset_path, condition = condition::backward;
 
 	if (ImGui::SameLine(0, button_spacing);
-		ImGui::ButtonEx(">", ImVec2(button_size, 0)))
+		ImGui::ButtonEx(">", ImVec2(button_size, 0), ImGuiButtonFlags_NoNavFocus))
 		_preset_working_path = _current_preset_path, condition = condition::forward;
 
 	ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2178,14 +2178,14 @@ void reshade::runtime::draw_preset_explorer()
 				break;
 			}
 
-			if (not_found)
-				if (preset_paths.size() > 0)
-					if (condition == condition::backward)
-						_preset_working_path = preset_paths[preset_paths.size() - 1];
-					else
-						_preset_working_path = preset_paths[0];
+			if (not_found && preset_paths.size() > 0)
+				if (not_found = false, condition == condition::backward)
+					_preset_working_path = preset_paths[preset_paths.size() - 1];
 				else
-					condition = condition::pass;
+					_preset_working_path = preset_paths[0];
+
+			if (not_found)
+				condition = condition::pass;
 			else
 				_current_preset_path = std::filesystem::absolute(_preset_working_path);
 		}

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2131,6 +2131,9 @@ void reshade::runtime::draw_preset_explorer()
 
 	if (is_explore_open || condition == condition::backward || condition == condition::forward)
 	{
+		if (_preset_working_path.is_relative())
+			_preset_working_path = g_reshade_dll_path.parent_path() / _preset_working_path;
+
 		std::filesystem::path directory_path;
 		if (std::filesystem::is_directory(_preset_working_path, ec) || !_preset_working_path.has_parent_path())
 			directory_path = _preset_working_path;

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2196,10 +2196,15 @@ void reshade::runtime::draw_preset_explorer()
 			for (const auto &entry : preset_files)
 			{
 				const bool is_current_preset_path = entry == _current_preset_path;
+
 				if (bool selected = is_current_preset_path;  ImGui::Selectable(entry.path().filename().u8string().c_str(), &selected))
 					_file_selection_path = entry, condition = condition::select;
-				if (is_current_preset_path && (condition == condition::backward || condition == condition::forward || (_preset_selectable_item_is_covered && !ImGui::IsWindowAppearing())))
-					ImGui::SetScrollHereY(), _preset_selectable_item_is_covered = false;
+
+				if (is_current_preset_path)
+					if (_preset_selectable_item_is_covered && !ImGui::IsWindowAppearing())
+						_preset_selectable_item_is_covered = false, ImGui::SetScrollHereY();
+					else if (condition == condition::backward || condition == condition::forward)
+						ImGui::SetScrollHereY();
 			}
 		}
 		ImGui::EndChild();

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2105,9 +2105,8 @@ void reshade::runtime::draw_preset_explorer()
 				condition = condition::add;
 			else
 			{
-				if (const std::string extension = _file_selection_path.extension().u8string();
-					extension != ".ini" && extension != ".txt")
-					_file_selection_path = _file_selection_path.wstring() + L".ini";
+				if (const std::wstring extension(_file_selection_path.extension()); extension != L".ini" && extension != L".txt")
+					_file_selection_path /= L".ini";
 				if (file_type == std::filesystem::file_type::not_found)
 					condition = condition::create;
 				else
@@ -2127,7 +2126,7 @@ void reshade::runtime::draw_preset_explorer()
 		std::vector<std::filesystem::directory_entry> preset_paths;
 		for (const auto &entry : std::filesystem::directory_iterator(directory_path, std::filesystem::directory_options::skip_permission_denied, ec))
 			if (!entry.is_directory())
-				if (const std::string extension = entry.path().extension().u8string(); extension == ".ini" || extension == ".txt")
+				if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
 					if (const reshade::ini_file preset(entry); preset.has("", "TechniqueSorting"))
 						preset_paths.push_back(entry);
 
@@ -2191,7 +2190,7 @@ void reshade::runtime::draw_preset_explorer()
 				}
 				else
 				{
-					if (const std::string extension = entry.path().extension().u8string(); extension == ".ini" || extension == ".txt")
+					if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
 						preset_files.push_back(entry);
 				}
 			}
@@ -2233,8 +2232,8 @@ void reshade::runtime::draw_preset_explorer()
 			if (std::filesystem::path relative_path = std::filesystem::u8path(filename);
 				relative_path.has_filename())
 			{
-				if (!relative_path.has_extension())
-					relative_path = relative_path.wstring() + L".ini";
+				if (const std::wstring extension(relative_path.extension()); extension != L".ini" && extension != L".txt")
+					relative_path /= L".ini";
 				std::filesystem::path file_selection_path = _file_selection_path / relative_path;
 
 				if (std::filesystem::file_type file_type = std::filesystem::status(file_selection_path, ec).type();

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2195,7 +2195,7 @@ void reshade::runtime::draw_preset_explorer()
 			{
 				const bool is_current_preset_path = entry == _current_preset_path;
 				if (bool selected = is_current_preset_path;  ImGui::Selectable(entry.path().filename().u8string().c_str(), &selected))
-					_file_selection_path = entry, condition = is_current_preset_path ? condition::none : condition::select;
+					_file_selection_path = entry, condition = condition::select;
 				if (is_current_preset_path && _preset_selectable_item_is_covered && !ImGui::IsWindowAppearing())
 					_preset_selectable_item_is_covered = false, ImGui::SetScrollHereY();
 			}

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2149,38 +2149,32 @@ void reshade::runtime::draw_preset_explorer()
 						if (const reshade::ini_file preset(entry); preset.has("", "TechniqueSorting"))
 							preset_paths.push_back(entry);
 
-			bool not_found = true;
-			const std::filesystem::path current_preset_path = std::filesystem::canonical(g_reshade_dll_path.parent_path() / _current_preset_path, ec);
-			for (size_t i = 0; preset_paths.size() > i; ++i)
+			if (preset_paths.size() > 0)
 			{
-				if (preset_paths[i] == current_preset_path)
-					not_found = false;
-				else
-					continue;
-
-				if (condition == condition::backward)
-					if (i == 0)
+				const std::filesystem::path current_preset_path = std::filesystem::weakly_canonical(g_reshade_dll_path.parent_path() / _current_preset_path, ec);
+				bool not_found = true;
+				for (size_t i = 0; preset_paths.size() > i && not_found; ++i)
+					if (preset_paths[i] == current_preset_path)
+						if (not_found = false, condition == condition::backward)
+							if (i == 0)
+								_preset_working_path = preset_paths[preset_paths.size() - 1];
+							else
+								_preset_working_path = preset_paths[i - 1];
+						else
+							if (i == preset_paths.size() - 1)
+								_preset_working_path = preset_paths[0];
+							else
+								_preset_working_path = preset_paths[i + 1];
+				if (not_found)
+					if (condition == condition::backward)
 						_preset_working_path = preset_paths[preset_paths.size() - 1];
 					else
-						_preset_working_path = preset_paths[i - 1];
-				else
-					if (i == preset_paths.size() - 1)
 						_preset_working_path = preset_paths[0];
-					else
-						_preset_working_path = preset_paths[i + 1];
-				break;
-			}
 
-			if (not_found && preset_paths.size() > 0)
-				if (not_found = false, condition == condition::backward)
-					_preset_working_path = preset_paths[preset_paths.size() - 1];
-				else
-					_preset_working_path = preset_paths[0];
-
-			if (not_found)
-				condition = condition::pass;
-			else
 				_current_preset_path = _preset_working_path;
+			}
+			else
+				condition = condition::pass;
 		}
 
 		if (is_explore_open)

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2249,11 +2249,12 @@ void reshade::runtime::draw_preset_explorer()
 					input_relative_preset_path += L".ini";
 				const std::filesystem::path input_absolute_preset_path = _preset_working_path / input_relative_preset_path;
 
-				if (const std::filesystem::file_type file_type = std::filesystem::status(input_absolute_preset_path, ec).type();
-					file_type == std::filesystem::file_type::not_found)
-					condition = condition::create;
+				if (const std::filesystem::file_type file_type = std::filesystem::status(input_absolute_preset_path, ec).type(); ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
+					condition = condition::pass;
 				else if (file_type == std::filesystem::file_type::directory)
 					condition = condition::pass;
+				else if (file_type == std::filesystem::file_type::not_found)
+					condition = condition::create;
 				else if (const reshade::ini_file preset(input_absolute_preset_path); preset.has("", "TechniqueSorting"))
 					condition = condition::select;
 				else

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2013,6 +2013,7 @@ void reshade::runtime::draw_overlay_technique_editor()
 
 bool _preset_path_input_mode = false;
 bool _preset_path_input_mode_changed = false;
+bool _preset_selectable_item_is_covered = true;
 void reshade::runtime::draw_preset_explorer()
 {
 	const ImVec2 cursor_pos = ImGui::GetCursorScreenPos();
@@ -2201,6 +2202,8 @@ void reshade::runtime::draw_preset_explorer()
 				const bool is_current_preset_path = entry == _current_preset_path;
 				if (bool selected = is_current_preset_path;  ImGui::Selectable(entry.path().filename().u8string().c_str(), &selected))
 					_file_selection_path = entry, condition = is_current_preset_path ? condition::none : condition::select;
+				if (is_current_preset_path && _preset_selectable_item_is_covered && !ImGui::IsWindowAppearing())
+					_preset_selectable_item_is_covered = false, ImGui::SetScrollHereY();
 			}
 		}
 		ImGui::EndChild();
@@ -2265,6 +2268,8 @@ void reshade::runtime::draw_preset_explorer()
 
 	if (is_explore_open)
 		ImGui::EndPopup();
+	else if (!_preset_selectable_item_is_covered)
+		_preset_selectable_item_is_covered = true;
 }
 
 #endif

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2242,9 +2242,11 @@ void reshade::runtime::draw_preset_explorer()
 		char filename[_MAX_PATH]{};
 		ImGui::InputText("Name", filename, sizeof(filename));
 
-		if (filename[0] != '\0' && ImGui::IsKeyPressedMap(ImGuiKey_Enter))
+		if (ImGui::IsKeyPressedMap(ImGuiKey_Enter))
 		{
-			if (std::filesystem::path input_relative_preset_path = std::filesystem::u8path(filename);
+			if (filename[0] == '\0')
+				condition = condition::cancel, _preset_working_path = _current_preset_path;
+			else if (std::filesystem::path input_relative_preset_path = std::filesystem::u8path(filename);
 				input_relative_preset_path.has_filename())
 			{
 				if (const std::wstring extension(input_relative_preset_path.extension()); extension != L".ini" && extension != L".txt")

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2103,7 +2103,7 @@ void reshade::runtime::draw_preset_explorer()
 				else
 					condition = condition::cancel;
 			else if (ImGui::IsKeyPressedMap(ImGuiKey_Enter))
-				condition = condition::cancel;
+				condition = condition::select; // Strongly trust the preset path passed by user-edited configuration
 			ImGui::PopStyleVar();
 		}
 

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2178,25 +2178,15 @@ void reshade::runtime::draw_preset_explorer()
 			{
 				if (ImGui::Selectable(".."))
 				{
-					if (!_preset_working_path.has_parent_path())
-						_preset_working_path = std::filesystem::absolute(reshade_container_path / _preset_working_path, ec);
-					while (!std::filesystem::is_directory(reshade_container_path / _preset_working_path, ec))
-					{
-						if (!_preset_working_path.has_parent_path())
-							_preset_working_path = std::filesystem::absolute(reshade_container_path / _preset_working_path, ec);
-						if (_preset_working_path.parent_path() != _preset_working_path)
-							_preset_working_path = _preset_working_path.parent_path();
-						else break;
-					}
+					for (_preset_working_path = std::filesystem::absolute(reshade_container_path / _preset_working_path);
+						!std::filesystem::is_directory(_preset_working_path, ec) && _preset_working_path.parent_path() != _preset_working_path;)
+						_preset_working_path = _preset_working_path.parent_path();
 					_preset_working_path = _preset_working_path.parent_path();
 
-					if (const std::filesystem::path preset_absolute_path = std::filesystem::absolute(reshade_container_path / _preset_working_path, ec);
-						std::filesystem::equivalent(reshade_container_path, preset_absolute_path))
+					if (std::filesystem::equivalent(reshade_container_path, _preset_working_path))
 						_preset_working_path = L".";
-					else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), preset_absolute_path.begin()))
+					else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), _preset_working_path.begin()))
 						_preset_working_path = _preset_working_path.lexically_proximate(reshade_container_path);
-					else
-						_preset_working_path = preset_absolute_path;
 				}
 
 				std::vector<std::filesystem::directory_entry> preset_paths;

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2071,7 +2071,7 @@ void reshade::runtime::draw_preset_explorer()
 			if (const bool is_returned = ImGui::IsKeyPressedMap(ImGuiKey_Enter);
 				is_edited || is_returned)
 			{
-				const std::filesystem::path input_preset_path = std::filesystem::u8path(buf);
+				std::filesystem::path input_preset_path = std::filesystem::u8path(buf);
 				std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / input_preset_path, ec).type();
 
 				if (is_edited && ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2062,6 +2062,7 @@ void reshade::runtime::draw_preset_explorer()
 		{
 			ImGui::PushItemWidth(root_window_width - (button_spacing + button_size) * 3);
 			ImGui::InputText("##path", buf, sizeof(buf));
+			_file_selection_path = std::filesystem::u8path(buf);
 			if (!ImGui::IsWindowAppearing())
 			{
 				if (_preset_path_input_mode_changed)
@@ -2075,8 +2076,6 @@ void reshade::runtime::draw_preset_explorer()
 				}
 			}
 			ImGui::PopItemWidth();
-
-			_file_selection_path = std::filesystem::u8path(buf);
 		}
 		else
 		{

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2130,7 +2130,7 @@ void reshade::runtime::draw_preset_explorer()
 	if (is_explore_open || condition == condition::backward || condition == condition::forward)
 	{
 		std::filesystem::path preset_container_path = std::filesystem::absolute(reshade_container_path / _preset_working_path);
-		if (!std::filesystem::is_directory(preset_container_path, ec) && preset_container_path.has_parent_path())
+		if (!std::filesystem::is_directory(preset_container_path, ec) && preset_container_path.has_filename())
 			preset_container_path = preset_container_path.parent_path();
 
 		std::vector<std::filesystem::directory_entry> preset_container;
@@ -2183,7 +2183,7 @@ void reshade::runtime::draw_preset_explorer()
 					while (!std::filesystem::is_directory(reshade_container_path / _preset_working_path, ec))
 					{
 						if (!_preset_working_path.has_parent_path())
-							_preset_working_path = std::filesystem::weakly_canonical(reshade_container_path / _preset_working_path, ec);
+							_preset_working_path = std::filesystem::absolute(reshade_container_path / _preset_working_path, ec);
 						if (_preset_working_path.parent_path() != _preset_working_path)
 							_preset_working_path = _preset_working_path.parent_path();
 						else break;

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2135,6 +2135,7 @@ void reshade::runtime::draw_preset_explorer()
 				not_found = false;
 			else
 				continue;
+
 			if (condition == condition::backward)
 				if (i == 0)
 					_file_selection_path = preset_paths[preset_paths.size() - 1];
@@ -2145,7 +2146,6 @@ void reshade::runtime::draw_preset_explorer()
 					_file_selection_path = preset_paths[0];
 				else
 					_file_selection_path = preset_paths[i + 1];
-
 			break;
 		}
 

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2190,7 +2190,7 @@ void reshade::runtime::draw_preset_explorer()
 				{
 					const bool is_current_preset = entry == _current_preset_path;
 
-					if (bool selected = is_current_preset;  ImGui::Selectable(entry.path().filename().u8string().c_str(), &selected))
+					if (ImGui::Selectable(entry.path().filename().u8string().c_str(), static_cast<bool>(is_current_preset)))
 						_file_selection_path = entry, condition = condition::select;
 
 					if (is_current_preset)

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2274,8 +2274,10 @@ void reshade::runtime::draw_preset_explorer()
 	{
 		if (condition != condition::cancel)
 		{
+			if (condition != condition::backward && condition != condition::forward)
+				_current_preset_path = std::filesystem::absolute(_preset_working_path);
+
 			_show_splash = true;
-			_current_preset_path = std::filesystem::absolute(_preset_working_path);
 
 			save_config();
 			load_current_preset();

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2103,7 +2103,16 @@ void reshade::runtime::draw_preset_explorer()
 				else
 					condition = condition::cancel;
 			else if (ImGui::IsKeyPressedMap(ImGuiKey_Enter))
-				condition = condition::select; // Strongly trust the preset path passed by user-edited configuration
+			{
+				if (const std::filesystem::file_type file_type = std::filesystem::status(_current_preset_path, ec).type(); ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
+					condition = condition::pass, assert(false); // ASSERT(). No recover
+				else if (file_type == std::filesystem::file_type::directory)
+					condition = condition::pass; // Wrong user use case
+				else if (file_type == std::filesystem::file_type::not_found)
+					condition = condition::create;
+				else
+					condition = condition::select;
+			}
 			ImGui::PopStyleVar();
 		}
 

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2083,7 +2083,7 @@ void reshade::runtime::draw_preset_explorer()
 					else
 					{
 						if (_preset_working_path.is_relative())
-							_preset_working_path = g_reshade_dll_path.parent_path() / _preset_working_path;
+							_preset_working_path = _current_preset_path.parent_path() / _preset_working_path;
 
 						if (ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
 							condition = condition::pass, _preset_working_path = _current_preset_path;
@@ -2140,7 +2140,7 @@ void reshade::runtime::draw_preset_explorer()
 	{
 		std::filesystem::path directory_path = _preset_working_path;
 		if (directory_path.is_relative())
-			directory_path = g_reshade_dll_path.parent_path() / directory_path;
+			directory_path = _current_preset_path.parent_path() / directory_path;
 		if (!std::filesystem::is_directory(directory_path, ec) && directory_path.has_parent_path())
 			directory_path = directory_path.parent_path();
 

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2038,8 +2038,8 @@ void reshade::runtime::draw_preset_explorer()
 		_file_selection_path = _current_preset_path.parent_path(), condition = condition::add;
 
 	ImGui::SetNextWindowPos(cursor_pos - _imgui_context->Style.WindowPadding);
-	const bool popup_visible = ImGui::BeginPopup("##explore");
-	if (popup_visible)
+	const bool is_explore_open = ImGui::BeginPopup("##explore");
+	if (is_explore_open)
 	{
 		if (ImGui::ButtonEx("<", ImVec2(button_size, 0)))
 			condition = condition::backward;
@@ -2124,7 +2124,7 @@ void reshade::runtime::draw_preset_explorer()
 			condition = condition::none;
 	}
 
-	if (popup_visible)
+	if (is_explore_open)
 	{
 		std::filesystem::path directory_path;
 		if (std::filesystem::is_directory(_file_selection_path) || !_file_selection_path.has_parent_path())
@@ -2223,11 +2223,11 @@ void reshade::runtime::draw_preset_explorer()
 		save_config();
 		load_current_preset();
 
-		if (popup_visible && condition != condition::backward && condition != condition::forward)
+		if (is_explore_open && condition != condition::backward && condition != condition::forward)
 			ImGui::CloseCurrentPopup();
 	}
 
-	if (popup_visible)
+	if (is_explore_open)
 		ImGui::EndPopup();
 }
 

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2071,7 +2071,7 @@ void reshade::runtime::draw_preset_explorer()
 				is_edited || is_returned)
 			{
 				const std::filesystem::path input_preset_path = std::filesystem::u8path(buf);
-				std::filesystem::file_type file_type = std::filesystem::status(input_preset_path, ec).type();
+				std::filesystem::file_type file_type = std::filesystem::status(g_reshade_dll_path.parent_path() / input_preset_path, ec).type();
 
 				if (is_edited && ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
 					_preset_working_path = std::move(input_preset_path);
@@ -2119,8 +2119,11 @@ void reshade::runtime::draw_preset_explorer()
 				if (_preset_working_path.has_filename())
 					if (const std::wstring extension(_preset_working_path.extension()); extension == L".ini" || extension == L".txt")
 						if (const std::filesystem::file_type file_type = std::filesystem::status(g_reshade_dll_path.parent_path() / _current_preset_path, ec).type();
-							ec.value() != 0x7b && file_type != std::filesystem::file_type::directory && file_type != std::filesystem::file_type::not_found) // 0x7b: ERROR_INVALID_NAME
-							condition = condition::select;
+							ec.value() != 0x7b && file_type != std::filesystem::file_type::directory) // 0x7b: ERROR_INVALID_NAME
+							if (file_type == std::filesystem::file_type::not_found)
+								condition = condition::create;
+							else
+								condition = condition::select;
 			ImGui::PopStyleVar();
 		}
 	}

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2070,7 +2070,7 @@ void reshade::runtime::draw_preset_explorer()
 			if (const bool is_returned = ImGui::IsKeyPressedMap(ImGuiKey_Enter);
 				is_edited || is_returned)
 			{
-				const std::filesystem::path input_preset_path = g_reshade_dll_path.parent_path() / std::filesystem::u8path(buf);
+				const std::filesystem::path input_preset_path = std::filesystem::u8path(buf);
 				std::filesystem::file_type file_type = std::filesystem::status(input_preset_path, ec).type();
 
 				if (is_edited && ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
@@ -2116,19 +2116,11 @@ void reshade::runtime::draw_preset_explorer()
 				else
 					condition = condition::cancel;
 			else if (ImGui::IsKeyPressedMap(ImGuiKey_Enter))
-			{
-				if (const std::filesystem::file_type file_type = std::filesystem::status(g_reshade_dll_path.parent_path() / _preset_working_path, ec).type(); ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
-					condition = condition::pass, assert(false); // ASSERT(). No recover
-				else if (file_type == std::filesystem::file_type::directory)
-					condition = condition::pass; // Wrong user use case
-				else if (file_type == std::filesystem::file_type::not_found)
-					if (_preset_working_path.has_filename())
-						condition = condition::create;
-					else
-						condition = condition::popup_add;
-				else
-					condition = condition::select;
-			}
+				if (_preset_working_path.has_filename())
+					if (const std::wstring extension(_preset_working_path.extension()); extension == L".ini" || extension == L".txt")
+						if (const std::filesystem::file_type file_type = std::filesystem::status(g_reshade_dll_path.parent_path() / _current_preset_path, ec).type();
+							ec.value() != 0x7b && file_type != std::filesystem::file_type::directory && file_type != std::filesystem::file_type::not_found) // 0x7b: ERROR_INVALID_NAME
+							condition = condition::select;
 			ImGui::PopStyleVar();
 		}
 	}

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2113,7 +2113,7 @@ void reshade::runtime::draw_preset_explorer()
 				else
 					condition = condition::cancel;
 			else if (ImGui::IsKeyPressedMap(ImGuiKey_Enter))
-				condition = condition::reload;
+				condition = condition::reload, _current_browse_path = _current_preset_path;
 			ImGui::PopStyleVar();
 		}
 	}

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2060,8 +2060,6 @@ void reshade::runtime::draw_preset_explorer()
 		ImGui::SameLine(0, button_spacing);
 		if (_preset_path_input_mode || ImGui::IsPopupOpen("##name"))
 		{
-			if (ImGui::IsPopupOpen("##name"))
-				auto a = 0;
 			ImGui::PushItemWidth(root_window_width - (button_spacing + button_size) * 3);
 			ImGui::InputText("##path", buf, sizeof(buf));
 			if (!ImGui::IsWindowAppearing())

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2091,8 +2091,9 @@ void reshade::runtime::draw_preset_explorer()
 							condition = condition::popup_add;
 						else
 						{
-							if (const std::wstring extension(_preset_working_path.extension()); extension != L".ini" && extension != L".txt")
-								_preset_working_path += L".ini";
+							if (_preset_working_path.has_filename())
+								if (const std::wstring extension(_preset_working_path.extension()); extension != L".ini" && extension != L".txt")
+									_preset_working_path += L".ini";
 							if (const std::filesystem::file_type file_type = std::filesystem::status(_preset_working_path, ec).type(); ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
 								condition = condition::pass, _preset_working_path = _current_preset_path;
 							else if (file_type == std::filesystem::file_type::directory)
@@ -2248,11 +2249,9 @@ void reshade::runtime::draw_preset_explorer()
 		char filename[_MAX_PATH]{};
 		ImGui::InputText("Name", filename, sizeof(filename));
 
-		if (!ImGui::IsWindowAppearing() && ImGui::IsKeyPressedMap(ImGuiKey_Enter))
+		if (ImGui::IsKeyPressedMap(ImGuiKey_Enter))
 		{
-			if (filename[0] == '\0')
-				condition = condition::cancel, _preset_working_path = _current_preset_path;
-			else if (std::filesystem::path input_relative_preset_path = std::filesystem::u8path(filename);
+			if (std::filesystem::path input_relative_preset_path = std::filesystem::u8path(filename);
 				input_relative_preset_path.has_filename())
 			{
 				if (const std::wstring extension(input_relative_preset_path.extension()); extension != L".ini" && extension != L".txt")

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2011,9 +2011,6 @@ void reshade::runtime::draw_overlay_technique_editor()
 	}
 }
 
-bool _preset_path_input_mode = false;
-bool _preset_path_input_mode_changed = false;
-bool _preset_selectable_item_is_covered = true;
 void reshade::runtime::draw_preset_explorer()
 {
 	const ImVec2 cursor_pos = ImGui::GetCursorScreenPos();

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2090,8 +2090,10 @@ void reshade::runtime::draw_preset_explorer()
 						{
 							if (_preset_working_path.has_filename())
 								if (const std::wstring extension(_preset_working_path.extension()); extension != L".ini" && extension != L".txt")
-									_preset_working_path += L".ini";
-							if (file_type = std::filesystem::status(g_reshade_dll_path.parent_path() / _preset_working_path, ec).type(); ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
+									_preset_working_path += L".ini",
+									file_type = std::filesystem::status(g_reshade_dll_path.parent_path() / _preset_working_path, ec).type();
+
+							if (ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
 								condition = condition::pass, _preset_working_path = _current_preset_path;
 							else if (file_type == std::filesystem::file_type::directory)
 								condition = condition::popup_add;
@@ -2201,7 +2203,7 @@ void reshade::runtime::draw_preset_explorer()
 					if (const std::filesystem::path reshade_container_path = g_reshade_dll_path.parent_path(); reshade_container_path == preset_canonical_path)
 						_preset_working_path = L".";
 					else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), preset_canonical_path.begin()))
-						_preset_working_path = std::filesystem::relative(preset_canonical_path, g_reshade_dll_path.parent_path(), ec);
+						_preset_working_path = std::filesystem::proximate(preset_canonical_path, g_reshade_dll_path.parent_path(), ec);
 					else
 						_preset_working_path = preset_canonical_path;
 				}
@@ -2217,7 +2219,7 @@ void reshade::runtime::draw_preset_explorer()
 							if (const std::filesystem::path reshade_container_path = g_reshade_dll_path.parent_path(); reshade_container_path == preset_canonical_path)
 								_preset_working_path = L".";
 							else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), preset_canonical_path.begin()))
-								_preset_working_path = std::filesystem::relative(preset_canonical_path, g_reshade_dll_path.parent_path(), ec);
+								_preset_working_path = std::filesystem::proximate(preset_canonical_path, g_reshade_dll_path.parent_path(), ec);
 							else
 								_preset_working_path = preset_canonical_path;
 						}
@@ -2304,7 +2306,7 @@ void reshade::runtime::draw_preset_explorer()
 			const std::filesystem::path preset_canonical_path = std::filesystem::weakly_canonical(g_reshade_dll_path.parent_path() / _preset_working_path, ec);
 			if (const std::filesystem::path reshade_container_path = g_reshade_dll_path.parent_path();
 				std::equal(reshade_container_path.begin(), reshade_container_path.end(), preset_canonical_path.begin()))
-				_current_preset_path = std::filesystem::relative(preset_canonical_path, g_reshade_dll_path.parent_path(), ec);
+				_current_preset_path = std::filesystem::proximate(preset_canonical_path, g_reshade_dll_path.parent_path(), ec);
 			else
 				_current_preset_path = preset_canonical_path;
 

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2225,22 +2225,22 @@ void reshade::runtime::draw_preset_explorer()
 
 		if (filename[0] != '\0' && ImGui::IsKeyPressedMap(ImGuiKey_Enter))
 		{
-			if (std::filesystem::path relative_path = std::filesystem::u8path(filename);
-				relative_path.has_filename())
+			if (std::filesystem::path input_relative_preset_path = std::filesystem::u8path(filename);
+				input_relative_preset_path.has_filename())
 			{
-				if (const std::wstring extension(relative_path.extension()); extension != L".ini" && extension != L".txt")
-					relative_path += L".ini";
-				std::filesystem::path file_selection_path = _file_selection_path / relative_path;
+				if (const std::wstring extension(input_relative_preset_path.extension()); extension != L".ini" && extension != L".txt")
+					input_relative_preset_path += L".ini";
+				std::filesystem::path input_absolute_preset_path = _file_selection_path / input_relative_preset_path;
 
-				if (std::filesystem::file_type file_type = std::filesystem::status(file_selection_path, ec).type();
+				if (std::filesystem::file_type file_type = std::filesystem::status(input_absolute_preset_path, ec).type();
 					file_type == std::filesystem::file_type::not_found)
 					condition = condition::select;
 				else if (file_type != std::filesystem::file_type::directory)
-					if (const reshade::ini_file preset(file_selection_path); preset.has("", "TechniqueSorting"))
+					if (const reshade::ini_file preset(input_absolute_preset_path); preset.has("", "TechniqueSorting"))
 						condition = condition::select;
 
 				if (condition == condition::select)
-					_file_selection_path = std::move(file_selection_path);
+					_file_selection_path = std::move(input_absolute_preset_path);
 			}
 		}
 

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2035,7 +2035,7 @@ void reshade::runtime::draw_preset_explorer()
 		ImGui::ButtonEx(_current_preset_path.stem().u8string().c_str(), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0)))
 	{
 		if (_imgui_context->IO.KeyCtrl)
-			_preset_path_input_mode = true, _preset_path_input_mode_changed = true;
+			_preset_path_input_mode = true;
 		_file_selection_path = _current_preset_path, ImGui::OpenPopup("##explore");
 	}
 	ImGui::PopStyleVar();
@@ -2060,25 +2060,20 @@ void reshade::runtime::draw_preset_explorer()
 			_file_selection_path.u8string().copy(buf, sizeof(buf) - 1);
 
 		ImGui::SameLine(0, button_spacing);
-		if (_preset_path_input_mode || ImGui::IsPopupOpen("##name"))
+		if (_preset_path_input_mode)
 		{
 			ImGui::InputTextEx("##path", buf, sizeof(buf), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0), ImGuiInputTextFlags_None);
 
 			std::filesystem::path file_selection_path = std::filesystem::u8path(buf);
-			if (!ImGui::IsItemEdited() || (std::filesystem::status(file_selection_path, ec), ec.value() != 0x7b)) // 0x7b: ERROR_INVALID_NAME
+			if (!ImGui::IsItemEdited() || (static_cast<void>(std::filesystem::status(file_selection_path, ec)), ec.value() != 0x7b)) // 0x7b: ERROR_INVALID_NAME
 				_file_selection_path = std::move(file_selection_path);
 
 			if (!ImGui::IsWindowAppearing())
 			{
-				if (_preset_path_input_mode_changed)
-				{
-					if (_preset_path_input_mode_changed = false, !ImGui::IsPopupOpen("##name"))
-						ImGui::SetKeyboardFocusHere();
-				}
-				else if (!ImGui::IsItemActive())
-				{
-					_preset_path_input_mode_changed = true, _preset_path_input_mode = false;
-				}
+				if (_imgui_context->IO.KeyCtrl && !ImGui::IsPopupOpen("##name"))
+					ImGui::SetKeyboardFocusHere();
+				else if (_preset_path_input_mode && !ImGui::IsItemActive())
+					_preset_path_input_mode = false;
 			}
 		}
 		else
@@ -2086,7 +2081,7 @@ void reshade::runtime::draw_preset_explorer()
 			ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
 			if (ImGui::ButtonEx(_current_preset_path.stem().u8string().c_str(), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0)))
 				if (_imgui_context->IO.KeyCtrl)
-					_preset_path_input_mode = true, _preset_path_input_mode_changed = true;
+					_preset_path_input_mode = true;
 				else
 					condition = condition::cancel;
 			ImGui::PopStyleVar();

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2151,6 +2151,8 @@ void reshade::runtime::draw_preset_explorer()
 
 		if (not_found)
 			condition = condition::none;
+		else
+			_current_preset_path = std::filesystem::absolute(_file_selection_path);
 	}
 
 	if (is_explore_open)
@@ -2196,8 +2198,8 @@ void reshade::runtime::draw_preset_explorer()
 				const bool is_current_preset_path = entry == _current_preset_path;
 				if (bool selected = is_current_preset_path;  ImGui::Selectable(entry.path().filename().u8string().c_str(), &selected))
 					_file_selection_path = entry, condition = condition::select;
-				if (is_current_preset_path && _preset_selectable_item_is_covered && !ImGui::IsWindowAppearing())
-					_preset_selectable_item_is_covered = false, ImGui::SetScrollHereY();
+				if (is_current_preset_path && (condition == condition::backward || condition == condition::forward || (_preset_selectable_item_is_covered && !ImGui::IsWindowAppearing())))
+					ImGui::SetScrollHereY(), _preset_selectable_item_is_covered = false;
 			}
 		}
 		ImGui::EndChild();

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2060,14 +2060,14 @@ void reshade::runtime::draw_preset_explorer()
 			char buf[_MAX_PATH]{};
 			_preset_working_path.u8string().copy(buf, sizeof(buf) - 1);
 
-			ImGui::InputTextEx("##path", buf, sizeof(buf), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0), ImGuiInputTextFlags_None);
+			const bool is_edited = ImGui::InputTextEx("##path", buf, sizeof(buf), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0), ImGuiInputTextFlags_None);
 
 			if (ImGui::IsWindowAppearing())
 				ImGui::SetKeyboardFocusHere();
 			else if (!ImGui::IsItemActive())
 				_preset_path_input_mode = false;
 
-			if (const bool is_edited = ImGui::IsItemEdited(), is_returned = ImGui::IsKeyPressedMap(ImGuiKey_Enter);
+			if (const bool is_returned = ImGui::IsKeyPressedMap(ImGuiKey_Enter);
 				is_edited || is_returned)
 			{
 				std::filesystem::path input_preset_path = std::filesystem::u8path(buf);

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2048,11 +2048,11 @@ void reshade::runtime::draw_preset_explorer()
 	if (is_explore_open)
 	{
 		if (ImGui::ButtonEx("<", ImVec2(button_size, 0), ImGuiButtonFlags_NoNavFocus))
-			condition = condition::backward;
+			condition = condition::backward, _preset_working_path = _current_preset_path;
 
 		if (ImGui::SameLine(0, button_spacing);
 			ImGui::ButtonEx(">", ImVec2(button_size, 0), ImGuiButtonFlags_NoNavFocus))
-			condition = condition::forward;
+			condition = condition::forward, _preset_working_path = _current_preset_path;
 
 		ImGui::SameLine(0, button_spacing);
 		if (_preset_path_input_mode)
@@ -2274,10 +2274,8 @@ void reshade::runtime::draw_preset_explorer()
 	{
 		if (condition != condition::cancel)
 		{
-			if (condition != condition::backward && condition != condition::forward)
-				_current_preset_path = std::filesystem::absolute(_preset_working_path);
-
 			_show_splash = true;
+			_current_preset_path = std::filesystem::absolute(_preset_working_path);
 
 			save_config();
 			load_current_preset();

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2032,7 +2032,7 @@ void reshade::runtime::draw_preset_explorer()
 
 	ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
 	if (ImGui::SameLine(0, button_spacing);
-		ImGui::ButtonEx(_current_preset_path.stem().u8string().c_str(), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0)))
+		ImGui::ButtonEx(_current_preset_path.stem().u8string().c_str(), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0), ImGuiButtonFlags_NoNavFocus))
 	{
 		if (_imgui_context->IO.KeyCtrl)
 			_preset_path_input_mode = true;
@@ -2040,18 +2040,18 @@ void reshade::runtime::draw_preset_explorer()
 	}
 	ImGui::PopStyleVar();
 
-	if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick))
+	if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_NoNavFocus))
 		_file_selection_path = _current_preset_path.parent_path(), condition = condition::popup_add;
 
 	ImGui::SetNextWindowPos(cursor_pos - _imgui_context->Style.WindowPadding);
 	const bool is_explore_open = ImGui::BeginPopup("##explore");
 	if (is_explore_open)
 	{
-		if (ImGui::ButtonEx("<", ImVec2(button_size, 0)))
+		if (ImGui::ButtonEx("<", ImVec2(button_size, 0), ImGuiButtonFlags_NoNavFocus))
 			condition = condition::backward;
 
 		if (ImGui::SameLine(0, button_spacing);
-			ImGui::ButtonEx(">", ImVec2(button_size, 0)))
+			ImGui::ButtonEx(">", ImVec2(button_size, 0), ImGuiButtonFlags_NoNavFocus))
 			condition = condition::forward;
 
 		char buf[_MAX_PATH]{};
@@ -2064,24 +2064,21 @@ void reshade::runtime::draw_preset_explorer()
 		{
 			ImGui::InputTextEx("##path", buf, sizeof(buf), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0), ImGuiInputTextFlags_None);
 
+			if (ImGui::IsWindowAppearing())
+				ImGui::SetKeyboardFocusHere();
+			else if (!ImGui::IsItemActive())
+				_preset_path_input_mode = false;
+
 			std::filesystem::path file_selection_path = std::filesystem::u8path(buf);
 			if (!ImGui::IsItemEdited() || (static_cast<void>(std::filesystem::status(file_selection_path, ec)), ec.value() != 0x7b)) // 0x7b: ERROR_INVALID_NAME
 				_file_selection_path = std::move(file_selection_path);
-
-			if (!ImGui::IsWindowAppearing())
-			{
-				if (_imgui_context->IO.KeyCtrl && !ImGui::IsPopupOpen("##name"))
-					ImGui::SetKeyboardFocusHere();
-				else if (_preset_path_input_mode && !ImGui::IsItemActive())
-					_preset_path_input_mode = false;
-			}
 		}
 		else
 		{
 			ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
-			if (ImGui::ButtonEx(_current_preset_path.stem().u8string().c_str(), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0)))
+			if (ImGui::ButtonEx(_current_preset_path.stem().u8string().c_str(), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0), ImGuiButtonFlags_NoNavFocus))
 				if (_imgui_context->IO.KeyCtrl)
-					_preset_path_input_mode = true;
+					ImGui::ActivateItem(ImGui::GetID("##path")), _preset_path_input_mode = true;
 				else
 					condition = condition::cancel;
 			ImGui::PopStyleVar();
@@ -2160,7 +2157,7 @@ void reshade::runtime::draw_preset_explorer()
 
 		if (is_explore_open)
 		{
-			if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick))
+			if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_NoNavFocus))
 				_file_selection_path = directory_path, condition = condition::popup_add;
 
 			if (ImGui::IsWindowAppearing() || condition == condition::backward || condition == condition::forward)

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2069,13 +2069,13 @@ void reshade::runtime::draw_preset_explorer()
 			else if (!ImGui::IsItemActive())
 				_preset_path_input_mode = false;
 
-			std::filesystem::path input_preset_path = std::filesystem::u8path(buf);
+			const std::filesystem::path input_preset_path = std::filesystem::u8path(buf);
 			if (!ImGui::IsItemEdited() || (static_cast<void>(std::filesystem::status(input_preset_path, ec)), ec.value() != 0x7b)) // 0x7b: ERROR_INVALID_NAME
 				_file_selection_path = std::move(input_preset_path);
 
 			if (ImGui::IsKeyPressedMap(ImGuiKey_Enter))
 			{
-				if (std::filesystem::file_type file_type = std::filesystem::status(input_preset_path, ec).type(); ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
+				if (const std::filesystem::file_type file_type = std::filesystem::status(input_preset_path, ec).type(); ec.value() == 0x7b) // 0x7b: ERROR_INVALID_NAME
 					condition = condition::pass, _file_selection_path = _current_preset_path;
 				else if (file_type == std::filesystem::file_type::directory)
 					condition = condition::popup_add;
@@ -2230,9 +2230,9 @@ void reshade::runtime::draw_preset_explorer()
 			{
 				if (const std::wstring extension(input_relative_preset_path.extension()); extension != L".ini" && extension != L".txt")
 					input_relative_preset_path += L".ini";
-				std::filesystem::path input_absolute_preset_path = _file_selection_path / input_relative_preset_path;
+				const std::filesystem::path input_absolute_preset_path = _file_selection_path / input_relative_preset_path;
 
-				if (std::filesystem::file_type file_type = std::filesystem::status(input_absolute_preset_path, ec).type();
+				if (const std::filesystem::file_type file_type = std::filesystem::status(input_absolute_preset_path, ec).type();
 					file_type == std::filesystem::file_type::not_found)
 					condition = condition::select;
 				else if (file_type != std::filesystem::file_type::directory)

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2021,8 +2021,6 @@ void reshade::runtime::draw_preset_explorer()
 	enum class condition { none, select, add, create, backward, forward };
 	condition condition = condition::none;
 
-	bool popup_explore = false;
-
 	if (ImGui::ButtonEx("<", ImVec2(button_size, 0)))
 		_file_selection_path = _current_preset_path, condition = condition::backward;
 
@@ -2033,7 +2031,7 @@ void reshade::runtime::draw_preset_explorer()
 	ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
 	if (ImGui::SameLine(0, button_spacing);
 		ImGui::ButtonEx(_current_preset_path.stem().u8string().c_str(), ImVec2(root_window_width - (button_spacing + button_size) * 3, 0)))
-		_file_selection_path = _current_preset_path, ImGui::OpenPopup("##explore"), popup_explore = true;
+		_file_selection_path = _current_preset_path, ImGui::OpenPopup("##explore");
 	ImGui::PopStyleVar();
 
 	if (ImGui::SameLine(0, button_spacing); ImGui::Button("+", ImVec2(button_size, 0)))
@@ -2137,7 +2135,7 @@ void reshade::runtime::draw_preset_explorer()
 		if (ImGui::SameLine(0, button_spacing); ImGui::Button("+", ImVec2(button_size, 0)))
 			_file_selection_path = directory_path, condition = condition::add;
 
-		if (popup_explore || condition == condition::backward || condition == condition::forward)
+		if (ImGui::IsWindowAppearing() || condition == condition::backward || condition == condition::forward)
 			ImGui::SetNextWindowFocus();
 
 		if (ImGui::BeginChild("##paths", ImVec2(0, 300), true))

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -843,8 +843,8 @@ void reshade::runtime::load_config()
 	std::error_code ec;
 
 	// Create a default preset file if none exists yet
-	if (_current_preset_path.empty() || (std::filesystem::status(_current_preset_path, ec), ec.value() == 0x7b)) // 0x7b: ERROR_INVALID_NAME
-		_current_preset_path = g_reshade_dll_path.parent_path() / "DefaultPreset.ini";
+	if (_current_preset_path.empty() || (std::filesystem::status(g_reshade_dll_path.parent_path() / _current_preset_path, ec), ec.value() == 0x7b)) // 0x7b: ERROR_INVALID_NAME
+		_current_preset_path = "DefaultPreset.ini";
 	else
 		_current_preset_path = _current_preset_path;
 

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1245,9 +1245,9 @@ void reshade::runtime::set_current_preset(std::filesystem::path path)
 	enum class path_state { invalid, valid };
 	path_state path_state = path_state::invalid;
 
-	if (!path.empty())
+	if (path.has_filename())
 		if (const std::wstring extension(path.extension()); extension == L".ini" || extension == L".txt")
-			if (!std::filesystem::exists(path, ec))
+			if (!std::filesystem::exists(reshade_container_path / path, ec))
 				path_state = path_state::valid;
 			else if (const reshade::ini_file preset(reshade_container_path / path); preset.has("", "TechniqueSorting"))
 				path_state = path_state::valid;

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -840,8 +840,10 @@ void reshade::runtime::load_config()
 	config.get("GENERAL", "ScreenshotIncludePreset", _screenshot_include_preset);
 	config.get("GENERAL", "NoReloadOnInit", _no_reload_on_init);
 
+	std::error_code ec;
+
 	// Create a default preset file if none exists yet
-	if (_current_preset_path.empty())
+	if (_current_preset_path.empty() || (std::filesystem::status(_current_preset_path, ec), ec.value() == 0x7b)) // 0x7b: ERROR_INVALID_NAME
 		_current_preset_path = g_reshade_dll_path.parent_path() / "DefaultPreset.ini";
 
 	for (const auto &callback : _load_config_callables)

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1242,7 +1242,6 @@ void reshade::runtime::set_current_preset(std::filesystem::path path)
 	std::error_code ec;
 	std::filesystem::path reshade_container_path = g_reshade_dll_path.parent_path();
 
-	// Create a default preset file if none exists yet
 	enum class path_state { invalid, valid };
 	path_state path_state = path_state::invalid;
 
@@ -1251,10 +1250,10 @@ void reshade::runtime::set_current_preset(std::filesystem::path path)
 			if (const reshade::ini_file preset(reshade_container_path / path); preset.has("", "TechniqueSorting"))
 				path_state = path_state::valid;
 
+	// Select a default preset file if none exists yet or not own
 	if (path_state == path_state::invalid)
 		path = "DefaultPreset.ini";
-
-	if (const std::filesystem::path preset_canonical_path = std::filesystem::weakly_canonical(reshade_container_path / path, ec);
+	else if (const std::filesystem::path preset_canonical_path = std::filesystem::weakly_canonical(reshade_container_path / path, ec);
 		std::equal(reshade_container_path.begin(), reshade_container_path.end(), preset_canonical_path.begin()))
 		path = preset_canonical_path.lexically_proximate(reshade_container_path);
 	else if (const std::filesystem::path preset_absolute_path = std::filesystem::absolute(reshade_container_path / path, ec);

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -843,10 +843,16 @@ void reshade::runtime::load_config()
 	std::error_code ec;
 
 	// Create a default preset file if none exists yet
-	if (_current_preset_path.empty() || (std::filesystem::status(g_reshade_dll_path.parent_path() / _current_preset_path, ec), ec.value() == 0x7b)) // 0x7b: ERROR_INVALID_NAME
+	enum class path_state { invalid, valid };
+	path_state path_state = path_state::invalid;
+
+	if (!_current_preset_path.empty())
+		if (const std::wstring extension(_current_preset_path.extension()); extension == L".ini" || extension == L".txt")
+			if (const reshade::ini_file preset(g_reshade_dll_path.parent_path() / _current_preset_path); preset.has("", "TechniqueSorting"))
+				path_state = path_state::valid;
+
+	if (path_state == path_state::invalid)
 		_current_preset_path = "DefaultPreset.ini";
-	else
-		_current_preset_path = _current_preset_path;
 
 	for (const auto &callback : _load_config_callables)
 		callback(config);

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -845,6 +845,8 @@ void reshade::runtime::load_config()
 	// Create a default preset file if none exists yet
 	if (_current_preset_path.empty() || (std::filesystem::status(_current_preset_path, ec), ec.value() == 0x7b)) // 0x7b: ERROR_INVALID_NAME
 		_current_preset_path = g_reshade_dll_path.parent_path() / "DefaultPreset.ini";
+	else
+		_current_preset_path = std::filesystem::absolute(_current_preset_path);
 
 	for (const auto &callback : _load_config_callables)
 		callback(config);

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -854,6 +854,13 @@ void reshade::runtime::load_config()
 	if (path_state == path_state::invalid)
 		_current_preset_path = "DefaultPreset.ini";
 
+	if (const std::filesystem::path reshade_container_path = g_reshade_dll_path.parent_path(),
+		preset_canonical_path = std::filesystem::weakly_canonical(reshade_container_path / _current_preset_path, ec);
+		std::equal(reshade_container_path.begin(), reshade_container_path.end(), preset_canonical_path.begin()))
+		_current_preset_path = std::filesystem::proximate(preset_canonical_path, reshade_container_path, ec);
+	else
+		_current_preset_path = preset_canonical_path;
+
 	for (const auto &callback : _load_config_callables)
 		callback(config);
 }

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -289,7 +289,7 @@ void reshade::runtime::load_effect(const std::filesystem::path &path, size_t &ou
 	// Fill all specialization constants with values from the current preset
 	if (_performance_mode && !_current_preset_path.empty() && effect.compile_sucess)
 	{
-		const ini_file preset(_current_preset_path);
+		const ini_file preset(g_reshade_dll_path.parent_path() / _current_preset_path);
 		const std::string section(path.filename().u8string());
 
 		for (reshadefx::uniform_info &constant : effect.module.spec_constants)
@@ -451,7 +451,7 @@ void reshade::runtime::load_effects()
 	if (!_current_preset_path.empty())
 	{
 		_preset_preprocessor_definitions.clear();
-		const ini_file preset(_current_preset_path);
+		const ini_file preset(g_reshade_dll_path.parent_path() / _current_preset_path);
 		preset.get("", "PreprocessorDefinitions", _preset_preprocessor_definitions);
 	}
 

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1235,7 +1235,7 @@ void reshade::runtime::reset_uniform_value(uniform &variable)
 
 void reshade::runtime::set_current_preset()
 {
-	set_current_preset(_preset_working_path);
+	set_current_preset(_current_browse_path);
 }
 void reshade::runtime::set_current_preset(std::filesystem::path path)
 {
@@ -1247,7 +1247,9 @@ void reshade::runtime::set_current_preset(std::filesystem::path path)
 
 	if (!path.empty())
 		if (const std::wstring extension(path.extension()); extension == L".ini" || extension == L".txt")
-			if (const reshade::ini_file preset(reshade_container_path / path); preset.has("", "TechniqueSorting"))
+			if (!std::filesystem::exists(path, ec))
+				path_state = path_state::valid;
+			else if (const reshade::ini_file preset(reshade_container_path / path); preset.has("", "TechniqueSorting"))
 				path_state = path_state::valid;
 
 	// Select a default preset file if none exists yet or not own
@@ -1262,6 +1264,6 @@ void reshade::runtime::set_current_preset(std::filesystem::path path)
 	else
 		path = preset_canonical_path;
 
-	_preset_working_path = path;
+	_current_browse_path = path;
 	_current_preset_path = reshade_container_path / path;
 }

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1254,12 +1254,12 @@ void reshade::runtime::set_current_preset(std::filesystem::path path)
 	if (path_state == path_state::invalid)
 		path = "DefaultPreset.ini";
 
-	if (const std::filesystem::path preset_absolute_path = std::filesystem::absolute(reshade_container_path / path, ec);
-		std::equal(reshade_container_path.begin(), reshade_container_path.end(), preset_absolute_path.begin()))
-		path = preset_absolute_path.lexically_proximate(reshade_container_path);
-	else if (const std::filesystem::path preset_canonical_path = std::filesystem::weakly_canonical(reshade_container_path / path, ec);
+	if (const std::filesystem::path preset_canonical_path = std::filesystem::weakly_canonical(reshade_container_path / path, ec);
 		std::equal(reshade_container_path.begin(), reshade_container_path.end(), preset_canonical_path.begin()))
 		path = preset_canonical_path.lexically_proximate(reshade_container_path);
+	else if (const std::filesystem::path preset_absolute_path = std::filesystem::absolute(reshade_container_path / path, ec);
+		std::equal(reshade_container_path.begin(), reshade_container_path.end(), preset_absolute_path.begin()))
+		path = preset_absolute_path.lexically_proximate(reshade_container_path);
 	else
 		path = preset_canonical_path;
 

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -846,7 +846,7 @@ void reshade::runtime::load_config()
 	if (_current_preset_path.empty() || (std::filesystem::status(_current_preset_path, ec), ec.value() == 0x7b)) // 0x7b: ERROR_INVALID_NAME
 		_current_preset_path = g_reshade_dll_path.parent_path() / "DefaultPreset.ini";
 	else
-		_current_preset_path = std::filesystem::absolute(_current_preset_path);
+		_current_preset_path = _current_preset_path;
 
 	for (const auto &callback : _load_config_callables)
 		callback(config);
@@ -879,7 +879,7 @@ void reshade::runtime::save_config(const std::filesystem::path &path) const
 
 void reshade::runtime::load_preset(const std::filesystem::path &path)
 {
-	const ini_file preset(path);
+	const ini_file preset(g_reshade_dll_path.parent_path() / path);
 
 	std::vector<std::string> technique_list;
 	preset.get("", "Techniques", technique_list);
@@ -892,7 +892,7 @@ void reshade::runtime::load_preset(const std::filesystem::path &path)
 	if (_reload_remaining_effects != 0 && // ... unless this is the 'load_current_preset' call in 'update_and_render_effects'
 		(_performance_mode || preset_preprocessor_definitions != _preset_preprocessor_definitions))
 	{
-		assert(path == _current_preset_path);
+		assert(g_reshade_dll_path.parent_path() / path == g_reshade_dll_path.parent_path() / _current_preset_path);
 		_preset_preprocessor_definitions = preset_preprocessor_definitions;
 		load_effects();
 		return; // Preset values are loaded in 'update_and_render_effects' during effect loading
@@ -953,7 +953,7 @@ void reshade::runtime::load_current_preset()
 }
 void reshade::runtime::save_preset(const std::filesystem::path &path) const
 {
-	ini_file preset(path);
+	ini_file preset(g_reshade_dll_path.parent_path() / path);
 
 	std::vector<size_t> effect_list;
 	std::vector<std::string> technique_list;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -360,9 +360,9 @@ namespace reshade
 		imgui_code_editor _editor;
 
 		// used by preset explorer
-		bool _preset_path_input_mode = false;
-		bool _preset_selectable_item_is_covered = true;
-		std::filesystem::path _preset_working_path;
+		bool _browse_path_is_input_mode = false;
+		bool _current_preset_is_covered = true;
+		std::filesystem::path _current_browse_path;
 #endif
 	};
 }

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -358,7 +358,6 @@ namespace reshade
 
 		// used by preset explorer
 		bool _preset_path_input_mode = false;
-		bool _preset_path_input_mode_changed = false;
 		bool _preset_selectable_item_is_covered = true;
 #endif
 	};

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -359,6 +359,7 @@ namespace reshade
 		// used by preset explorer
 		bool _preset_path_input_mode = false;
 		bool _preset_selectable_item_is_covered = true;
+		std::filesystem::path _preset_working_path;
 #endif
 	};
 }

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -255,6 +255,9 @@ namespace reshade
 		void get_uniform_value(const uniform &variable, uint8_t *data, size_t size) const;
 		void set_uniform_value(uniform &variable, const uint8_t *data, size_t size);
 
+		void set_current_preset();
+		void set_current_preset(std::filesystem::path path);
+
 		bool _needs_update = false;
 		unsigned long _latest_version[3] = {};
 		std::shared_ptr<class input> _input;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -355,6 +355,11 @@ namespace reshade
 		char _effect_filter_buffer[64] = {};
 		std::filesystem::path _file_selection_path;
 		imgui_code_editor _editor;
+
+		// used by preset explorer
+		bool _preset_path_input_mode = false;
+		bool _preset_path_input_mode_changed = false;
+		bool _preset_selectable_item_is_covered = true;
 #endif
 	};
 }


### PR DESCRIPTION
This proposal is reimplement of #100

This request contains
* Add prev/next button
* Change contant of preset path to stem
* Highlight current preset in selectable items ~and can not select it~

![preset_explorer_prevnext](https://user-images.githubusercontent.com/42232001/56856988-002bce00-69a2-11e9-8312-2c1603de3e6c.gif)
