### PR TITLE
Shortcut keys for switching backward or forward between presets

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -950,11 +950,6 @@ void reshade::runtime::draw_overlay_menu_settings()
 		modified |= imgui_key_input("Effect Toggle Key", _effects_key_data, *_input);
 		_ignore_shortcuts |= ImGui::IsItemActive();
 
-		modified |= imgui_key_input("Previous Preset Key", _previous_preset_key_data, *_input);
-		_ignore_shortcuts |= ImGui::IsItemActive();
-		modified |= imgui_key_input("Next Preset Key", _next_preset_key_data, *_input);
-		_ignore_shortcuts |= ImGui::IsItemActive();
-
 		modified |= ImGui::Combo("Input Processing", &_input_processing_mode,
 			"Pass on all input\0"
 			"Block input when cursor is on overlay\0"
@@ -2301,69 +2296,98 @@ void reshade::runtime::draw_preset_explorer()
 		}
 	}
 
-	if (condition == condition::backward || condition == condition::forward)
+	if (is_explore_open || condition == condition::backward || condition == condition::forward)
 	{
-		if (!switch_current_preset(condition == condition::forward))
-			condition = condition::pass;
-	}
+		std::filesystem::path preset_container_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
+		if (!std::filesystem::is_directory(preset_container_path, ec) && preset_container_path.has_filename())
+			preset_container_path = preset_container_path.parent_path();
 
-	if (is_explore_open)
-	{
 		std::vector<std::filesystem::directory_entry> preset_container;
-		get_preset_container(preset_container);
+		for (const auto &entry : std::filesystem::directory_iterator(preset_container_path, std::filesystem::directory_options::skip_permission_denied, ec))
+			preset_container.push_back(entry);
 
-		if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_NoNavFocus))
-			if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _current_browse_path, ec).type(); ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
-				if (condition = condition::popup_add; file_type == std::filesystem::file_type::not_found || file_type != std::filesystem::file_type::directory)
-					_current_browse_path = _current_browse_path.parent_path();
-
-		if (ImGui::IsWindowAppearing() || condition == condition::backward || condition == condition::forward)
-			ImGui::SetNextWindowFocus();
-
-		if (ImGui::BeginChild("##paths", ImVec2(0, 300), true))
+		if (condition == condition::backward || condition == condition::forward)
 		{
-			if (ImGui::Selectable(".."))
-			{
-				for (_current_browse_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
-					!std::filesystem::is_directory(_current_browse_path, ec) && _current_browse_path.parent_path() != _current_browse_path;)
-					_current_browse_path = _current_browse_path.parent_path();
-				_current_browse_path = _current_browse_path.parent_path();
-
-				if (std::filesystem::equivalent(reshade_container_path, _current_browse_path))
-					_current_browse_path = L".";
-				else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), _current_browse_path.begin()))
-					_current_browse_path = _current_browse_path.lexically_proximate(reshade_container_path);
-			}
-
 			std::vector<std::filesystem::directory_entry> preset_paths;
 			for (const auto &entry : preset_container)
-				if (const std::filesystem::file_type file_type = entry.status(ec).type(); file_type == std::filesystem::file_type::directory)
-					if (ImGui::Selectable(("<DIR> " + entry.path().filename().u8string()).c_str()))
-						if (std::filesystem::equivalent(reshade_container_path, entry))
-							_current_browse_path = L".";
-						else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), entry.path().begin()))
-							_current_browse_path = entry.path().lexically_proximate(reshade_container_path);
-						else
-							_current_browse_path = entry;
-					else {}
-				else if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
-					preset_paths.push_back(entry);
+				if (!entry.is_directory())
+					if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
+						if (const reshade::ini_file preset(entry); preset.has("", "Techniques"))
+							preset_paths.push_back(entry);
 
-			for (const auto &entry : preset_paths)
+			if (preset_paths.begin() == preset_paths.end())
+				condition = condition::pass;
+			else
 			{
-				const bool is_current_preset = std::filesystem::equivalent(entry, _current_preset_path, ec);
-
-				if (ImGui::Selectable(entry.path().filename().u8string().c_str(), static_cast<bool>(is_current_preset)))
-					condition = condition::select, _current_browse_path = entry.path().lexically_proximate(reshade_container_path);
-
-				if (is_current_preset)
-					if (_current_preset_is_covered && !ImGui::IsWindowAppearing())
-						_current_preset_is_covered = false, ImGui::SetScrollHereY();
-					else if (condition == condition::backward || condition == condition::forward)
-						ImGui::SetScrollHereY();
+				const std::filesystem::path &current_preset_path = _current_preset_path;
+				if (auto it = std::find_if(preset_paths.begin(), preset_paths.end(), [&ec, &current_preset_path](const std::filesystem::directory_entry &entry) { return std::filesystem::equivalent(entry, current_preset_path, ec); }); it == preset_paths.end())
+					if (condition == condition::backward)
+						_current_preset_path = _current_browse_path = preset_paths.back();
+					else
+						_current_preset_path = _current_browse_path = preset_paths.front();
+				else
+					if (condition == condition::backward)
+						_current_preset_path = _current_browse_path = it == preset_paths.begin() ? preset_paths.back() : *--it;
+					else
+						_current_preset_path = _current_browse_path = it == preset_paths.end() - 1 ? preset_paths.front() : *++it;
 			}
 		}
-		ImGui::EndChild();
+
+		if (is_explore_open)
+		{
+			if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_NoNavFocus))
+				if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _current_browse_path, ec).type(); ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
+					if (condition = condition::popup_add; file_type == std::filesystem::file_type::not_found || file_type != std::filesystem::file_type::directory)
+						_current_browse_path = _current_browse_path.parent_path();
+
+			if (ImGui::IsWindowAppearing() || condition == condition::backward || condition == condition::forward)
+				ImGui::SetNextWindowFocus();
+
+			if (ImGui::BeginChild("##paths", ImVec2(0, 300), true))
+			{
+				if (ImGui::Selectable(".."))
+				{
+					for (_current_browse_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
+						!std::filesystem::is_directory(_current_browse_path, ec) && _current_browse_path.parent_path() != _current_browse_path;)
+						_current_browse_path = _current_browse_path.parent_path();
+					_current_browse_path = _current_browse_path.parent_path();
+
+					if (std::filesystem::equivalent(reshade_container_path, _current_browse_path))
+						_current_browse_path = L".";
+					else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), _current_browse_path.begin()))
+						_current_browse_path = _current_browse_path.lexically_proximate(reshade_container_path);
+				}
+
+				std::vector<std::filesystem::directory_entry> preset_paths;
+				for (const auto &entry : preset_container)
+					if (const std::filesystem::file_type file_type = entry.status(ec).type(); file_type == std::filesystem::file_type::directory)
+						if (ImGui::Selectable(("<DIR> " + entry.path().filename().u8string()).c_str()))
+							if (std::filesystem::equivalent(reshade_container_path, entry))
+								_current_browse_path = L".";
+							else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), entry.path().begin()))
+								_current_browse_path = entry.path().lexically_proximate(reshade_container_path);
+							else
+								_current_browse_path = entry;
+						else {}
+					else if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
+						preset_paths.push_back(entry);
+
+				for (const auto &entry : preset_paths)
+				{
+					const bool is_current_preset = std::filesystem::equivalent(entry, _current_preset_path, ec);
+
+					if (ImGui::Selectable(entry.path().filename().u8string().c_str(), static_cast<bool>(is_current_preset)))
+						condition = condition::select, _current_browse_path = entry.path().lexically_proximate(reshade_container_path);
+
+					if (is_current_preset)
+						if (_current_preset_is_covered && !ImGui::IsWindowAppearing())
+							_current_preset_is_covered = false, ImGui::SetScrollHereY();
+						else if (condition == condition::backward || condition == condition::forward)
+							ImGui::SetScrollHereY();
+				}
+			}
+			ImGui::EndChild();
+		}
 	}
 
 	if (condition == condition::select)
