### PR TITLE
!!! BUGFIX !!! Force depth texture access to shader in d3d12

### DIFF
--- a/source/d3d10/d3d10_device.cpp
+++ b/source/d3d10/d3d10_device.cpp
@@ -52,7 +52,7 @@ bool D3D10Device::save_depth_texture(ID3D10DepthStencilView *pDepthStencilView, 
 	const float aspect_ratio = float(runtime->frame_width()) / float(runtime->frame_height());
 	const float texture_aspect_ratio = float(desc.Width) / float(desc.Height);
 
-	if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 2.0f || height_factor > 2.0f || width_factor < 0.5f || height_factor < 0.5f)
+	if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 1.85f || height_factor > 1.85f || width_factor < 0.5f || height_factor < 0.5f)
 		return false; // No match, not a good fit
 
 	// In case the depth texture is retrieved, we make a copy of it and store it in an ordered map to use it later in the final rendering stage.

--- a/source/d3d10/draw_call_tracker.cpp
+++ b/source/d3d10/draw_call_tracker.cpp
@@ -218,7 +218,7 @@ namespace reshade::d3d10
 			const float height_factor = desc.Height != height ? float(height) / desc.Height : 1.0f;
 			const float texture_aspect_ratio = float(desc.Width) / float(desc.Height);
 
-			if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 2.0f || height_factor > 2.0f || width_factor < 0.5f || height_factor < 0.5f)
+			if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 1.85f || height_factor > 1.85f || width_factor < 0.5f || height_factor < 0.5f)
 				continue; // No match, not a good fit
 
 			if (snapshot.stats.drawcalls >= best_snapshot.stats.drawcalls)

--- a/source/d3d11/d3d11_device_context.cpp
+++ b/source/d3d11/d3d11_device_context.cpp
@@ -70,7 +70,7 @@ bool D3D11DeviceContext::save_depth_texture(ID3D11DepthStencilView *pDepthStenci
 	const float aspect_ratio = float(runtime->frame_width()) / float(runtime->frame_height());
 	const float texture_aspect_ratio = float(desc.Width) / float(desc.Height);
 
-	if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 2.0f || height_factor > 2.0f || width_factor < 0.5f || height_factor < 0.5f)
+	if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 1.85f || height_factor > 1.85f || width_factor < 0.5f || height_factor < 0.5f)
 		return false; // No match, not a good fit
 
 	// In case the depth texture is retrieved, we make a copy of it and store it in an ordered map to use it later in the final rendering stage.

--- a/source/d3d11/draw_call_tracker.cpp
+++ b/source/d3d11/draw_call_tracker.cpp
@@ -218,7 +218,7 @@ namespace reshade::d3d11
 			const float height_factor = desc.Height != height ? float(height) / desc.Height : 1.0f;
 			const float texture_aspect_ratio = float(desc.Width) / float(desc.Height);
 
-			if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 2.0f || height_factor > 2.0f || width_factor < 0.5f || height_factor < 0.5f)
+			if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 1.85f || height_factor > 1.85f || width_factor < 0.5f || height_factor < 0.5f)
 				continue; // No match, not a good fit
 
 			if (snapshot.stats.drawcalls >= best_snapshot.stats.drawcalls)

--- a/source/d3d12/d3d12_device.cpp
+++ b/source/d3d12/d3d12_device.cpp
@@ -513,6 +513,8 @@ D3D12_HEAP_PROPERTIES STDMETHODCALLTYPE D3D12Device::GetCustomHeapProperties(UIN
 }
 HRESULT STDMETHODCALLTYPE D3D12Device::CreateCommittedResource(const D3D12_HEAP_PROPERTIES *pHeapProperties, D3D12_HEAP_FLAGS HeapFlags, const D3D12_RESOURCE_DESC *pResourceDesc, D3D12_RESOURCE_STATES InitialResourceState, const D3D12_CLEAR_VALUE *pOptimizedClearValue, REFIID riidResource, void **ppvResource)
 {
+	D3D12_RESOURCE_DESC new_desc = *pResourceDesc;
+	new_desc.Flags = new_desc.Flags & ~D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE;
 	return _orig->CreateCommittedResource(pHeapProperties, HeapFlags, pResourceDesc, InitialResourceState, pOptimizedClearValue, riidResource, ppvResource);
 }
 HRESULT STDMETHODCALLTYPE D3D12Device::CreateHeap(const D3D12_HEAP_DESC *pDesc, REFIID riid, void **ppvHeap)

