### PR TITLE
Change to displaying size bytes with binary prefix

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1302,8 +1302,8 @@ void reshade::runtime::draw_overlay_menu_statistics()
 
 			post_processing_memory_size += memory_size;
 
-			if (memory_size > 1024 * 1024) {
-				memory_view = std::ldiv(memory_size, 1024 * 1024);
+			if (memory_size > 1048576) {
+				memory_view = std::ldiv(memory_size, 1048576);
 				memory_view.rem /= 1000;
 				memory_size_unit = "MB";
 			}
@@ -1338,8 +1338,8 @@ void reshade::runtime::draw_overlay_menu_statistics()
 
 		ImGui::Separator();
 
-		if (post_processing_memory_size > 1024 * 1024) {
-			post_processing_memory_view = std::ldiv(post_processing_memory_size, 1024 * 1024);
+		if (post_processing_memory_size > 1048576) {
+			post_processing_memory_view = std::ldiv(post_processing_memory_size, 1048576);
 			post_processing_memory_view.rem /= 1000;
 			memory_size_unit = "MB";
 		}

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1313,7 +1313,7 @@ void reshade::runtime::draw_overlay_menu_statistics()
 			}
 
 			ImGui::TextUnformatted(texture.unique_name.c_str());
-			ImGui::Text("%ux%u +%u %s %ld.%03ld %s",
+			ImGui::Text("%ux%u +%u %s %ld.%03ld%s",
 				texture.width,
 				texture.height,
 				texture.levels - 1,
@@ -1348,7 +1348,7 @@ void reshade::runtime::draw_overlay_menu_statistics()
 			memory_size_unit = "KiB";
 		}
 
-		ImGui::Text("Total memory usage: %ld.%03ld %s", post_processing_memory_view.quot, post_processing_memory_view.rem, memory_size_unit);
+		ImGui::Text("Total memory usage: %ld.%03ld%s", post_processing_memory_view.quot, post_processing_memory_view.rem, memory_size_unit);
 	}
 }
 

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1302,14 +1302,14 @@ void reshade::runtime::draw_overlay_menu_statistics()
 
 			post_processing_memory_size += memory_size;
 
-			if (memory_size >= 1048576) {
-				memory_view = std::ldiv(memory_size, 1048576);
+			if (memory_size >= 1024 * 1024) {
+				memory_view = std::ldiv(memory_size, 1024 * 1024);
 				memory_view.rem /= 1000;
-				memory_size_unit = "MB";
+				memory_size_unit = "MiB";
 			}
 			else {
 				memory_view = std::ldiv(memory_size, 1024);
-				memory_size_unit = "KB";
+				memory_size_unit = "KiB";
 			}
 
 			ImGui::TextUnformatted(texture.unique_name.c_str());
@@ -1338,14 +1338,14 @@ void reshade::runtime::draw_overlay_menu_statistics()
 
 		ImGui::Separator();
 
-		if (post_processing_memory_size >= 1048576) {
-			post_processing_memory_view = std::ldiv(post_processing_memory_size, 1048576);
+		if (post_processing_memory_size >= 1024 * 1024) {
+			post_processing_memory_view = std::ldiv(post_processing_memory_size, 1024 * 1024);
 			post_processing_memory_view.rem /= 1000;
-			memory_size_unit = "MB";
+			memory_size_unit = "MiB";
 		}
 		else {
 			post_processing_memory_view = std::ldiv(post_processing_memory_size, 1024);
-			memory_size_unit = "KB";
+			memory_size_unit = "KiB";
 		}
 
 		ImGui::Text("Total memory usage: %ld.%03ld %s", post_processing_memory_view.quot, post_processing_memory_view.rem, memory_size_unit);

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1302,7 +1302,7 @@ void reshade::runtime::draw_overlay_menu_statistics()
 
 			post_processing_memory_size += memory_size;
 
-			if (memory_size > 1048576) {
+			if (memory_size >= 1048576) {
 				memory_view = std::ldiv(memory_size, 1048576);
 				memory_view.rem /= 1000;
 				memory_size_unit = "MB";

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1338,7 +1338,7 @@ void reshade::runtime::draw_overlay_menu_statistics()
 
 		ImGui::Separator();
 
-		if (post_processing_memory_size > 1048576) {
+		if (post_processing_memory_size >= 1048576) {
 			post_processing_memory_view = std::ldiv(post_processing_memory_size, 1048576);
 			post_processing_memory_view.rem /= 1000;
 			memory_size_unit = "MB";


### PR DESCRIPTION
Windows OS uses binary prefix.
![mbfile](https://user-images.githubusercontent.com/42232001/64471298-c312ec00-d18a-11e9-8e5d-81678b36a319.png)