@@ -2428,61 +2452,6 @@ void reshade::runtime::draw_preset_explorer()
 		ImGui::EndPopup();
 	else if (!_current_preset_is_covered)
 		_current_preset_is_covered = true;
-}
-
-void reshade::runtime::get_preset_container(std::vector<std::filesystem::directory_entry>& preset_container)
-{
-	static const std::filesystem::path reshade_container_path = g_reshade_dll_path.parent_path();
-	std::error_code ec;
-
-	std::filesystem::path preset_container_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
-	if (!std::filesystem::is_directory(preset_container_path, ec) && preset_container_path.has_filename())
-		preset_container_path = preset_container_path.parent_path();
-
-	for (const auto& entry : std::filesystem::directory_iterator(preset_container_path, std::filesystem::directory_options::skip_permission_denied, ec))
-		preset_container.push_back(entry);
-}
-
-bool reshade::runtime::switch_current_preset(bool bToNext)
-{
-	std::error_code ec;
-	std::vector<std::filesystem::directory_entry> preset_container;
-	get_preset_container(preset_container);
-
-	std::vector<std::filesystem::directory_entry> preset_paths;
-	for (const auto& entry : preset_container)
-		if (!entry.is_directory())
-			if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
-				if (const reshade::ini_file preset(entry); preset.has("", "Techniques"))
-					preset_paths.push_back(entry);
-
-	if (preset_paths.begin() == preset_paths.end())
-		return false;
-	else
-	{
-		const std::filesystem::path& current_preset_path = _current_preset_path;
-		if (auto it = std::find_if(preset_paths.begin(), preset_paths.end(), [&ec, &current_preset_path](const std::filesystem::directory_entry& entry) { return std::filesystem::equivalent(entry, current_preset_path, ec); }); it == preset_paths.end())
-			if (bToNext)
-				_current_preset_path = _current_browse_path = preset_paths.front();
-			else
-				_current_preset_path = _current_browse_path = preset_paths.back();
-		else
-			if (bToNext)
-			{
-				if (it != preset_paths.end() - 1)
-					_current_preset_path = _current_browse_path = *++it;
-				else
-					return false;
-			}
-			else
-			{
-				if (it != preset_paths.begin())
-					_current_preset_path = _current_browse_path = *--it;
-				else
-					return false;
-			}
-	}
-	return true;
 }
 
 #endif

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -950,13 +950,6 @@ void reshade::runtime::draw_overlay_menu_settings()
 		modified |= imgui_key_input("Effect Toggle Key", _effects_key_data, *_input);
 		_ignore_shortcuts |= ImGui::IsItemActive();
 
-		modified |= imgui_key_input("Previous Preset Key", _previous_preset_key_data, *_input);
-		_ignore_shortcuts |= ImGui::IsItemActive();
-		modified |= imgui_key_input("Next Preset Key", _next_preset_key_data, *_input);
-		_ignore_shortcuts |= ImGui::IsItemActive();
-
-		modified |= ImGui::SliderInt("Preset transition delay (ms)", &_preset_transition_delay, 0, 10 * 1000);
-
 		modified |= ImGui::Combo("Input Processing", &_input_processing_mode,
 			"Pass on all input\0"
 			"Block input when cursor is on overlay\0"
@@ -2303,69 +2296,98 @@ void reshade::runtime::draw_preset_explorer()
 		}
 	}
 
-	if (condition == condition::backward || condition == condition::forward)
+	if (is_explore_open || condition == condition::backward || condition == condition::forward)
 	{
-		if (!switch_current_preset(condition == condition::forward))
-			condition = condition::pass;
-	}
+		std::filesystem::path preset_container_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
+		if (!std::filesystem::is_directory(preset_container_path, ec) && preset_container_path.has_filename())
+			preset_container_path = preset_container_path.parent_path();
 
-	if (is_explore_open)
-	{
 		std::vector<std::filesystem::directory_entry> preset_container;
-		get_preset_container(preset_container);
+		for (const auto &entry : std::filesystem::directory_iterator(preset_container_path, std::filesystem::directory_options::skip_permission_denied, ec))
+			preset_container.push_back(entry);
 
-		if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_NoNavFocus))
-			if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _current_browse_path, ec).type(); ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
-				if (condition = condition::popup_add; file_type == std::filesystem::file_type::not_found || file_type != std::filesystem::file_type::directory)
-					_current_browse_path = _current_browse_path.parent_path();
-
-		if (ImGui::IsWindowAppearing() || condition == condition::backward || condition == condition::forward)
-			ImGui::SetNextWindowFocus();
-
-		if (ImGui::BeginChild("##paths", ImVec2(0, 300), true))
+		if (condition == condition::backward || condition == condition::forward)
 		{
-			if (ImGui::Selectable(".."))
-			{
-				for (_current_browse_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
-					!std::filesystem::is_directory(_current_browse_path, ec) && _current_browse_path.parent_path() != _current_browse_path;)
-					_current_browse_path = _current_browse_path.parent_path();
-				_current_browse_path = _current_browse_path.parent_path();
-
-				if (std::filesystem::equivalent(reshade_container_path, _current_browse_path))
-					_current_browse_path = L".";
-				else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), _current_browse_path.begin()))
-					_current_browse_path = _current_browse_path.lexically_proximate(reshade_container_path);
-			}
-
 			std::vector<std::filesystem::directory_entry> preset_paths;
 			for (const auto &entry : preset_container)
-				if (const std::filesystem::file_type file_type = entry.status(ec).type(); file_type == std::filesystem::file_type::directory)
-					if (ImGui::Selectable(("<DIR> " + entry.path().filename().u8string()).c_str()))
-						if (std::filesystem::equivalent(reshade_container_path, entry))
-							_current_browse_path = L".";
-						else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), entry.path().begin()))
-							_current_browse_path = entry.path().lexically_proximate(reshade_container_path);
-						else
-							_current_browse_path = entry;
-					else {}
-				else if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
-					preset_paths.push_back(entry);
+				if (!entry.is_directory())
+					if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
+						if (const reshade::ini_file preset(entry); preset.has("", "Techniques"))
+							preset_paths.push_back(entry);
 
-			for (const auto &entry : preset_paths)
+			if (preset_paths.begin() == preset_paths.end())
+				condition = condition::pass;
+			else
 			{
-				const bool is_current_preset = std::filesystem::equivalent(entry, _current_preset_path, ec);
-
-				if (ImGui::Selectable(entry.path().filename().u8string().c_str(), static_cast<bool>(is_current_preset)))
-					condition = condition::select, _current_browse_path = entry.path().lexically_proximate(reshade_container_path);
-
-				if (is_current_preset)
-					if (_current_preset_is_covered && !ImGui::IsWindowAppearing())
-						_current_preset_is_covered = false, ImGui::SetScrollHereY();
-					else if (condition == condition::backward || condition == condition::forward)
-						ImGui::SetScrollHereY();
+				const std::filesystem::path &current_preset_path = _current_preset_path;
+				if (auto it = std::find_if(preset_paths.begin(), preset_paths.end(), [&ec, &current_preset_path](const std::filesystem::directory_entry &entry) { return std::filesystem::equivalent(entry, current_preset_path, ec); }); it == preset_paths.end())
+					if (condition == condition::backward)
+						_current_preset_path = _current_browse_path = preset_paths.back();
+					else
+						_current_preset_path = _current_browse_path = preset_paths.front();
+				else
+					if (condition == condition::backward)
+						_current_preset_path = _current_browse_path = it == preset_paths.begin() ? preset_paths.back() : *--it;
+					else
+						_current_preset_path = _current_browse_path = it == preset_paths.end() - 1 ? preset_paths.front() : *++it;
 			}
 		}
