### PR TITLE
Optimization Mode

### DIFF
--- a/source/effect_parser.cpp
+++ b/source/effect_parser.cpp
@@ -2367,10 +2367,6 @@ bool reshadefx::parser::parse_variable(type type, std::string name, bool global)
 
 			// Global variables that are not 'static' are always 'extern' and 'uniform'
 			type.qualifiers |= type::q_extern | type::q_uniform;
-
-			// It is invalid to make 'uniform' variables constant, since they can be modified externally
-			if (type.has(type::q_const))
-				return error(location, 3035, '\'' + name + "': variables which are 'uniform' cannot be declared 'const'"), false;
 		}
 	}
 	else
@@ -2570,7 +2566,7 @@ bool reshadefx::parser::parse_variable(type type, std::string name, bool global)
 
 	symbol symbol;
 
-	if (type.is_numeric() && type.has(type::q_const) && initializer.is_constant) // Variables with a constant initializer and constant type are named constants
+	if (type.is_numeric() && (type.has(type::q_const) && !type.has(type::q_uniform)) && initializer.is_constant) // Variables with a constant initializer and constant type are named constants
 	{
 		// Named constants are special symbols
 		symbol = { symbol_type::constant, 0, type, initializer.constant };

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2047,7 +2047,22 @@ void reshade::runtime::draw_overlay_variable_editor()
 
 		// A value has changed, so save the current preset
 		if (modified)
+		{
 			save_current_preset();
+
+			if (variable.type.has(reshadefx::type::q_const))
+			{
+				const std::filesystem::path source_file = _loaded_effects[variable.effect_index].source_file;
+
+				// Reload effect file
+				_textures_loaded = false;
+				_reload_total_effects = 1;
+				_reload_remaining_effects = 1;
+				unload_effect(variable.effect_index);
+				load_effect(source_file, variable.effect_index);
+				assert(_reload_remaining_effects == 0);
+			}
+		}
 	}
 
 	ImGui::PopItemWidth();

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -2052,6 +2052,8 @@ void reshade::runtime::draw_overlay_variable_editor()
 
 			if (variable.type.has(reshadefx::type::q_const))
 			{
+				ini_file::flush_cache(_current_preset_path);
+
 				const std::filesystem::path source_file = _loaded_effects[variable.effect_index].source_file;
 
 				// Reload effect file

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -329,7 +329,7 @@ void reshade::runtime::load_effect(const std::filesystem::path &path, size_t &ou
 	// Fill all specialization constants with values from the current preset
 	if (!_current_preset_path.empty() && effect.compile_sucess)
 	{
-		const ini_file &preset = ini_file::load_cache(_current_preset_path); // TODO: Require thread safety
+		const ini_file preset(_current_preset_path);
 		const std::string section(path.filename().u8string());
 
 		for (reshadefx::uniform_info &constant : effect.module.spec_constants)

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -327,9 +327,9 @@ void reshade::runtime::load_effect(const std::filesystem::path &path, size_t &ou
 	}
 
 	// Fill all specialization constants with values from the current preset
-	if (_performance_mode && !_current_preset_path.empty() && effect.compile_sucess)
+	if (!_current_preset_path.empty() && effect.compile_sucess)
 	{
-		const ini_file preset(_current_preset_path);
+		const ini_file &preset = ini_file::load_cache(_current_preset_path); // TODO: Require thread safety
 		const std::string section(path.filename().u8string());
 
 		for (reshadefx::uniform_info &constant : effect.module.spec_constants)


### PR DESCRIPTION
Add support `const uniform` syntax.
And I will add new ReShadeUI definition `__const_uniform`.

```hlsl
// Source code
__const_uniform int iLUT_Selector ...
```
```hlsl
// Result for supported version
const uniform int iLUT_Selector ...

// Result for unsupported version
uniform int iLUT_Selector ...
```