--- a/source/d3d12/d3d12_device.cpp
+++ b/source/d3d12/d3d12_device.cpp
@@ -95,7 +95,7 @@ bool D3D12Device::save_depth_texture(ID3D12GraphicsCommandList * cmdList, reshad
 	const float aspect_ratio = float(runtime->frame_width()) / float(runtime->frame_height());
 	const float texture_aspect_ratio = float(desc.Width) / float(desc.Height);
 
-	if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 2.0f || height_factor > 2.0f || width_factor < 0.5f || height_factor < 0.5f)
+	if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 1.85f || height_factor > 1.85f || width_factor < 0.5f || height_factor < 0.5f)
 		return false; // No match, not a good fit
 
 	// In case the depth texture is retrieved, we make a copy of it and store it in an ordered map to use it later in the final rendering stage.
@@ -146,7 +146,7 @@ void D3D12Device::track_active_rendertargets(ID3D12GraphicsCommandList * cmdList
 	const float aspect_ratio = float(runtime->frame_width()) / float(runtime->frame_height());
 	const float texture_aspect_ratio = float(desc.Width) / float(desc.Height);
 
-	if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 2.0f || height_factor > 2.0f || width_factor < 0.5f || height_factor < 0.5f)
+	if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 1.85f || height_factor > 1.85f || width_factor < 0.5f || height_factor < 0.5f)
 		return; // No match, not a good fit
 
 	if (desc.SampleDesc.Count > 1)

--- a/source/d3d12/d3d12_device.cpp
+++ b/source/d3d12/d3d12_device.cpp
@@ -515,7 +515,7 @@ HRESULT STDMETHODCALLTYPE D3D12Device::CreateCommittedResource(const D3D12_HEAP_
 {
 	D3D12_RESOURCE_DESC new_desc = *pResourceDesc;
 	new_desc.Flags = new_desc.Flags & ~D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE;
-	return _orig->CreateCommittedResource(pHeapProperties, HeapFlags, pResourceDesc, InitialResourceState, pOptimizedClearValue, riidResource, ppvResource);
+	return _orig->CreateCommittedResource(pHeapProperties, HeapFlags, &new_desc, InitialResourceState, pOptimizedClearValue, riidResource, ppvResource);
 }
 HRESULT STDMETHODCALLTYPE D3D12Device::CreateHeap(const D3D12_HEAP_DESC *pDesc, REFIID riid, void **ppvHeap)
 {

--- a/source/d3d12/draw_call_tracker.cpp
+++ b/source/d3d12/draw_call_tracker.cpp
@@ -172,7 +172,7 @@ namespace reshade::d3d12
 			const float height_factor = float(height) / float(desc.Height);
 			const float texture_aspect_ratio = float(desc.Width) / float(desc.Height);
 
-			if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 2.0f || height_factor > 2.0f || width_factor < 0.5f || height_factor < 0.5f)
+			if (fabs(texture_aspect_ratio - aspect_ratio) > 0.1f || width_factor > 1.85f || height_factor > 1.85f || width_factor < 0.5f || height_factor < 0.5f)
 				continue; // No match, not a good fit
 
 			if (snapshot.stats.vertices >= best_snapshot.stats.vertices)


### PR DESCRIPTION
In some D3D12 games (for instance, FIFA 19), Reshade crashes when trying to create a graphic pipeline state, or a new shader resource view based on the depth image.

This is due to the fact that the depth image resource was created with the D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE flag. It not only disallows the shader access to this resource, it also crashes the CreateShaderResourceView method or the CreateGraphicsPipelineState method.

Now, FIFA 19 D3D12 has a proper access to depth buffer without crashing. As it is a Frostbite 3 game, maybe this fix can be usefull for some other D3D12 games ;-)

![FIFA_19_depth_map_1](https://user-images.githubusercontent.com/35728054/64596167-b4f3e400-d3b3-11e9-9431-e2e50163cff7.jpg)
![FIFA_19_depth_map_2](https://user-images.githubusercontent.com/35728054/64596169-b7eed480-d3b3-11e9-929a-02fee0e76644.jpg)