-		ImGui::EndChild();
+
+		if (is_explore_open)
+		{
+			if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_NoNavFocus))
+				if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _current_browse_path, ec).type(); ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
+					if (condition = condition::popup_add; file_type == std::filesystem::file_type::not_found || file_type != std::filesystem::file_type::directory)
+						_current_browse_path = _current_browse_path.parent_path();
+
+			if (ImGui::IsWindowAppearing() || condition == condition::backward || condition == condition::forward)
+				ImGui::SetNextWindowFocus();
+
+			if (ImGui::BeginChild("##paths", ImVec2(0, 300), true))
+			{
+				if (ImGui::Selectable(".."))
+				{
+					for (_current_browse_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
+						!std::filesystem::is_directory(_current_browse_path, ec) && _current_browse_path.parent_path() != _current_browse_path;)
+						_current_browse_path = _current_browse_path.parent_path();
+					_current_browse_path = _current_browse_path.parent_path();
+
+					if (std::filesystem::equivalent(reshade_container_path, _current_browse_path))
+						_current_browse_path = L".";
+					else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), _current_browse_path.begin()))
+						_current_browse_path = _current_browse_path.lexically_proximate(reshade_container_path);
+				}
+
+				std::vector<std::filesystem::directory_entry> preset_paths;
+				for (const auto &entry : preset_container)
+					if (const std::filesystem::file_type file_type = entry.status(ec).type(); file_type == std::filesystem::file_type::directory)
+						if (ImGui::Selectable(("<DIR> " + entry.path().filename().u8string()).c_str()))
+							if (std::filesystem::equivalent(reshade_container_path, entry))
+								_current_browse_path = L".";
+							else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), entry.path().begin()))
+								_current_browse_path = entry.path().lexically_proximate(reshade_container_path);
+							else
+								_current_browse_path = entry;
+						else {}
+					else if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
+						preset_paths.push_back(entry);
+
+				for (const auto &entry : preset_paths)
+				{
+					const bool is_current_preset = std::filesystem::equivalent(entry, _current_preset_path, ec);
+
+					if (ImGui::Selectable(entry.path().filename().u8string().c_str(), static_cast<bool>(is_current_preset)))
+						condition = condition::select, _current_browse_path = entry.path().lexically_proximate(reshade_container_path);
+
+					if (is_current_preset)
+						if (_current_preset_is_covered && !ImGui::IsWindowAppearing())
+							_current_preset_is_covered = false, ImGui::SetScrollHereY();
+						else if (condition == condition::backward || condition == condition::forward)
+							ImGui::SetScrollHereY();
+				}
+			}
+			ImGui::EndChild();
+		}
 	}
 
 	if (condition == condition::select)
@@ -2430,63 +2452,6 @@ void reshade::runtime::draw_preset_explorer()
 		ImGui::EndPopup();
 	else if (!_current_preset_is_covered)
 		_current_preset_is_covered = true;
-}
-
-void reshade::runtime::get_preset_container(std::vector<std::filesystem::directory_entry>& preset_container)
-{
-	static const std::filesystem::path reshade_container_path = g_reshade_dll_path.parent_path();
-	std::error_code ec;
-
-	std::filesystem::path preset_container_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
-	if (!std::filesystem::is_directory(preset_container_path, ec) && preset_container_path.has_filename())
-		preset_container_path = preset_container_path.parent_path();
-
-	for (const auto& entry : std::filesystem::directory_iterator(preset_container_path, std::filesystem::directory_options::skip_permission_denied, ec))
-		preset_container.push_back(entry);
-}
-
-bool reshade::runtime::switch_current_preset(bool bToNext)
-{
-	std::error_code ec;
-	std::vector<std::filesystem::directory_entry> preset_container;
-	get_preset_container(preset_container);
-
-	std::vector<std::filesystem::directory_entry> preset_paths;
-	for (const auto& entry : preset_container)
-		if (!entry.is_directory())
-			if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
-				if (const reshade::ini_file preset(entry); preset.has("", "Techniques"))
-					preset_paths.push_back(entry);
-
-	if (preset_paths.begin() == preset_paths.end())
-		return false;
-	else
-	{
-		const std::filesystem::path& current_preset_path = _current_preset_path;
-		if (auto it = std::find_if(preset_paths.begin(), preset_paths.end(), [&ec, &current_preset_path](const std::filesystem::directory_entry& entry) { return std::filesystem::equivalent(entry, current_preset_path, ec); }); it == preset_paths.end())
-			if (bToNext)
-				_current_preset_path = _current_browse_path = preset_paths.front();
-			else
-				_current_preset_path = _current_browse_path = preset_paths.back();
-		else
-			if (bToNext)
-			{
-				if (it != preset_paths.end() - 1)
-					_current_preset_path = _current_browse_path = *++it;
-				else
-					_current_preset_path = _current_browse_path = preset_paths.front();
-//					return false; // this line must  be used istead of the above one for not going round and round through presets
-			}
-			else
-			{
-				if (it != preset_paths.begin())
-					_current_preset_path = _current_browse_path = *--it;
-				else
-					_current_preset_path = _current_browse_path = preset_paths.back();
-//					return false; // this line must  be used istead of the above one for not going round and round through presets
-			}
-	}
-	return true;
 }
 
 #endif

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -955,6 +955,8 @@ void reshade::runtime::draw_overlay_menu_settings()
 		modified |= imgui_key_input("Next Preset Key", _next_preset_key_data, *_input);
 		_ignore_shortcuts |= ImGui::IsItemActive();
 
+		modified |= ImGui::SliderInt("Preset transition delay", &_preset_transition_delay, 0, 10 * 1000);
+
 		modified |= ImGui::Combo("Input Processing", &_input_processing_mode,
 			"Pass on all input\0"
 			"Block input when cursor is on overlay\0"

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -950,6 +950,11 @@ void reshade::runtime::draw_overlay_menu_settings()
 		modified |= imgui_key_input("Effect Toggle Key", _effects_key_data, *_input);
 		_ignore_shortcuts |= ImGui::IsItemActive();
 
+		modified |= imgui_key_input("Previous Preset Key", _previous_preset_key_data, *_input);
+		_ignore_shortcuts |= ImGui::IsItemActive();
+		modified |= imgui_key_input("Next Preset Key", _next_preset_key_data, *_input);
+		_ignore_shortcuts |= ImGui::IsItemActive();
+
 		modified |= ImGui::Combo("Input Processing", &_input_processing_mode,
 			"Pass on all input\0"
 			"Block input when cursor is on overlay\0"
@@ -2296,98 +2301,69 @@ void reshade::runtime::draw_preset_explorer()
 		}
 	}
 
-	if (is_explore_open || condition == condition::backward || condition == condition::forward)
+	if (condition == condition::backward || condition == condition::forward)
 	{
-		std::filesystem::path preset_container_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
-		if (!std::filesystem::is_directory(preset_container_path, ec) && preset_container_path.has_filename())
-			preset_container_path = preset_container_path.parent_path();
+		if (!switch_current_preset(condition == condition::forward))
+			condition = condition::pass;
+	}
 
