### PR TITLE
Add support for saving  before and after screenshots on the same frame

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -855,6 +855,7 @@ void reshade::runtime::draw_overlay_menu_settings()
 		modified |= imgui_directory_input_box("Screenshot Path", _screenshot_path, _file_selection_path);
 		modified |= ImGui::Combo("Screenshot Format", &_screenshot_format, "Bitmap (*.bmp)\0Portable Network Graphics (*.png)\0");
 		modified |= ImGui::Checkbox("Include Preset & Settings", &_screenshot_include_preset);
+		modified |= ImGui::Checkbox("Save Before and After", &_screenshot_save_before);
 	}
 
 	if (ImGui::CollapsingHeader("User Interface", ImGuiTreeNodeFlags_DefaultOpen))

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -654,7 +654,7 @@ void reshade::runtime::update_and_render_effects()
 	const auto input_lock = _input->lock();
 
 	if (_should_save_screenshot && (_screenshot_save_before || !_effects_enabled))
-		save_screenshot(_effects_enabled ? L"-original" : std::wstring(), _effects_enabled);
+		save_screenshot(_effects_enabled ? L"-original" : std::wstring(), !_effects_enabled);
 
 	// Nothing to do here if effects are disabled globally
 	if (!_effects_enabled)
@@ -783,7 +783,7 @@ void reshade::runtime::update_and_render_effects()
 
 	if (_should_save_screenshot)
 	{
-		save_screenshot(std::wstring(), false);
+		save_screenshot(std::wstring(), true);
 		_should_save_screenshot = false;
 	}
 }

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -158,13 +158,6 @@ void reshade::runtime::on_present()
 	// Lock input so it cannot be modified by other threads while we are reading it here
 	const auto input_lock = _input->lock();
 
-	if (_should_save_screenshot)
-	{
-		if (_effects_enabled)
-			save_screenshot(false);
-		_should_save_screenshot = false;
-	}
-
 	// Handle keyboard shortcuts
 	if (!_ignore_shortcuts)
 	{
@@ -175,12 +168,7 @@ void reshade::runtime::on_present()
 			_effects_enabled = !_effects_enabled;
 
 		if (_input->is_key_pressed(_screenshot_key_data))
-		{
-			if (_screenshot_save_before)
-				_should_save_screenshot = true;
-			else
-				save_screenshot(false);
-		}
+			_should_save_screenshot = true;
 	}
 
 #if RESHADE_GUI
@@ -665,12 +653,15 @@ void reshade::runtime::update_and_render_effects()
 	// TODO: This does not catch input happening between now and 'on_present'
 	const auto input_lock = _input->lock();
 
-	if (_should_save_screenshot && _screenshot_save_before)
-		save_screenshot(true);
+	if (_should_save_screenshot && (_screenshot_save_before || !_effects_enabled))
+		save_screenshot(_effects_enabled ? L"-original" : std::wstring(), _effects_enabled);
 
 	// Nothing to do here if effects are disabled globally
 	if (!_effects_enabled)
+	{
+		_should_save_screenshot = false;
 		return;
+	}
 
 	// Update special uniform variables
 	for (uniform &variable : _uniforms)
@@ -788,6 +779,12 @@ void reshade::runtime::update_and_render_effects()
 		const auto time_technique_finished = std::chrono::high_resolution_clock::now();
 
 		technique.average_cpu_duration.append(std::chrono::duration_cast<std::chrono::nanoseconds>(time_technique_finished - time_technique_started).count());
+	}
+
+	if (_should_save_screenshot)
+	{
+		save_screenshot(std::wstring(), false);
+		_should_save_screenshot = false;
 	}
 }
 
@@ -1040,7 +1037,7 @@ void reshade::runtime::save_current_preset() const
 	save_preset(_current_preset_path);
 }
 
-void reshade::runtime::save_screenshot(bool before)
+void reshade::runtime::save_screenshot(const std::wstring &postfix, const bool should_save_preset)
 {
 	std::vector<uint8_t> data(_width * _height * 4);
 	capture_screenshot(data.data());
@@ -1053,8 +1050,7 @@ void reshade::runtime::save_screenshot(bool before)
 	sprintf_s(filename, " %.4d-%.2d-%.2d %.2d-%.2d-%.2d", _date[0], _date[1], _date[2], hour, minute, seconds);
 
 	const std::wstring least = (_screenshot_path.is_relative() ? g_target_executable_path.parent_path() / _screenshot_path : _screenshot_path) / g_target_executable_path.stem().concat(filename);
-	const std::wstring beforeafter = least + (_screenshot_save_before ? (before ? L"-before" : L"-after") : L"");
-	const std::wstring screenshot_path = beforeafter + (_screenshot_format == 0 ? L".bmp" : L".png");
+	const std::wstring screenshot_path = least + postfix + (_screenshot_format == 0 ? L".bmp" : L".png");
 
 	LOG(INFO) << "Saving screenshot to " << screenshot_path << " ...";
 
@@ -1086,7 +1082,7 @@ void reshade::runtime::save_screenshot(bool before)
 	{
 		LOG(ERROR) << "Failed to write screenshot to " << screenshot_path << '!';
 	}
-	else if (_screenshot_include_preset && (!before || !_effects_enabled))
+	else if (_screenshot_include_preset && should_save_preset)
 	{
 		save_preset(least + L".ini");
 	}

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -250,7 +250,7 @@ namespace reshade
 		/// <summary>
 		/// Create a copy of the current frame and write it to an image file on disk.
 		/// </summary>
-		void save_screenshot(bool before = false);
+		void save_screenshot(const std::wstring &postfix = std::wstring(), bool should_save_preset = false);
 
 		void get_uniform_value(const uniform &variable, uint8_t *data, size_t size) const;
 		void set_uniform_value(uniform &variable, const uint8_t *data, size_t size);

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -250,7 +250,7 @@ namespace reshade
 		/// <summary>
 		/// Create a copy of the current frame and write it to an image file on disk.
 		/// </summary>
-		void save_screenshot();
+		void save_screenshot(bool before = false);
 
 		void get_uniform_value(const uniform &variable, uint8_t *data, size_t size) const;
 		void set_uniform_value(uniform &variable, const uint8_t *data, size_t size);
@@ -273,6 +273,7 @@ namespace reshade
 		std::filesystem::path _last_screenshot_file;
 		bool _screenshot_save_success = false;
 		bool _screenshot_include_preset = false;
+		bool _screenshot_save_before = false;
 
 		std::filesystem::path _current_preset_path;
 
@@ -285,6 +286,7 @@ namespace reshade
 		bool _performance_mode = false;
 		bool _no_reload_on_init = false;
 		bool _last_reload_successful = true;
+		bool _should_save_screenshot = false;
 		std::mutex _reload_mutex;
 		size_t _reload_total_effects = 1;
 		std::vector<size_t> _reload_compile_queue;


### PR DESCRIPTION
This patch allows ReShade to save a clean image before rendering effects by moving the `save_screenshot` call to the `update_and_render_effects` subroutine when the option is selected. The benefit of this is having before-and-after screenshots on the same frame, allowing you to see the effects of the shaders with no changes from the game.

This modifies the signature for `save_screenshot()` into `save_screenshot(bool)` to accomodate for the `-before` and `-after` suffix on the screenshot filename.
