### PR TITLE
Fix delaying of depth detection

### DIFF
--- a/source/d3d11/draw_call_tracker.cpp
+++ b/source/d3d11/draw_call_tracker.cpp
@@ -234,9 +234,9 @@ namespace reshade::d3d11
 		return best_snapshot;
 	}
 
-	void draw_call_tracker::keep_cleared_depth_textures(bool reversed)
+	void draw_call_tracker::keep_cleared_depth_textures(bool inverted)
 	{
-		if (reversed)
+		if (inverted)
 		{
 			auto it = std::find_if(_cleared_depth_textures.rbegin(), _cleared_depth_textures.rend(), [](const std::pair<UINT, depth_texture_save_info> &w) { return w.second.cleared; }).base();
 			if (it != _cleared_depth_textures.begin())
@@ -260,13 +260,13 @@ namespace reshade::d3d11
 		}
 	}
 
-	ID3D11Texture2D *draw_call_tracker::find_best_cleared_depth_buffer_texture(UINT clear_index, bool reversed)
+	ID3D11Texture2D *draw_call_tracker::find_best_cleared_depth_buffer_texture(UINT clear_index, bool inverted)
 	{
 		// Function that selects the best cleared depth texture according to the clearing number defined in the configuration settings
 		ID3D11Texture2D *best_match = nullptr;
 
 		// Ensure to work only on the depth textures retrieved before the last depth stencil clearance
-		keep_cleared_depth_textures(reversed);
+		keep_cleared_depth_textures(inverted);
 
 		for (const auto &it : _cleared_depth_textures)
 		{

--- a/source/d3d11/draw_call_tracker.cpp
+++ b/source/d3d11/draw_call_tracker.cpp
@@ -238,9 +238,9 @@ namespace reshade::d3d11
 	{
 		if (inverted)
 		{
-			auto it = std::find_if(_cleared_depth_textures.rbegin(), _cleared_depth_textures.rend(), [](const std::pair<UINT, depth_texture_save_info> &w) { return w.second.cleared; }).base();
-			if (it != _cleared_depth_textures.begin())
-				_cleared_depth_textures.erase(_cleared_depth_textures.begin(), it--);
+			const auto it = std::find_if(_cleared_depth_textures.rbegin(), _cleared_depth_textures.rend(), [](const std::pair<UINT, depth_texture_save_info> &w) { return w.second.cleared; });
+			if (it != _cleared_depth_textures.rend())
+				_cleared_depth_textures.erase(_cleared_depth_textures.begin(), --it.base());
 		}
 		else
 		{

--- a/source/d3d11/draw_call_tracker.hpp
+++ b/source/d3d11/draw_call_tracker.hpp
@@ -52,10 +52,10 @@ namespace reshade::d3d11
 		void track_rendertargets(int format_index, ID3D11DepthStencilView *depthstencil, UINT num_views, ID3D11RenderTargetView *const *views);
 		void track_depth_texture(int format_index, UINT index, com_ptr<ID3D11Texture2D> src_texture, com_ptr<ID3D11DepthStencilView> src_depthstencil, com_ptr<ID3D11Texture2D> dest_texture, bool cleared);
 
-		void keep_cleared_depth_textures(bool reversed);
+		void keep_cleared_depth_textures(bool inverted);
 
 		intermediate_snapshot_info find_best_snapshot(UINT width, UINT height);
-		ID3D11Texture2D *find_best_cleared_depth_buffer_texture(UINT clear_index, bool reversed);
+		ID3D11Texture2D *find_best_cleared_depth_buffer_texture(UINT clear_index, bool inverted);
 #endif
 
 	private:

--- a/source/d3d11/draw_call_tracker.hpp
+++ b/source/d3d11/draw_call_tracker.hpp
@@ -52,10 +52,10 @@ namespace reshade::d3d11
 		void track_rendertargets(int format_index, ID3D11DepthStencilView *depthstencil, UINT num_views, ID3D11RenderTargetView *const *views);
 		void track_depth_texture(int format_index, UINT index, com_ptr<ID3D11Texture2D> src_texture, com_ptr<ID3D11DepthStencilView> src_depthstencil, com_ptr<ID3D11Texture2D> dest_texture, bool cleared);
 
-		void keep_cleared_depth_textures();
+		void keep_cleared_depth_textures(bool reversed);
 
 		intermediate_snapshot_info find_best_snapshot(UINT width, UINT height);
-		ID3D11Texture2D *find_best_cleared_depth_buffer_texture(UINT clear_index);
+		ID3D11Texture2D *find_best_cleared_depth_buffer_texture(UINT clear_index, bool reversed);
 #endif
 
 	private:

--- a/source/d3d11/runtime_d3d11.cpp
+++ b/source/d3d11/runtime_d3d11.cpp
@@ -10,6 +10,7 @@
 #include "resource_loading.hpp"
 #include "dxgi/format_utils.hpp"
 #include <imgui.h>
+#include <imgui_internal.h>
 #include <d3dcompiler.h>
 
 namespace reshade::d3d11
@@ -1381,17 +1382,23 @@ void reshade::d3d11::runtime_d3d11::draw_debug_menu()
 			ImGui::Spacing();
 			ImGui::TextUnformatted("Depth Buffers:");
 
+			if (cleared_depth_buffer_index == UINT_MAX)
+				ImGui::SetCursorPosY(ImGui::GetCursorPosY() + ImGui::GetCurrentContext()->Style.FramePadding.y);
+
 			unsigned int current_index = 1;
 
 			for (const auto &it : _current_tracker->cleared_depth_textures())
 			{
-				char label[16]{};
-				sprintf_s(label, "%s%2u", (current_index == cleared_depth_buffer_index ? "> " : "  "), current_index);
-
 				if (cleared_depth_buffer_index == UINT_MAX)
-					ImGui::Text(label);
+				{
+					ImGui::Dummy(ImVec2(ImGui::GetFrameHeight(), ImGui::GetCurrentContext()->FontSize + ImGui::GetCurrentContext()->Style.FramePadding.y * 2.0f));
+					ImGui::SameLine(0.0f, ImGui::GetCurrentContext()->Style.ItemInnerSpacing.x), ImGui::TextUnformatted("    ");
+				}
 				else
 				{
+					char label[16]{};
+					sprintf_s(label, "%s%2u", (current_index == cleared_depth_buffer_index ? "> " : "  "), current_index);
+
 					if (bool value = cleared_depth_buffer_index == current_index; ImGui::Checkbox(label, &value))
 					{
 						cleared_depth_buffer_index = value ? current_index : 0;

--- a/source/d3d11/runtime_d3d11.cpp
+++ b/source/d3d11/runtime_d3d11.cpp
@@ -1362,7 +1362,7 @@ void reshade::d3d11::runtime_d3d11::draw_debug_menu()
 		if (depth_buffer_before_clear)
 		{
 			ImGui::SameLine();
-			modified |= ImGui::Checkbox("Reversed", &_clearing_depthstencil_after_present);
+			modified |= ImGui::Checkbox("Inverted", &_clearing_depthstencil_after_present);
 
 			if (ImGui::Checkbox("Extended depth buffer detection", &extended_depth_buffer_detection))
 			{

--- a/source/d3d11/runtime_d3d11.hpp
+++ b/source/d3d11/runtime_d3d11.hpp
@@ -34,6 +34,7 @@ namespace reshade::d3d11
 		bool depth_buffer_before_clear = false;
 		bool extended_depth_buffer_detection = false;
 		unsigned int cleared_depth_buffer_index = 0;
+		bool _clearing_depthstencil_after_present = false;
 		int depth_buffer_texture_format = 0; // No depth buffer texture format filter by default
 
 	private:


### PR DESCRIPTION
This change is make certain that "save_depth_texture()" function does copy the last used depth texture before "Present()" call.
And add support that if game does clearing depth stencil view at inverted timing.