+	if (is_explore_open)
+	{
 		std::vector<std::filesystem::directory_entry> preset_container;
-		for (const auto &entry : std::filesystem::directory_iterator(preset_container_path, std::filesystem::directory_options::skip_permission_denied, ec))
-			preset_container.push_back(entry);
+		get_preset_container(preset_container);
 
-		if (condition == condition::backward || condition == condition::forward)
-		{
-			std::vector<std::filesystem::directory_entry> preset_paths;
-			for (const auto &entry : preset_container)
-				if (!entry.is_directory())
-					if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
-						if (const reshade::ini_file preset(entry); preset.has("", "Techniques"))
-							preset_paths.push_back(entry);
-
-			if (preset_paths.begin() == preset_paths.end())
-				condition = condition::pass;
-			else
-			{
-				const std::filesystem::path &current_preset_path = _current_preset_path;
-				if (auto it = std::find_if(preset_paths.begin(), preset_paths.end(), [&ec, &current_preset_path](const std::filesystem::directory_entry &entry) { return std::filesystem::equivalent(entry, current_preset_path, ec); }); it == preset_paths.end())
-					if (condition == condition::backward)
-						_current_preset_path = _current_browse_path = preset_paths.back();
-					else
-						_current_preset_path = _current_browse_path = preset_paths.front();
-				else
-					if (condition == condition::backward)
-						_current_preset_path = _current_browse_path = it == preset_paths.begin() ? preset_paths.back() : *--it;
-					else
-						_current_preset_path = _current_browse_path = it == preset_paths.end() - 1 ? preset_paths.front() : *++it;
-			}
-		}
-
-		if (is_explore_open)
-		{
-			if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_NoNavFocus))
-				if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _current_browse_path, ec).type(); ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
-					if (condition = condition::popup_add; file_type == std::filesystem::file_type::not_found || file_type != std::filesystem::file_type::directory)
-						_current_browse_path = _current_browse_path.parent_path();
-
-			if (ImGui::IsWindowAppearing() || condition == condition::backward || condition == condition::forward)
-				ImGui::SetNextWindowFocus();
-
-			if (ImGui::BeginChild("##paths", ImVec2(0, 300), true))
-			{
-				if (ImGui::Selectable(".."))
-				{
-					for (_current_browse_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
-						!std::filesystem::is_directory(_current_browse_path, ec) && _current_browse_path.parent_path() != _current_browse_path;)
-						_current_browse_path = _current_browse_path.parent_path();
+		if (ImGui::SameLine(0, button_spacing); ImGui::ButtonEx("+", ImVec2(button_size, 0), ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_NoNavFocus))
+			if (const std::filesystem::file_type file_type = std::filesystem::status(reshade_container_path / _current_browse_path, ec).type(); ec.value() != 0x7b) // 0x7b: ERROR_INVALID_NAME
+				if (condition = condition::popup_add; file_type == std::filesystem::file_type::not_found || file_type != std::filesystem::file_type::directory)
 					_current_browse_path = _current_browse_path.parent_path();
 
-					if (std::filesystem::equivalent(reshade_container_path, _current_browse_path))
-						_current_browse_path = L".";
-					else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), _current_browse_path.begin()))
-						_current_browse_path = _current_browse_path.lexically_proximate(reshade_container_path);
-				}
+		if (ImGui::IsWindowAppearing() || condition == condition::backward || condition == condition::forward)
+			ImGui::SetNextWindowFocus();
 
-				std::vector<std::filesystem::directory_entry> preset_paths;
-				for (const auto &entry : preset_container)
-					if (const std::filesystem::file_type file_type = entry.status(ec).type(); file_type == std::filesystem::file_type::directory)
-						if (ImGui::Selectable(("<DIR> " + entry.path().filename().u8string()).c_str()))
-							if (std::filesystem::equivalent(reshade_container_path, entry))
-								_current_browse_path = L".";
-							else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), entry.path().begin()))
-								_current_browse_path = entry.path().lexically_proximate(reshade_container_path);
-							else
-								_current_browse_path = entry;
-						else {}
-					else if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
-						preset_paths.push_back(entry);
+		if (ImGui::BeginChild("##paths", ImVec2(0, 300), true))
+		{
+			if (ImGui::Selectable(".."))
+			{
+				for (_current_browse_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
+					!std::filesystem::is_directory(_current_browse_path, ec) && _current_browse_path.parent_path() != _current_browse_path;)
+					_current_browse_path = _current_browse_path.parent_path();
+				_current_browse_path = _current_browse_path.parent_path();
 
-				for (const auto &entry : preset_paths)
-				{
-					const bool is_current_preset = std::filesystem::equivalent(entry, _current_preset_path, ec);
-
-					if (ImGui::Selectable(entry.path().filename().u8string().c_str(), static_cast<bool>(is_current_preset)))
-						condition = condition::select, _current_browse_path = entry.path().lexically_proximate(reshade_container_path);
-
-					if (is_current_preset)
-						if (_current_preset_is_covered && !ImGui::IsWindowAppearing())
-							_current_preset_is_covered = false, ImGui::SetScrollHereY();
-						else if (condition == condition::backward || condition == condition::forward)
-							ImGui::SetScrollHereY();
-				}
+				if (std::filesystem::equivalent(reshade_container_path, _current_browse_path))
+					_current_browse_path = L".";
+				else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), _current_browse_path.begin()))
+					_current_browse_path = _current_browse_path.lexically_proximate(reshade_container_path);
 			}
-			ImGui::EndChild();
+
+			std::vector<std::filesystem::directory_entry> preset_paths;
+			for (const auto &entry : preset_container)
+				if (const std::filesystem::file_type file_type = entry.status(ec).type(); file_type == std::filesystem::file_type::directory)
+					if (ImGui::Selectable(("<DIR> " + entry.path().filename().u8string()).c_str()))
+						if (std::filesystem::equivalent(reshade_container_path, entry))
+							_current_browse_path = L".";
+						else if (std::equal(reshade_container_path.begin(), reshade_container_path.end(), entry.path().begin()))
+							_current_browse_path = entry.path().lexically_proximate(reshade_container_path);
+						else
+							_current_browse_path = entry;
+					else {}
+				else if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
+					preset_paths.push_back(entry);
+
+			for (const auto &entry : preset_paths)
+			{
+				const bool is_current_preset = std::filesystem::equivalent(entry, _current_preset_path, ec);
+
+				if (ImGui::Selectable(entry.path().filename().u8string().c_str(), static_cast<bool>(is_current_preset)))
+					condition = condition::select, _current_browse_path = entry.path().lexically_proximate(reshade_container_path);
+
+				if (is_current_preset)
+					if (_current_preset_is_covered && !ImGui::IsWindowAppearing())
+						_current_preset_is_covered = false, ImGui::SetScrollHereY();
+					else if (condition == condition::backward || condition == condition::forward)
+						ImGui::SetScrollHereY();
+			}
 		}
+		ImGui::EndChild();
 	}
 
 	if (condition == condition::select)
@@ -2452,6 +2428,61 @@ void reshade::runtime::draw_preset_explorer()
 		ImGui::EndPopup();
 	else if (!_current_preset_is_covered)
 		_current_preset_is_covered = true;
+}
+
+void reshade::runtime::get_preset_container(std::vector<std::filesystem::directory_entry>& preset_container)
+{
+	static const std::filesystem::path reshade_container_path = g_reshade_dll_path.parent_path();
+	std::error_code ec;
+
+	std::filesystem::path preset_container_path = std::filesystem::absolute(reshade_container_path / _current_browse_path);
+	if (!std::filesystem::is_directory(preset_container_path, ec) && preset_container_path.has_filename())
+		preset_container_path = preset_container_path.parent_path();
+
+	for (const auto& entry : std::filesystem::directory_iterator(preset_container_path, std::filesystem::directory_options::skip_permission_denied, ec))
+		preset_container.push_back(entry);
+}
+
+bool reshade::runtime::switch_current_preset(bool bToNext)
+{
+	std::error_code ec;
+	std::vector<std::filesystem::directory_entry> preset_container;
+	get_preset_container(preset_container);
+
+	std::vector<std::filesystem::directory_entry> preset_paths;
+	for (const auto& entry : preset_container)
+		if (!entry.is_directory())
+			if (const std::wstring extension(entry.path().extension()); extension == L".ini" || extension == L".txt")
+				if (const reshade::ini_file preset(entry); preset.has("", "Techniques"))
+					preset_paths.push_back(entry);
+
+	if (preset_paths.begin() == preset_paths.end())
+		return false;
+	else
+	{
+		const std::filesystem::path& current_preset_path = _current_preset_path;
+		if (auto it = std::find_if(preset_paths.begin(), preset_paths.end(), [&ec, &current_preset_path](const std::filesystem::directory_entry& entry) { return std::filesystem::equivalent(entry, current_preset_path, ec); }); it == preset_paths.end())
+			if (bToNext)
+				_current_preset_path = _current_browse_path = preset_paths.front();
+			else
+				_current_preset_path = _current_browse_path = preset_paths.back();
+		else
+			if (bToNext)
+			{
+				if (it != preset_paths.end() - 1)
+					_current_preset_path = _current_browse_path = *++it;
+				else
+					return false;
+			}
+			else
+			{
+				if (it != preset_paths.begin())
+					_current_preset_path = _current_browse_path = *--it;
+				else
+					return false;
+			}
+	}
+	return true;
 }
 
 #endif

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -958,7 +958,9 @@ void reshade::runtime::draw_overlay_menu_settings()
 		modified |= imgui_key_input("Next Preset Key", _next_preset_key_data, *_input);
 		_ignore_shortcuts |= ImGui::IsItemActive();
 
