### PR TITLE
effect_codegen.hpp: #Include <memory> (fixes VS2019/v142 build failures)

### DIFF
--- a/source/effect_codegen.hpp
+++ b/source/effect_codegen.hpp
@@ -7,6 +7,7 @@
 
 #include "effect_lexer.hpp"
 #include <algorithm>
+#include <memory>
 
 namespace reshadefx
 {


### PR DESCRIPTION
For some reason v142 toolset complains about std missing unique_ptr unless `#include <memory>`  is added to `effect_codegen.hpp`. I'm not sure this is the right include place but figured a pull is better than a issue report. There's still a lot more kinks to work out for v142 toolset but my local ricer branch seems to run fine, albeit with modified props to suppress errors and cool it's heels.

I don't think this is an issue with VS2019 having a newer "std:latest" standard since I also explicitly tested /std:c++17

Other than loads of deprecations and other warnings,  `Release App|Win32` and `Release App|x64` seem to be the only configurations which fail to compile (though there's likely a lot more corner cases, i.e. runtime_opengl* and probably some libs needing updating).

Forgive the 3am pull request if this is inappropriate or broken