-		modified |= ImGui::SliderInt("Preset transition delay (ms)", &_preset_transition_delay, 0, 10 * 1000);
+		modified |= ImGui::SliderInt("Preset transition\ndelay (ms)", &_preset_transition_delay, 0, 10 * 1000);
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("%s", "Makes a smooth transition, but only for floating point values.\nRecommended for multiple presets that contain the same shaders, otherwise set this to 0");
 
 		modified |= ImGui::Combo("Input Processing", &_input_processing_mode,
 			"Pass on all input\0"

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2472,14 +2472,16 @@ bool reshade::runtime::switch_current_preset(bool bToNext)
 				if (it != preset_paths.end() - 1)
 					_current_preset_path = _current_browse_path = *++it;
 				else
-					return false;
+					_current_preset_path = _current_browse_path = preset_paths.front();
+//					return false; // this line must  be used istead of the above one for not going round and round through presets
 			}
 			else
 			{
 				if (it != preset_paths.begin())
 					_current_preset_path = _current_browse_path = *--it;
 				else
-					return false;
+					_current_preset_path = _current_browse_path = preset_paths.back();
+//					return false; // this line must  be used istead of the above one for not going round and round through presets
 			}
 	}
 	return true;

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -955,7 +955,7 @@ void reshade::runtime::draw_overlay_menu_settings()
 		modified |= imgui_key_input("Next Preset Key", _next_preset_key_data, *_input);
 		_ignore_shortcuts |= ImGui::IsItemActive();
 
-		modified |= ImGui::SliderInt("Preset transition delay", &_preset_transition_delay, 0, 10 * 1000);
+		modified |= ImGui::SliderInt("Preset transition delay (ms)", &_preset_transition_delay, 0, 10 * 1000);
 
 		modified |= ImGui::Combo("Input Processing", &_input_processing_mode,
 			"Pass on all input\0"

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -79,6 +79,8 @@ reshade::runtime::runtime() :
 	_reload_key_data(),
 	_effects_key_data(),
 	_screenshot_key_data(),
+	_previous_preset_key_data(),
+	_next_preset_key_data(),
 	_screenshot_path(g_target_executable_path.parent_path())
 {
 	// Default shortcut PrtScrn
@@ -174,7 +176,21 @@ void reshade::runtime::on_present()
 
 		if (_input->is_key_pressed(_screenshot_key_data))
 			_should_save_screenshot = true;
+
+		bool bPreviousPresetKeyPressed = _input->is_key_pressed(_previous_preset_key_data);
+		bool bNextPresetKeyPressed = _input->is_key_pressed(_next_preset_key_data);
+		if (bPreviousPresetKeyPressed || bNextPresetKeyPressed)
+			if(switch_current_preset(bNextPresetKeyPressed))
+			{
+				_last_preset_switching_time = current_time;
+				_is_in_between_presets_transition = true;
+				set_current_preset();
+				save_config();
+			}
 	}
+
+	if (_is_in_between_presets_transition)
+		load_current_preset();
 
 #if RESHADE_GUI
 	// Draw overlay
@@ -882,6 +898,9 @@ void reshade::runtime::load_config()
 	config.get("INPUT", "KeyReload", _reload_key_data);
 	config.get("INPUT", "KeyEffects", _effects_key_data);
 	config.get("INPUT", "KeyScreenshot", _screenshot_key_data);
+	config.get("INPUT", "KeyPreviousPreset", _previous_preset_key_data);
+	config.get("INPUT", "KeyNextPreset", _next_preset_key_data);
+	config.get("INPUT", "PresetTransitionDelay", _preset_transition_delay);
 
 	config.get("GENERAL", "PerformanceMode", _performance_mode);
 	config.get("GENERAL", "EffectSearchPaths", _effect_search_paths);
@@ -921,6 +940,9 @@ void reshade::runtime::save_config(const std::filesystem::path &path) const
 	config.set("INPUT", "KeyReload", _reload_key_data);
 	config.set("INPUT", "KeyEffects", _effects_key_data);
 	config.set("INPUT", "KeyScreenshot", _screenshot_key_data);
+	config.set("INPUT", "KeyPreviousPreset", _previous_preset_key_data);
+	config.set("INPUT", "KeyNextPreset", _next_preset_key_data);
+	config.set("INPUT", "PresetTransitionDelay", _preset_transition_delay);
 
 	config.set("GENERAL", "PerformanceMode", _performance_mode);
 	config.set("GENERAL", "EffectSearchPaths", _effect_search_paths);
@@ -968,26 +990,68 @@ void reshade::runtime::load_preset(const std::filesystem::path &path)
 			       (std::find(sorted_technique_list.begin(), sorted_technique_list.end(), rhs.name) - sorted_technique_list.begin());
 		});
 
+	// compute time since the transition has started and how much is left till it should end
+	auto nMicrosecondsPassed = std::chrono::duration_cast<std::chrono::microseconds>(_last_present_time - _last_preset_switching_time).count();
+	auto nMilisecondsLeft = _preset_transition_delay - nMicrosecondsPassed / 1000;
+	auto nMilisecondsLeftFromLastFrame = nMilisecondsLeft + +std::chrono::duration_cast<std::chrono::microseconds>(_last_frame_duration).count() / 1000;
+
+	if (_is_in_between_presets_transition && nMilisecondsLeft <= 0)
+		_is_in_between_presets_transition = false;
+
 	for (uniform &variable : _uniforms)
 	{
+		reshadefx::constant values_old;
 		reshadefx::constant values;
 
 		switch (variable.type.base)
 		{
 		case reshadefx::type::t_int:
 			get_uniform_value(variable, values.as_int, 16);
+			values_old = values;
 			preset.get(_loaded_effects[variable.effect_index].source_file.filename().u8string(), variable.name, values.as_int);
+			if (_is_in_between_presets_transition)
+			{
+				for (int i = 0; i < 16; i++)
+				{
+					if (abs(values.as_int[i] - values_old.as_int[i]) > 1)
+					{
+						auto fRatio = static_cast<float>(values.as_int[i] - values_old.as_int[i]) / nMilisecondsLeftFromLastFrame;
+						values.as_int[i] = static_cast<int32_t>(values.as_int[i] - fRatio * nMilisecondsLeft);
+					}
+				}
+			}
 			set_uniform_value(variable, values.as_int, 16);
 			break;
 		case reshadefx::type::t_bool:
 		case reshadefx::type::t_uint:
 			get_uniform_value(variable, values.as_uint, 16);
+			values_old = values;
 			preset.get(_loaded_effects[variable.effect_index].source_file.filename().u8string(), variable.name, values.as_uint);
+			if (_is_in_between_presets_transition)
+			{
+				for (int i = 0; i < 16; i++)
+				{
+					if (abs(static_cast<float>(values.as_uint[i]) - values_old.as_uint[i]) > 1)
+					{
+						auto fRatio = (static_cast<float>(values.as_uint[i]) - values_old.as_uint[i]) / nMilisecondsLeftFromLastFrame;
+						values.as_uint[i] = static_cast<uint32_t>(values.as_uint[i] - fRatio * nMilisecondsLeft);
+					}
+				}
+			}
 			set_uniform_value(variable, values.as_uint, 16);
 			break;
 		case reshadefx::type::t_float:
 			get_uniform_value(variable, values.as_float, 16);
+			values_old = values;
 			preset.get(_loaded_effects[variable.effect_index].source_file.filename().u8string(), variable.name, values.as_float);
+			if (_is_in_between_presets_transition)
+			{
+				for (int i = 0; i < 16; i++)
+				{
+					auto fRatio = static_cast<float>(values.as_float[i] - values_old.as_float[i]) / nMilisecondsLeftFromLastFrame;
+					values.as_float[i] = static_cast<float>(values.as_float[i] - fRatio * nMilisecondsLeft);
+				}
+			}
 			set_uniform_value(variable, values.as_float, 16);
 			break;
 		}

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -79,6 +79,8 @@ reshade::runtime::runtime() :
 	_reload_key_data(),
 	_effects_key_data(),
 	_screenshot_key_data(),
+	_previous_preset_key_data(),
+	_next_preset_key_data(),
 	_screenshot_path(g_target_executable_path.parent_path())
 {
 	// Default shortcut PrtScrn
@@ -174,6 +176,16 @@ void reshade::runtime::on_present()
 
 		if (_input->is_key_pressed(_screenshot_key_data))
 			_should_save_screenshot = true;
+
+		bool bPreviousPresetKeyPressed = _input->is_key_pressed(_previous_preset_key_data);
+		bool bNextPresetKeyPressed = _input->is_key_pressed(_next_preset_key_data);
+		if (bPreviousPresetKeyPressed || bNextPresetKeyPressed)
+			if(switch_current_preset(bNextPresetKeyPressed))
+			{
+				set_current_preset();
+				save_config();
+				load_current_preset();
+			}
 	}
 
 #if RESHADE_GUI
@@ -882,6 +894,8 @@ void reshade::runtime::load_config()
 	config.get("INPUT", "KeyReload", _reload_key_data);
 	config.get("INPUT", "KeyEffects", _effects_key_data);
 	config.get("INPUT", "KeyScreenshot", _screenshot_key_data);
+	config.get("INPUT", "KeyPreviousPreset", _previous_preset_key_data);
+	config.get("INPUT", "KeyNextPreset", _next_preset_key_data);
 
 	config.get("GENERAL", "PerformanceMode", _performance_mode);
 	config.get("GENERAL", "EffectSearchPaths", _effect_search_paths);
@@ -921,6 +935,8 @@ void reshade::runtime::save_config(const std::filesystem::path &path) const
 	config.set("INPUT", "KeyReload", _reload_key_data);
 	config.set("INPUT", "KeyEffects", _effects_key_data);
 	config.set("INPUT", "KeyScreenshot", _screenshot_key_data);
+	config.set("INPUT", "KeyPreviousPreset", _previous_preset_key_data);
+	config.set("INPUT", "KeyNextPreset", _next_preset_key_data);
 
 	config.set("GENERAL", "PerformanceMode", _performance_mode);
 	config.set("GENERAL", "EffectSearchPaths", _effect_search_paths);

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -79,8 +79,6 @@ reshade::runtime::runtime() :
 	_reload_key_data(),
 	_effects_key_data(),
 	_screenshot_key_data(),
-	_previous_preset_key_data(),
-	_next_preset_key_data(),
 	_screenshot_path(g_target_executable_path.parent_path())
 {
 	// Default shortcut PrtScrn
@@ -176,21 +174,7 @@ void reshade::runtime::on_present()
 
 		if (_input->is_key_pressed(_screenshot_key_data))
 			_should_save_screenshot = true;
-
-		bool bPreviousPresetKeyPressed = _input->is_key_pressed(_previous_preset_key_data);
-		bool bNextPresetKeyPressed = _input->is_key_pressed(_next_preset_key_data);
-		if (bPreviousPresetKeyPressed || bNextPresetKeyPressed)
-			if(switch_current_preset(bNextPresetKeyPressed))
-			{
-				_last_preset_switching_time = current_time;
-				_is_in_between_presets_transition = true;
-				set_current_preset();
-				save_config();
-			}
 	}
-
-	if (_is_in_between_presets_transition)
-		load_current_preset();
 
 #if RESHADE_GUI
 	// Draw overlay
@@ -898,9 +882,6 @@ void reshade::runtime::load_config()
 	config.get("INPUT", "KeyReload", _reload_key_data);
 	config.get("INPUT", "KeyEffects", _effects_key_data);
 	config.get("INPUT", "KeyScreenshot", _screenshot_key_data);
-	config.get("INPUT", "KeyPreviousPreset", _previous_preset_key_data);
-	config.get("INPUT", "KeyNextPreset", _next_preset_key_data);
-	config.get("INPUT", "PresetTransitionDelay", _preset_transition_delay);
 
 	config.get("GENERAL", "PerformanceMode", _performance_mode);
 	config.get("GENERAL", "EffectSearchPaths", _effect_search_paths);
@@ -940,9 +921,6 @@ void reshade::runtime::save_config(const std::filesystem::path &path) const
 	config.set("INPUT", "KeyReload", _reload_key_data);
 	config.set("INPUT", "KeyEffects", _effects_key_data);
 	config.set("INPUT", "KeyScreenshot", _screenshot_key_data);
-	config.set("INPUT", "KeyPreviousPreset", _previous_preset_key_data);
-	config.set("INPUT", "KeyNextPreset", _next_preset_key_data);
-	config.set("INPUT", "PresetTransitionDelay", _preset_transition_delay);
 
 	config.set("GENERAL", "PerformanceMode", _performance_mode);
 	config.set("GENERAL", "EffectSearchPaths", _effect_search_paths);
@@ -990,68 +968,26 @@ void reshade::runtime::load_preset(const std::filesystem::path &path)
 			       (std::find(sorted_technique_list.begin(), sorted_technique_list.end(), rhs.name) - sorted_technique_list.begin());
 		});
 
-	// compute times since the transition has started and how much left till it should end
-	auto nMicrosecondsPassed = std::chrono::duration_cast<std::chrono::microseconds>(_last_present_time - _last_preset_switching_time).count();
-	auto nMilisecondsLeft = _preset_transition_delay - nMicrosecondsPassed / 1000;
-	auto nMilisecondsLeftFromLastFrame = nMilisecondsLeft + +std::chrono::duration_cast<std::chrono::microseconds>(_last_frame_duration).count() / 1000;
-
-	if (_is_in_between_presets_transition && nMilisecondsLeft <= 0)
-		_is_in_between_presets_transition = false;
-
 	for (uniform &variable : _uniforms)
 	{
-		reshadefx::constant values_old;
 		reshadefx::constant values;
 
 		switch (variable.type.base)
 		{
 		case reshadefx::type::t_int:
 			get_uniform_value(variable, values.as_int, 16);
-			values_old = values;
 			preset.get(_loaded_effects[variable.effect_index].source_file.filename().u8string(), variable.name, values.as_int);
-			if (_is_in_between_presets_transition)
-			{
-				for (int i = 0; i < 16; i++)
-				{
-					if (abs(values.as_int[i] - values_old.as_int[i]) > 1)
-					{
-						auto fRatio = static_cast<float>(values.as_int[i] - values_old.as_int[i]) / nMilisecondsLeftFromLastFrame;
-						values.as_int[i] = static_cast<int32_t>(values.as_int[i] - fRatio * nMilisecondsLeft);
-					}
-				}
-			}
 			set_uniform_value(variable, values.as_int, 16);
 			break;
 		case reshadefx::type::t_bool:
 		case reshadefx::type::t_uint:
 			get_uniform_value(variable, values.as_uint, 16);
-			values_old = values;
 			preset.get(_loaded_effects[variable.effect_index].source_file.filename().u8string(), variable.name, values.as_uint);
-			if (_is_in_between_presets_transition)
-			{
-				for (int i = 0; i < 16; i++)
-				{
-					if (abs(static_cast<float>(values.as_uint[i]) - values_old.as_uint[i]) > 1)
-					{
-						auto fRatio = (static_cast<float>(values.as_uint[i]) - values_old.as_uint[i]) / nMilisecondsLeftFromLastFrame;
-						values.as_uint[i] = static_cast<uint32_t>(values.as_uint[i] - fRatio * nMilisecondsLeft);
-					}
-				}
-			}
 			set_uniform_value(variable, values.as_uint, 16);
 			break;
 		case reshadefx::type::t_float:
 			get_uniform_value(variable, values.as_float, 16);
-			values_old = values;
 			preset.get(_loaded_effects[variable.effect_index].source_file.filename().u8string(), variable.name, values.as_float);
-			if (_is_in_between_presets_transition)
-			{
-				for (int i = 0; i < 16; i++)
-				{
-					auto fRatio = static_cast<float>(values.as_float[i] - values_old.as_float[i]) / nMilisecondsLeftFromLastFrame;
-					values.as_float[i] = static_cast<float>(values.as_float[i] - fRatio * nMilisecondsLeft);
-				}
-			}
 			set_uniform_value(variable, values.as_float, 16);
 			break;
 		}

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -79,8 +79,6 @@ reshade::runtime::runtime() :
 	_reload_key_data(),
 	_effects_key_data(),
 	_screenshot_key_data(),
-	_previous_preset_key_data(),
-	_next_preset_key_data(),
 	_screenshot_path(g_target_executable_path.parent_path())
 {
 	// Default shortcut PrtScrn
@@ -176,16 +174,6 @@ void reshade::runtime::on_present()
 
 		if (_input->is_key_pressed(_screenshot_key_data))
 			_should_save_screenshot = true;
-
-		bool bPreviousPresetKeyPressed = _input->is_key_pressed(_previous_preset_key_data);
-		bool bNextPresetKeyPressed = _input->is_key_pressed(_next_preset_key_data);
-		if (bPreviousPresetKeyPressed || bNextPresetKeyPressed)
-			if(switch_current_preset(bNextPresetKeyPressed))
-			{
-				set_current_preset();
-				save_config();
-				load_current_preset();
-			}
 	}
 
 #if RESHADE_GUI
@@ -894,8 +882,6 @@ void reshade::runtime::load_config()
 	config.get("INPUT", "KeyReload", _reload_key_data);
 	config.get("INPUT", "KeyEffects", _effects_key_data);
 	config.get("INPUT", "KeyScreenshot", _screenshot_key_data);
-	config.get("INPUT", "KeyPreviousPreset", _previous_preset_key_data);
-	config.get("INPUT", "KeyNextPreset", _next_preset_key_data);
 
 	config.get("GENERAL", "PerformanceMode", _performance_mode);
 	config.get("GENERAL", "EffectSearchPaths", _effect_search_paths);
@@ -935,8 +921,6 @@ void reshade::runtime::save_config(const std::filesystem::path &path) const
 	config.set("INPUT", "KeyReload", _reload_key_data);
 	config.set("INPUT", "KeyEffects", _effects_key_data);
 	config.set("INPUT", "KeyScreenshot", _screenshot_key_data);
-	config.set("INPUT", "KeyPreviousPreset", _previous_preset_key_data);
-	config.set("INPUT", "KeyNextPreset", _next_preset_key_data);
 
 	config.set("GENERAL", "PerformanceMode", _performance_mode);
 	config.set("GENERAL", "EffectSearchPaths", _effect_search_paths);

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -960,10 +960,6 @@ void reshade::runtime::load_config()
 	else
 		_current_preset_path = g_reshade_dll_path.parent_path() / current_preset_path;
 
-#if RESHADE_GUI
-	_current_browse_path = _current_preset_path.parent_path();
-#endif
-
 	for (const auto &callback : _load_config_callables)
 		callback(config);
 }
@@ -1038,8 +1034,7 @@ void reshade::runtime::load_preset(const std::filesystem::path &path)
 
 	for (uniform &variable : _uniforms)
 	{
-		reshadefx::constant values_old;
-		reshadefx::constant values;
+		reshadefx::constant values, values_old;
 
 		switch (variable.type.base)
 		{

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -177,10 +177,10 @@ void reshade::runtime::on_present()
 		if (_input->is_key_pressed(_screenshot_key_data))
 			_should_save_screenshot = true;
 
-		bool bPreviousPresetKeyPressed = _input->is_key_pressed(_previous_preset_key_data);
-		bool bNextPresetKeyPressed = _input->is_key_pressed(_next_preset_key_data);
-		if (bPreviousPresetKeyPressed || bNextPresetKeyPressed)
-			if(switch_to_next_preset(bPreviousPresetKeyPressed))
+		bool is_previous_preset_key_pressed = _input->is_key_pressed(_previous_preset_key_data);
+		bool is_next_preset_key_pressed = _input->is_key_pressed(_next_preset_key_data);
+		if (is_previous_preset_key_pressed || is_next_preset_key_pressed)
+			if(switch_to_next_preset(is_next_preset_key_pressed))
 			{
 				_last_preset_switching_time = current_time;
 				_is_in_between_presets_transition = true;
@@ -1010,12 +1010,12 @@ void reshade::runtime::load_preset(const std::filesystem::path &path)
 			       (std::find(sorted_technique_list.begin(), sorted_technique_list.end(), rhs.name) - sorted_technique_list.begin());
 		});
 
-	// compute time since the transition has started and how much is left till it should end
-	auto nMicrosecondsPassed = std::chrono::duration_cast<std::chrono::microseconds>(_last_present_time - _last_preset_switching_time).count();
-	auto nMilisecondsLeft = _preset_transition_delay - nMicrosecondsPassed / 1000;
-	auto nMilisecondsLeftFromLastFrame = nMilisecondsLeft + +std::chrono::duration_cast<std::chrono::microseconds>(_last_frame_duration).count() / 1000;
+	// compute times since the transition has started and how much left till it should end
+	auto n_microseconds_passed = std::chrono::duration_cast<std::chrono::microseconds>(_last_present_time - _last_preset_switching_time).count();
+	auto n_miliseconds_left = _preset_transition_delay - n_microseconds_passed / 1000;
+	auto n_miliseconds_left_from_last_frame = n_miliseconds_left + +std::chrono::duration_cast<std::chrono::microseconds>(_last_frame_duration).count() / 1000;
 
-	if (_is_in_between_presets_transition && nMilisecondsLeft <= 0)
+	if (_is_in_between_presets_transition && n_miliseconds_left <= 0)
 		_is_in_between_presets_transition = false;
 
 	for (uniform &variable : _uniforms)
@@ -1035,8 +1035,8 @@ void reshade::runtime::load_preset(const std::filesystem::path &path)
 				{
 					if (abs(values.as_int[i] - values_old.as_int[i]) > 1)
 					{
-						auto fRatio = static_cast<float>(values.as_int[i] - values_old.as_int[i]) / nMilisecondsLeftFromLastFrame;
-						values.as_int[i] = static_cast<int32_t>(values.as_int[i] - fRatio * nMilisecondsLeft);
+						auto f_ratio = static_cast<float>(values.as_int[i] - values_old.as_int[i]) / n_miliseconds_left_from_last_frame;
+						values.as_int[i] = static_cast<int32_t>(values.as_int[i] - f_ratio * n_miliseconds_left);
 					}
 				}
 			}
@@ -1053,8 +1053,8 @@ void reshade::runtime::load_preset(const std::filesystem::path &path)
 				{
 					if (abs(static_cast<float>(values.as_uint[i]) - values_old.as_uint[i]) > 1)
 					{
-						auto fRatio = (static_cast<float>(values.as_uint[i]) - values_old.as_uint[i]) / nMilisecondsLeftFromLastFrame;
-						values.as_uint[i] = static_cast<uint32_t>(values.as_uint[i] - fRatio * nMilisecondsLeft);
+						auto f_ratio = (static_cast<float>(values.as_uint[i]) - values_old.as_uint[i]) / n_miliseconds_left_from_last_frame;
+						values.as_uint[i] = static_cast<uint32_t>(values.as_uint[i] - f_ratio * n_miliseconds_left);
 					}
 				}
 			}
@@ -1068,8 +1068,8 @@ void reshade::runtime::load_preset(const std::filesystem::path &path)
 			{
 				for (int i = 0; i < 16; i++)
 				{
-					auto fRatio = static_cast<float>(values.as_float[i] - values_old.as_float[i]) / nMilisecondsLeftFromLastFrame;
-					values.as_float[i] = static_cast<float>(values.as_float[i] - fRatio * nMilisecondsLeft);
+					auto f_ratio = static_cast<float>(values.as_float[i] - values_old.as_float[i]) / n_miliseconds_left_from_last_frame;
+					values.as_float[i] = static_cast<float>(values.as_float[i] - f_ratio * n_miliseconds_left);
 				}
 			}
 			set_uniform_value(variable, values.as_float, 16);

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -274,6 +274,7 @@ namespace reshade
 		unsigned int _screenshot_key_data[4];
 		unsigned int _previous_preset_key_data[4];
 		unsigned int _next_preset_key_data[4];
+		int _preset_transition_delay = 1000; //miliseconds
 		int _screenshot_format = 1;
 		std::filesystem::path _screenshot_path;
 		std::filesystem::path _configuration_path;
@@ -294,6 +295,7 @@ namespace reshade
 		bool _no_reload_on_init = false;
 		bool _last_reload_successful = true;
 		bool _should_save_screenshot = false;
+		bool _is_in_between_presets_transition = false;
 		std::mutex _reload_mutex;
 		size_t _reload_total_effects = 1;
 		std::vector<size_t> _reload_compile_queue;
@@ -307,6 +309,7 @@ namespace reshade
 		std::chrono::high_resolution_clock::time_point _last_reload_time;
 		std::chrono::high_resolution_clock::time_point _last_present_time;
 		std::chrono::high_resolution_clock::time_point _last_screenshot_time;
+		std::chrono::high_resolution_clock::time_point _last_preset_switching_time;
 
 		std::vector<std::function<void(ini_file &)>> _save_config_callables;
 		std::vector<std::function<void(const ini_file &)>> _load_config_callables;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -272,9 +272,6 @@ namespace reshade
 		unsigned int _reload_key_data[4];
 		unsigned int _effects_key_data[4];
 		unsigned int _screenshot_key_data[4];
-		unsigned int _previous_preset_key_data[4];
-		unsigned int _next_preset_key_data[4];
-		int _preset_transition_delay = 1000; //miliseconds
 		int _screenshot_format = 1;
 		std::filesystem::path _screenshot_path;
 		std::filesystem::path _configuration_path;
@@ -295,7 +292,6 @@ namespace reshade
 		bool _no_reload_on_init = false;
 		bool _last_reload_successful = true;
 		bool _should_save_screenshot = false;
-		bool _is_in_between_presets_transition = false;
 		std::mutex _reload_mutex;
 		size_t _reload_total_effects = 1;
 		std::vector<size_t> _reload_compile_queue;
@@ -309,7 +305,6 @@ namespace reshade
 		std::chrono::high_resolution_clock::time_point _last_reload_time;
 		std::chrono::high_resolution_clock::time_point _last_present_time;
 		std::chrono::high_resolution_clock::time_point _last_screenshot_time;
-		std::chrono::high_resolution_clock::time_point _last_preset_switching_time;
 
 		std::vector<std::function<void(ini_file &)>> _save_config_callables;
 		std::vector<std::function<void(const ini_file &)>> _load_config_callables;
@@ -331,9 +326,6 @@ namespace reshade
 		void draw_overlay_variable_editor();
 		void draw_overlay_technique_editor();
 		void draw_preset_explorer();
-
-		void get_preset_container(std::vector<std::filesystem::directory_entry> &preset_container);
-		bool switch_current_preset(bool bToNext);
 
 		std::vector<std::pair<std::string, std::function<void()>>> _menu_callables;
 		std::unique_ptr<texture> _imgui_font_atlas;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -272,8 +272,6 @@ namespace reshade
 		unsigned int _reload_key_data[4];
 		unsigned int _effects_key_data[4];
 		unsigned int _screenshot_key_data[4];
-		unsigned int _previous_preset_key_data[4];
-		unsigned int _next_preset_key_data[4];
 		int _screenshot_format = 1;
 		std::filesystem::path _screenshot_path;
 		std::filesystem::path _configuration_path;
@@ -328,9 +326,6 @@ namespace reshade
 		void draw_overlay_variable_editor();
 		void draw_overlay_technique_editor();
 		void draw_preset_explorer();
-
-		void get_preset_container(std::vector<std::filesystem::directory_entry> &preset_container);
-		bool switch_current_preset(bool bToNext);
 
 		std::vector<std::pair<std::string, std::function<void()>>> _menu_callables;
 		std::unique_ptr<texture> _imgui_font_atlas;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -294,6 +294,8 @@ namespace reshade
 		bool _no_reload_on_init = false;
 		bool _last_reload_successful = true;
 		bool _should_save_screenshot = false;
+		bool _is_previous_preset_key_pressed = false;
+		bool _is_next_preset_key_pressed = false;
 		bool _is_in_between_presets_transition = false;
 		std::mutex _reload_mutex;
 		size_t _reload_total_effects = 1;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -272,6 +272,9 @@ namespace reshade
 		unsigned int _reload_key_data[4];
 		unsigned int _effects_key_data[4];
 		unsigned int _screenshot_key_data[4];
+		unsigned int _previous_preset_key_data[4];
+		unsigned int _next_preset_key_data[4];
+		int _preset_transition_delay = 1000; //miliseconds
 		int _screenshot_format = 1;
 		std::filesystem::path _screenshot_path;
 		std::filesystem::path _configuration_path;
@@ -292,6 +295,7 @@ namespace reshade
 		bool _no_reload_on_init = false;
 		bool _last_reload_successful = true;
 		bool _should_save_screenshot = false;
+		bool _is_in_between_presets_transition = false;
 		std::mutex _reload_mutex;
 		size_t _reload_total_effects = 1;
 		std::vector<size_t> _reload_compile_queue;
@@ -305,6 +309,7 @@ namespace reshade
 		std::chrono::high_resolution_clock::time_point _last_reload_time;
 		std::chrono::high_resolution_clock::time_point _last_present_time;
 		std::chrono::high_resolution_clock::time_point _last_screenshot_time;
+		std::chrono::high_resolution_clock::time_point _last_preset_switching_time;
 
 		std::vector<std::function<void(ini_file &)>> _save_config_callables;
 		std::vector<std::function<void(const ini_file &)>> _load_config_callables;
@@ -326,6 +331,9 @@ namespace reshade
 		void draw_overlay_variable_editor();
 		void draw_overlay_technique_editor();
 		void draw_preset_explorer();
+
+		void get_preset_container(std::vector<std::filesystem::directory_entry> &preset_container);
+		bool switch_current_preset(bool bToNext);
 
 		std::vector<std::pair<std::string, std::function<void()>>> _menu_callables;
 		std::unique_ptr<texture> _imgui_font_atlas;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -272,6 +272,8 @@ namespace reshade
 		unsigned int _reload_key_data[4];
 		unsigned int _effects_key_data[4];
 		unsigned int _screenshot_key_data[4];
+		unsigned int _previous_preset_key_data[4];
+		unsigned int _next_preset_key_data[4];
 		int _screenshot_format = 1;
 		std::filesystem::path _screenshot_path;
 		std::filesystem::path _configuration_path;
@@ -326,6 +328,9 @@ namespace reshade
 		void draw_overlay_variable_editor();
 		void draw_overlay_technique_editor();
 		void draw_preset_explorer();
+
+		void get_preset_container(std::vector<std::filesystem::directory_entry> &preset_container);
+		bool switch_current_preset(bool bToNext);
 
 		std::vector<std::pair<std::string, std::function<void()>>> _menu_callables;
 		std::unique_ptr<texture> _imgui_font_atlas;


### PR DESCRIPTION
Added shortcut keys for switching backward or forward between presets. They can be configured in the settings page jut below "Effect Toggle Key". Also the switching is no longer circular, It does not go directly from the last to the first preset anymore. For example: when using depth of field filter with manual focus and  want to quickly go to the last preset (or the first), it will no longer go circular if pressing the shortcut key once more by accident.
There aren't so many changes in code as the git is showing, because there was a re-indentation of a  big block of c ode (which I think I could avoid it in fact, sorry for that)