### PR TITLE
Add cache for effect

### DIFF
--- a/ReShadeFX.vcxproj
+++ b/ReShadeFX.vcxproj
@@ -150,6 +150,7 @@
     <ClInclude Include="source\effect_expression.hpp" />
     <ClInclude Include="source\effect_lexer.hpp" />
     <ClInclude Include="source\effect_parser.hpp" />
+    <ClInclude Include="source\effect_parser_injector.hpp" />
     <ClInclude Include="source\effect_preprocessor.hpp" />
     <ClInclude Include="source\effect_symbol_table.hpp" />
   </ItemGroup>

--- a/ReShadeFX.vcxproj.filters
+++ b/ReShadeFX.vcxproj.filters
@@ -15,6 +15,7 @@
     <ClInclude Include="source\effect_expression.hpp" />
     <ClInclude Include="source\effect_lexer.hpp" />
     <ClInclude Include="source\effect_parser.hpp" />
+    <ClInclude Include="source\effect_parser_injector.hpp" />
     <ClInclude Include="source\effect_preprocessor.hpp" />
     <ClInclude Include="source\effect_symbol_table.hpp" />
   </ItemGroup>

--- a/source/d3d10/runtime_d3d10.cpp
+++ b/source/d3d10/runtime_d3d10.cpp
@@ -642,7 +642,6 @@ bool reshade::d3d10::runtime_d3d10::compile_effect(effect_data &effect)
 	const auto D3DCompile = reinterpret_cast<pD3DCompile>(GetProcAddress(_d3d_compiler, "D3DCompile"));
 	const auto D3DDisassemble = reinterpret_cast<pD3DDisassemble>(GetProcAddress(_d3d_compiler, "D3DDisassemble"));
 
-	const std::string hlsl = effect.preamble + effect.module.hlsl;
 	std::unordered_map<std::string, com_ptr<IUnknown>> entry_points;
 
 	// Compile the generated HLSL source code to DX byte code
@@ -672,7 +671,7 @@ bool reshade::d3d10::runtime_d3d10::compile_effect(effect_data &effect)
 		}
 
 		HRESULT hr = D3DCompile(
-			hlsl.c_str(), hlsl.size(),
+			effect.module.hlsl.c_str(), effect.module.hlsl.size(),
 			nullptr, nullptr, nullptr,
 			entry_point.name.c_str(),
 			profile.c_str(),

--- a/source/d3d10/runtime_d3d10.cpp
+++ b/source/d3d10/runtime_d3d10.cpp
@@ -57,6 +57,7 @@ reshade::d3d10::runtime_d3d10::runtime_d3d10(ID3D10Device1 *device, IDXGISwapCha
 	dxgi_device->GetAdapter(&dxgi_adapter);
 
 	_renderer_id = device->GetFeatureLevel();
+	_renderer_name = "DX10";
 	if (DXGI_ADAPTER_DESC desc; SUCCEEDED(dxgi_adapter->GetDesc(&desc)))
 		_vendor_id = desc.VendorId, _device_id = desc.DeviceId;
 
@@ -670,29 +671,58 @@ bool reshade::d3d10::runtime_d3d10::compile_effect(effect_data &effect)
 			break;
 		}
 
-		HRESULT hr = D3DCompile(
-			effect.module.hlsl.c_str(), effect.module.hlsl.size(),
-			nullptr, nullptr, nullptr,
-			entry_point.name.c_str(),
-			profile.c_str(),
-			D3DCOMPILE_ENABLE_STRICTNESS | D3DCOMPILE_OPTIMIZATION_LEVEL3, 0,
-			&d3d_compiled, &d3d_errors);
+		std::string attributes;
+		attributes += "func=D3DCompile;";
+		attributes += "name=(null);defines=(null);include=(null);";
+		attributes += "entrypoint=" + entry_point.name + ';';
+		attributes += "profile=" + profile + ';';
+		attributes += "compile=" + std::to_string(D3DCOMPILE_ENABLE_STRICTNESS | D3DCOMPILE_OPTIMIZATION_LEVEL3) + ';';
+		attributes += "effect=0;";
 
-		if (d3d_errors != nullptr) // Append warnings to the output error string as well
-			effect.errors.append(static_cast<const char *>(d3d_errors->GetBufferPointer()), d3d_errors->GetBufferSize() - 1); // Subtracting one to not append the null-terminator as well
+		const void *buffer_pointer = nullptr;
+		size_t buffer_size = 0;
 
-		// No need to setup resources if any of the shaders failed to compile
-		if (FAILED(hr))
-			return false;
+		std::vector<char> cso;
+		if (load_shader_cache(effect.source_file, entry_point.name, effect.module.hlsl, attributes, cso))
+		{
+			buffer_pointer = cso.data();
+			buffer_size = cso.size();
+		}
+		else
+		{
+			HRESULT hr = D3DCompile(
+				effect.module.hlsl.c_str(), effect.module.hlsl.size(),
+				nullptr, nullptr, nullptr,
+				entry_point.name.c_str(),
+				profile.c_str(),
+				D3DCOMPILE_ENABLE_STRICTNESS | D3DCOMPILE_OPTIMIZATION_LEVEL3, 0,
+				&d3d_compiled, &d3d_errors);
 
-		if (com_ptr<ID3DBlob> d3d_disassembled; SUCCEEDED(D3DDisassemble(d3d_compiled->GetBufferPointer(), d3d_compiled->GetBufferSize(), 0, nullptr, &d3d_disassembled)))
+			if (d3d_errors != nullptr) // Append warnings to the output error string as well
+				effect.errors.append(static_cast<const char *>(d3d_errors->GetBufferPointer()), d3d_errors->GetBufferSize() - 1); // Subtracting one to not append the null-terminator as well
+
+			// No need to setup resources if any of the shaders failed to compile
+			if (FAILED(hr))
+				return false;
+
+			buffer_pointer = d3d_compiled->GetBufferPointer();
+			buffer_size = d3d_compiled->GetBufferSize();
+
+			cso.resize(buffer_size);
+			std::memcpy(cso.data(), buffer_pointer, buffer_size);
+
+			save_shader_cache(effect.source_file, entry_point.name, effect.module.hlsl, attributes, cso);
+		}
+
+		if (com_ptr<ID3DBlob> d3d_disassembled; SUCCEEDED(D3DDisassemble(buffer_pointer, buffer_size, 0, nullptr, &d3d_disassembled)))
 			entry_point.assembly = std::string(static_cast<const char *>(d3d_disassembled->GetBufferPointer()));
 
 		// Create runtime shader objects from the compiled DX byte code
+		HRESULT hr;
 		if (entry_point.is_pixel_shader)
-			hr = _device->CreatePixelShader(d3d_compiled->GetBufferPointer(), d3d_compiled->GetBufferSize(), reinterpret_cast<ID3D10PixelShader **>(&entry_points[entry_point.name]));
+			hr = _device->CreatePixelShader(buffer_pointer, buffer_size, reinterpret_cast<ID3D10PixelShader **>(&entry_points[entry_point.name]));
 		else
-			hr = _device->CreateVertexShader(d3d_compiled->GetBufferPointer(), d3d_compiled->GetBufferSize(), reinterpret_cast<ID3D10VertexShader **>(&entry_points[entry_point.name]));
+			hr = _device->CreateVertexShader(buffer_pointer, buffer_size, reinterpret_cast<ID3D10VertexShader **>(&entry_points[entry_point.name]));
 
 		if (FAILED(hr))
 		{

--- a/source/d3d11/runtime_d3d11.cpp
+++ b/source/d3d11/runtime_d3d11.cpp
@@ -59,6 +59,7 @@ reshade::d3d11::runtime_d3d11::runtime_d3d11(ID3D11Device *device, IDXGISwapChai
 	dxgi_device->GetAdapter(&dxgi_adapter);
 
 	_renderer_id = device->GetFeatureLevel();
+	_renderer_name = "DX11";
 	if (DXGI_ADAPTER_DESC desc; SUCCEEDED(dxgi_adapter->GetDesc(&desc)))
 		_vendor_id = desc.VendorId, _device_id = desc.DeviceId;
 
@@ -696,7 +697,7 @@ bool reshade::d3d11::runtime_d3d11::compile_effect(effect_data &effect)
 		size_t buffer_size = 0;
 
 		std::vector<char> cso;
-		if (load_shader_cache("D3D11", effect, entry_point.name, effect.module.hlsl, attributes, cso))
+		if (load_shader_cache(effect.source_file, entry_point.name, effect.module.hlsl, attributes, cso))
 		{
 			buffer_pointer = cso.data();
 			buffer_size = cso.size();
@@ -724,7 +725,7 @@ bool reshade::d3d11::runtime_d3d11::compile_effect(effect_data &effect)
 			cso.resize(buffer_size);
 			std::memcpy(cso.data(), buffer_pointer, buffer_size);
 
-			save_shader_cache("D3D11", effect, entry_point.name, effect.module.hlsl, attributes, cso);
+			save_shader_cache(effect.source_file, entry_point.name, effect.module.hlsl, attributes, cso);
 		}
 
 		if (com_ptr<ID3DBlob> d3d_disassembled; SUCCEEDED(D3DDisassemble(buffer_pointer, buffer_size, 0, nullptr, &d3d_disassembled)))

--- a/source/d3d11/runtime_d3d11.cpp
+++ b/source/d3d11/runtime_d3d11.cpp
@@ -696,8 +696,8 @@ bool reshade::d3d11::runtime_d3d11::compile_effect(effect_data &effect)
 		const void *buffer_pointer = nullptr;
 		size_t buffer_size = 0;
 
-		std::vector<uint8_t> cso;
-		if (load_shader_cache("d3d11", hlsl, attributes, cso))
+		std::vector<char> cso;
+		if (load_shader_cache("D3D11", effect, entry_point.name, hlsl, attributes, cso))
 		{
 			buffer_pointer = cso.data();
 			buffer_size = cso.size();
@@ -725,7 +725,7 @@ bool reshade::d3d11::runtime_d3d11::compile_effect(effect_data &effect)
 			cso.resize(buffer_size);
 			std::memcpy(cso.data(), buffer_pointer, buffer_size);
 
-			save_shader_cache("d3d11", hlsl, attributes, cso);
+			save_shader_cache("D3D11", effect, entry_point.name, hlsl, attributes, cso);
 		}
 
 		if (com_ptr<ID3DBlob> d3d_disassembled; SUCCEEDED(D3DDisassemble(buffer_pointer, buffer_size, 0, nullptr, &d3d_disassembled)))

--- a/source/d3d11/runtime_d3d11.cpp
+++ b/source/d3d11/runtime_d3d11.cpp
@@ -653,7 +653,6 @@ bool reshade::d3d11::runtime_d3d11::compile_effect(effect_data &effect)
 	const auto D3DCompile = reinterpret_cast<pD3DCompile>(GetProcAddress(_d3d_compiler, "D3DCompile"));
 	const auto D3DDisassemble = reinterpret_cast<pD3DDisassemble>(GetProcAddress(_d3d_compiler, "D3DDisassemble"));
 
-	const std::string hlsl = effect.preamble + effect.module.hlsl;
 	std::unordered_map<std::string, com_ptr<IUnknown>> entry_points;
 
 	// Compile the generated HLSL source code to DX byte code
@@ -697,7 +696,7 @@ bool reshade::d3d11::runtime_d3d11::compile_effect(effect_data &effect)
 		size_t buffer_size = 0;
 
 		std::vector<char> cso;
-		if (load_shader_cache("D3D11", effect, entry_point.name, hlsl, attributes, cso))
+		if (load_shader_cache("D3D11", effect, entry_point.name, effect.module.hlsl, attributes, cso))
 		{
 			buffer_pointer = cso.data();
 			buffer_size = cso.size();
@@ -705,7 +704,7 @@ bool reshade::d3d11::runtime_d3d11::compile_effect(effect_data &effect)
 		else
 		{
 			HRESULT hr = D3DCompile(
-				hlsl.c_str(), hlsl.size(),
+				effect.module.hlsl.c_str(), effect.module.hlsl.size(),
 				nullptr, nullptr, nullptr,
 				entry_point.name.c_str(),
 				profile.c_str(),
@@ -725,7 +724,7 @@ bool reshade::d3d11::runtime_d3d11::compile_effect(effect_data &effect)
 			cso.resize(buffer_size);
 			std::memcpy(cso.data(), buffer_pointer, buffer_size);
 
-			save_shader_cache("D3D11", effect, entry_point.name, hlsl, attributes, cso);
+			save_shader_cache("D3D11", effect, entry_point.name, effect.module.hlsl, attributes, cso);
 		}
 
 		if (com_ptr<ID3DBlob> d3d_disassembled; SUCCEEDED(D3DDisassemble(buffer_pointer, buffer_size, 0, nullptr, &d3d_disassembled)))

--- a/source/d3d12/runtime_d3d12.cpp
+++ b/source/d3d12/runtime_d3d12.cpp
@@ -814,7 +814,7 @@ bool reshade::d3d12::runtime_d3d12::compile_effect(effect_data &effect)
 			cso.resize(d3d_compiled->GetBufferSize());
 			std::memcpy(cso.data(), d3d_compiled->GetBufferPointer(), cso.size());
 
-			save_shader_cache(effect, entry_point.name, effect.module.hlsl, attributes, cso);
+			save_shader_cache(effect.source_file, entry_point.name, effect.module.hlsl, attributes, cso);
 		}
 
 		if (com_ptr<ID3DBlob> d3d_disassembled; SUCCEEDED(D3DDisassemble(cso.data(), cso.size(), 0, nullptr, &d3d_disassembled)))

--- a/source/d3d12/runtime_d3d12.cpp
+++ b/source/d3d12/runtime_d3d12.cpp
@@ -775,7 +775,6 @@ bool reshade::d3d12::runtime_d3d12::compile_effect(effect_data &effect)
 	const auto D3DCompile = reinterpret_cast<pD3DCompile>(GetProcAddress(_d3d_compiler, "D3DCompile"));
 	const auto D3DDisassemble = reinterpret_cast<pD3DDisassemble>(GetProcAddress(_d3d_compiler, "D3DDisassemble"));
 
-	const std::string hlsl = effect.preamble + effect.module.hlsl;
 	std::unordered_map<std::string, com_ptr<ID3DBlob>> entry_points;
 
 	// Compile the generated HLSL source code to DX byte code
@@ -785,7 +784,7 @@ bool reshade::d3d12::runtime_d3d12::compile_effect(effect_data &effect)
 		com_ptr<ID3DBlob> d3d_errors;
 
 		const HRESULT hr = D3DCompile(
-			hlsl.c_str(), hlsl.size(),
+			effect.module.hlsl.c_str(), effect.module.hlsl.size(),
 			nullptr, nullptr, nullptr,
 			entry_point.name.c_str(),
 			entry_point.is_pixel_shader ? "ps_5_0" : "vs_5_0",

--- a/source/d3d12/runtime_d3d12.hpp
+++ b/source/d3d12/runtime_d3d12.hpp
@@ -57,7 +57,7 @@ namespace reshade::d3d12
 		void unload_effect(size_t id) override;
 		void unload_effects() override;
 
-		bool init_technique(technique &technique, const std::unordered_map<std::string, com_ptr<ID3DBlob>> &entry_points);
+		bool init_technique(technique &technique, const std::unordered_map<std::string, std::vector<char>> &entry_points);
 
 		void render_technique(technique &technique) override;
 

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -721,13 +721,13 @@ bool reshade::d3d9::runtime_d3d9::compile_effect(effect_data &effect)
 	const auto D3DDisassemble = reinterpret_cast<pD3DDisassemble>(GetProcAddress(_d3d_compiler, "D3DDisassemble"));
 
 	// Add specialization constant defines to source code
-	effect.preamble += "#define COLOR_PIXEL_SIZE 1.0 / " + std::to_string(_width) + ", 1.0 / " + std::to_string(_height) + "\n"
+	const std::string defines = "#define COLOR_PIXEL_SIZE 1.0 / " + std::to_string(_width) + ", 1.0 / " + std::to_string(_height) + "\n"
 		"#define DEPTH_PIXEL_SIZE COLOR_PIXEL_SIZE\n"
 		"#define SV_TARGET_PIXEL_SIZE COLOR_PIXEL_SIZE\n"
 		"#define SV_DEPTH_PIXEL_SIZE COLOR_PIXEL_SIZE\n";
 
-	const std::string hlsl_vs = effect.preamble + effect.module.hlsl;
-	const std::string hlsl_ps = effect.preamble + "#define POSITION VPOS\n" + effect.module.hlsl;
+	const std::string hlsl_vs = defines + effect.module.hlsl;
+	const std::string hlsl_ps = defines + "#define POSITION VPOS\n" + effect.module.hlsl;
 
 	std::unordered_map<std::string, com_ptr<IUnknown>> entry_points;
 

--- a/source/d3d9/runtime_d3d9.cpp
+++ b/source/d3d9/runtime_d3d9.cpp
@@ -61,6 +61,7 @@ reshade::d3d9::runtime_d3d9::runtime_d3d9(IDirect3DDevice9 *device, IDirect3DSwa
 	_vendor_id = adapter_desc.VendorId;
 	_device_id = adapter_desc.DeviceId;
 	_renderer_id = 0x9000;
+	_renderer_name = "DX9";
 
 	_num_samplers = caps.MaxSimultaneousTextures;
 	_num_simultaneous_rendertargets = std::min(caps.NumSimultaneousRTs, DWORD(8));
@@ -739,29 +740,58 @@ bool reshade::d3d9::runtime_d3d9::compile_effect(effect_data &effect)
 		com_ptr<ID3DBlob> compiled, d3d_errors;
 		const std::string &hlsl = entry_point.is_pixel_shader ? hlsl_ps : hlsl_vs;
 
-		HRESULT hr = D3DCompile(
-			hlsl.c_str(), hlsl.size(),
-			nullptr, nullptr, nullptr,
-			entry_point.name.c_str(),
-			entry_point.is_pixel_shader ? "ps_3_0" : "vs_3_0",
-			D3DCOMPILE_OPTIMIZATION_LEVEL3, 0,
-			&compiled, &d3d_errors);
+		std::string attributes;
+		attributes += "func=D3DCompile;";
+		attributes += "name=(null);defines=(null);include=(null);";
+		attributes += "entrypoint=" + entry_point.name + ';';
+		attributes += "profile=" + entry_point.is_pixel_shader ? "ps_3_0;" : "vs_3_0;";
+		attributes += "compile=" + std::to_string(D3DCOMPILE_ENABLE_STRICTNESS | D3DCOMPILE_OPTIMIZATION_LEVEL3) + ';';
+		attributes += "effect=0;";
 
-		if (d3d_errors != nullptr) // Append warnings to the output error string as well
-			effect.errors.append(static_cast<const char *>(d3d_errors->GetBufferPointer()), d3d_errors->GetBufferSize() - 1); // Subtracting one to not append the null-terminator as well
+		const void *buffer_pointer = nullptr;
+		size_t buffer_size = 0;
 
-		// No need to setup resources if any of the shaders failed to compile
-		if (FAILED(hr))
-			return false;
+		std::vector<char> cso;
+		if (load_shader_cache(effect.source_file, entry_point.name, effect.module.hlsl, attributes, cso))
+		{
+			buffer_pointer = cso.data();
+			buffer_size = cso.size();
+		}
+		else
+		{
+			HRESULT hr = D3DCompile(
+				hlsl.c_str(), hlsl.size(),
+				nullptr, nullptr, nullptr,
+				entry_point.name.c_str(),
+				entry_point.is_pixel_shader ? "ps_3_0" : "vs_3_0",
+				D3DCOMPILE_OPTIMIZATION_LEVEL3, 0,
+				&compiled, &d3d_errors);
 
-		if (com_ptr<ID3DBlob> d3d_disassembled; SUCCEEDED(D3DDisassemble(compiled->GetBufferPointer(), compiled->GetBufferSize(), 0, nullptr, &d3d_disassembled)))
+			if (d3d_errors != nullptr) // Append warnings to the output error string as well
+				effect.errors.append(static_cast<const char *>(d3d_errors->GetBufferPointer()), d3d_errors->GetBufferSize() - 1); // Subtracting one to not append the null-terminator as well
+
+			// No need to setup resources if any of the shaders failed to compile
+			if (FAILED(hr))
+				return false;
+
+			buffer_pointer = compiled->GetBufferPointer();
+			buffer_size = compiled->GetBufferSize();
+
+			cso.resize(buffer_size);
+			std::memcpy(cso.data(), buffer_pointer, buffer_size);
+
+			save_shader_cache(effect.source_file, entry_point.name, effect.module.hlsl, attributes, cso);
+		}
+
+		if (com_ptr<ID3DBlob> d3d_disassembled; SUCCEEDED(D3DDisassemble(buffer_pointer, buffer_size, 0, nullptr, &d3d_disassembled)))
 			entry_point.assembly = std::string(static_cast<const char *>(d3d_disassembled->GetBufferPointer()));
 
 		// Create runtime shader objects from the compiled DX byte code
+		HRESULT hr;
 		if (entry_point.is_pixel_shader)
-			hr = _device->CreatePixelShader(static_cast<const DWORD *>(compiled->GetBufferPointer()), reinterpret_cast<IDirect3DPixelShader9 **>(&entry_points[entry_point.name]));
+			hr = _device->CreatePixelShader(static_cast<const DWORD *>(buffer_pointer), reinterpret_cast<IDirect3DPixelShader9 **>(&entry_points[entry_point.name]));
 		else
-			hr = _device->CreateVertexShader(static_cast<const DWORD *>(compiled->GetBufferPointer()), reinterpret_cast<IDirect3DVertexShader9 **>(&entry_points[entry_point.name]));
+			hr = _device->CreateVertexShader(static_cast<const DWORD *>(buffer_pointer), reinterpret_cast<IDirect3DVertexShader9 **>(&entry_points[entry_point.name]));
 
 		if (FAILED(hr))
 		{

--- a/source/effect_codegen.hpp
+++ b/source/effect_codegen.hpp
@@ -306,20 +306,17 @@ namespace reshadefx
 	/// Create a back-end implementation for GLSL code generation.
 	/// </summary>
 	/// <param name="debug_info">Whether to append debug information like line directives to the generated code.</param>
-	/// <param name="uniforms_to_spec_constants">Whether to convert uniform variables to specialization constants.</param>
-	codegen *create_codegen_glsl(bool debug_info, bool uniforms_to_spec_constants);
+	codegen *create_codegen_glsl(bool debug_info);
 	/// <summary>
 	/// Create a back-end implementation for HLSL code generation.
 	/// </summary>
 	/// <param name="shader_model">The HLSL shader model version (e.g. 30, 41, 50, 60, ...)</param>
 	/// <param name="debug_info">Whether to append debug information like line directives to the generated code.</param>
-	/// <param name="uniforms_to_spec_constants">Whether to convert uniform variables to specialization constants.</param>
-	codegen *create_codegen_hlsl(unsigned int shader_model, bool debug_info, bool uniforms_to_spec_constants);
+	codegen *create_codegen_hlsl(unsigned int shader_model, bool debug_info);
 	/// <summary>
 	/// Create a back-end implementation for SPIR-V code generation.
 	/// </summary>
 	/// <param name="vulkan_semantics">Generate SPIR-V for OpenGL or for Vulkan.</param>
 	/// <param name="debug_info">Whether to append debug information like line directives to the generated code.</param>
-	/// <param name="uniforms_to_spec_constants">Whether to convert uniform variables to specialization constants.</param>
-	codegen *create_codegen_spirv(bool vulkan_semantics, bool debug_info, bool uniforms_to_spec_constants);
+	codegen *create_codegen_spirv(bool vulkan_semantics, bool debug_info);
 }

--- a/source/effect_codegen_glsl.cpp
+++ b/source/effect_codegen_glsl.cpp
@@ -13,8 +13,8 @@ using namespace reshadefx;
 class codegen_glsl final : public codegen
 {
 public:
-	codegen_glsl(bool debug_info, bool uniforms_to_spec_constants)
-		: _debug_info(debug_info), _uniforms_to_spec_constants(uniforms_to_spec_constants)
+	codegen_glsl(bool debug_info)
+		: _debug_info(debug_info)
 	{
 		// Create default block and reserve a memory block to avoid frequent reallocations
 		std::string &block = _blocks.emplace(0, std::string()).first->second;
@@ -38,7 +38,6 @@ private:
 	std::unordered_map<id, std::string> _names;
 	std::unordered_map<id, std::string> _blocks;
 	bool _debug_info = false;
-	bool _uniforms_to_spec_constants = false;
 	unsigned int _current_ubo_offset = 0;
 	std::unordered_map<id, id> _remapped_sampler_variables;
 
@@ -343,7 +342,7 @@ private:
 
 		define_name<naming::unique>(res, "_Globals_" + info.name);
 
-		if (_uniforms_to_spec_constants && info.has_initializer_value)
+		if (info.type.has(type::q_const) && info.has_initializer_value)
 		{
 			std::string &code = _blocks.at(_current_block);
 
@@ -1437,7 +1436,7 @@ private:
 	}
 };
 
-codegen *reshadefx::create_codegen_glsl(bool debug_info, bool uniforms_to_spec_constants)
+codegen *reshadefx::create_codegen_glsl(bool debug_info)
 {
-	return new codegen_glsl(debug_info, uniforms_to_spec_constants);
+	return new codegen_glsl(debug_info);
 }

--- a/source/effect_codegen_glsl.cpp
+++ b/source/effect_codegen_glsl.cpp
@@ -351,9 +351,8 @@ private:
 			code += "const ";
 			write_type(code, info.type);
 			code += ' ' + id_to_name(res) + " = ";
-			if (!info.type.is_scalar())
-				write_type<false, false>(code, info.type);
-			code += "(SPEC_CONSTANT_" + info.name + ");\n";
+			write_constant(code, info.type, info.initializer_value);
+			code += ";\n";
 
 			_module.spec_constants.push_back(info);
 		}

--- a/source/effect_codegen_spirv.cpp
+++ b/source/effect_codegen_spirv.cpp
@@ -114,8 +114,8 @@ struct spirv_basic_block
 class codegen_spirv final : public codegen
 {
 public:
-	codegen_spirv(bool vulkan_semantics, bool debug_info, bool uniforms_to_spec_constants)
-		: _debug_info(debug_info), _vulkan_semantics(vulkan_semantics), _uniforms_to_spec_constants(uniforms_to_spec_constants)
+	codegen_spirv(bool vulkan_semantics, bool debug_info)
+		: _debug_info(debug_info), _vulkan_semantics(vulkan_semantics)
 	{
 		_glsl_ext = make_id();
 	}
@@ -599,7 +599,7 @@ private:
 	}
 	id   define_uniform(const location &, uniform_info &info) override
 	{
-		if (_uniforms_to_spec_constants && info.type.is_scalar() && info.has_initializer_value)
+		if (info.type.has(type::q_const) && info.type.is_scalar() && info.has_initializer_value)
 		{
 			const id res = emit_constant(info.type, info.initializer_value, true);
 
@@ -1939,7 +1939,7 @@ private:
 	}
 };
 
-codegen *reshadefx::create_codegen_spirv(bool vulkan_semantics, bool debug_info, bool uniforms_to_spec_constants)
+codegen *reshadefx::create_codegen_spirv(bool vulkan_semantics, bool debug_info)
 {
-	return new codegen_spirv(vulkan_semantics, debug_info, uniforms_to_spec_constants);
+	return new codegen_spirv(vulkan_semantics, debug_info);
 }

--- a/source/effect_parser.cpp
+++ b/source/effect_parser.cpp
@@ -2570,12 +2570,7 @@ bool reshadefx::parser::parse_variable(type type, std::string name, bool global)
 
 	symbol symbol;
 
-	if (type.is_numeric() && type.has(type::q_const) && initializer.is_constant) // Variables with a constant initializer and constant type are named constants
-	{
-		// Named constants are special symbols
-		symbol = { symbol_type::constant, 0, type, initializer.constant };
-	}
-	else if (type.is_texture())
+	if (type.is_texture())
 	{
 		assert(global);
 
@@ -2615,8 +2610,15 @@ bool reshadefx::parser::parse_variable(type type, std::string name, bool global)
 		uniform_info.initializer_value = std::move(initializer.constant);
 		uniform_info.has_initializer_value = initializer.is_constant;
 
+		_effect_parser_injector.emit_uniform_definition(uniform_info);
+
 		symbol = { symbol_type::variable, 0, type };
 		symbol.id = _codegen->define_uniform(location, uniform_info);
+	}
+	else if (type.is_numeric() && type.has(type::q_const) && initializer.is_constant) // Variables with a constant initializer and constant type are named constants
+	{
+		// Named constants are special symbols
+		symbol = { symbol_type::constant, 0, type, initializer.constant };
 	}
 	else // All other variables are separate entities
 	{

--- a/source/effect_parser.hpp
+++ b/source/effect_parser.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "effect_lexer.hpp"
+#include "effect_parser_injector.hpp"
 #include "effect_symbol_table.hpp"
 #include <memory>
 
@@ -30,6 +31,8 @@ namespace reshadefx
 		/// </summary>
 		std::string &errors() { return _errors; }
 		const std::string &errors() const { return _errors; }
+
+		void set_injector(const reshadefx::effect_parser_injector &effect_parser_injector) { _effect_parser_injector = effect_parser_injector; }
 
 	private:
 		void error(const location &location, unsigned int code, const std::string &message);
@@ -85,5 +88,7 @@ namespace reshadefx
 		std::vector<uint32_t> _loop_break_target_stack;
 		std::vector<uint32_t> _loop_continue_target_stack;
 		type _current_return_type;
+
+		reshadefx::effect_parser_injector _effect_parser_injector;
 	};
 }

--- a/source/effect_parser_injector.hpp
+++ b/source/effect_parser_injector.hpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2014 Patrick Mours. All rights reserved.
+ * License: https://github.com/crosire/reshade#license
+ */
+
+#pragma once
+
+#include "effect_parser.hpp"
+#include <vector>
+#include <functional>
+
+namespace reshadefx
+{
+	/// <summary>
+	/// A parser for the ReShade FX shader language.
+	/// </summary>
+	class effect_parser_injector
+	{
+	public:
+		void subscribe_uniform_definition(std::function<void(reshadefx::uniform_info &)> function) { _uniform_info_callables.push_back(function); }
+		void emit_uniform_definition(reshadefx::uniform_info &uniform_info) { for (auto &callback : _uniform_info_callables) { callback(uniform_info); } }
+
+	private:
+		std::vector<std::function<void(reshadefx::uniform_info &)>> _uniform_info_callables;
+	};
+}

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1599,7 +1599,7 @@ void reshade::runtime::draw_code_editor()
 		_reload_total_effects = 1;
 		_reload_remaining_effects = 1;
 		unload_effect(_selected_effect);
-		load_effect(source_file, _selected_effect);
+		load_effect(ini_file::load_cache(_current_preset_path), source_file, _selected_effect); // Copy is not required because this is runs synchronously.
 		assert(_reload_remaining_effects == 0);
 
 		// Reloading an effect file invalidates all textures, but the statistics window may already have drawn references to those, so need to reset it

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1599,7 +1599,7 @@ void reshade::runtime::draw_code_editor()
 		_reload_total_effects = 1;
 		_reload_remaining_effects = 1;
 		unload_effect(_selected_effect);
-		load_effect(ini_file::load_cache(_current_preset_path), source_file, _selected_effect); // Copy is not required because this is runs synchronously.
+		load_effect(ini_file::load_cache(_current_preset_path), _loaded_effects[_selected_effect], _selected_effect); // Copy is not required because this is runs synchronously.
 		assert(_reload_remaining_effects == 0);
 
 		// Reloading an effect file invalidates all textures, but the statistics window may already have drawn references to those, so need to reset it
@@ -2215,7 +2215,7 @@ void reshade::runtime::draw_overlay_technique_editor()
 			{
 				std::string source_code;
 				if (condition == condition::input)
-					source_code = effect.preamble + effect.module.hlsl;
+					source_code = effect.module.hlsl;
 				else if (condition == condition::output)
 					source_code = effect.module.entry_points[selected_index].assembly;
 

--- a/source/opengl/runtime_gl.cpp
+++ b/source/opengl/runtime_gl.cpp
@@ -559,8 +559,6 @@ bool reshade::opengl::runtime_gl::compile_effect(effect_data &effect)
 		spec_constants.push_back(constant.offset);
 		spec_constant_values.push_back(constant.initializer_value.as_uint[0]);
 	}
-#else
-	effect.preamble = "#version 430\n" + effect.preamble;
 #endif
 
 	std::unordered_map<std::string, GLuint> entry_points;
@@ -575,8 +573,7 @@ bool reshade::opengl::runtime_gl::compile_effect(effect_data &effect)
 		glShaderBinary(1, &shader_id, GL_SHADER_BINARY_FORMAT_SPIR_V, effect.module.spirv.data(), effect.module.spirv.size() * sizeof(uint32_t));
 		glSpecializeShader(shader_id, entry_point.first.c_str(), GLuint(spec_constants.size()), spec_constants.data(), spec_constant_values.data());
 #else
-		std::string defines = effect.preamble;
-		defines += "#define ENTRY_POINT_" + entry_point.name + " 1\n";
+		std::string defines = "#version 430\n#define ENTRY_POINT_" + entry_point.name + " 1\n";
 		if (!entry_point.is_pixel_shader) // OpenGL does not allow using 'discard' in the vertex shader profile
 			defines += "#define discard\n"
 				"#define dFdx(x) x\n" // 'dFdx', 'dFdx' and 'fwidth' too are only available in fragment shaders

--- a/source/opengl/runtime_gl.cpp
+++ b/source/opengl/runtime_gl.cpp
@@ -79,6 +79,7 @@ reshade::opengl::runtime_gl::runtime_gl()
 	glGetIntegerv(GL_MAJOR_VERSION, &major);
 	glGetIntegerv(GL_MAJOR_VERSION, &minor);
 	_renderer_id = 0x10000 | (major << 12) | (minor << 8);
+	_renderer_name = "OpenGL";
 
 	// Query vendor and device ID from Windows assuming we are running on the primary display device
 	// This is done because the information reported by OpenGL is not always reflecting the actual rendering device (e.g. on NVIDIA Optimus laptops)

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -547,7 +547,7 @@ void reshade::runtime::load_effects()
 
 	// Keep track of the spawned threads, so the runtime cannot be destroyed while they are still running
 	for (size_t n = 0; n < num_splits; ++n)
-		_worker_threads.emplace_back([this, &preset, effect_files, num_splits, n]() mutable {
+		_worker_threads.emplace_back([this, preset, effect_files, num_splits, n]() mutable {
 			for (size_t id, i = 0; i < effect_files.size(); ++i)
 				if (i * num_splits / effect_files.size() == n)
 					load_effect(preset, effect_files[i], id);

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -312,7 +312,7 @@ void reshade::runtime::load_effect(const reshade::ini_file &preset, const std::f
 		{
 			attributes += include.u8string() + '=';
 			for (const auto &entry : std::filesystem::directory_iterator(include, ec))
-				if (const auto filename = entry.path().filename(); filename.extension() == L".fx" || filename.extension() == L".fxh")
+				if (const auto filename = entry.path().filename(); filename.extension() == L".fxh" || (filename.extension() == L".fx" && std::filesystem::equivalent(entry, path, ec)))
 					attributes += filename.u8string() + '?' + std::to_string(entry.last_write_time(ec).time_since_epoch().count()) + ',';
 
 			attributes.resize(attributes.size() - 1);

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -323,12 +323,7 @@ void reshade::runtime::load_effect(const reshade::ini_file &preset, reshade::eff
 			pp.add_macro_definition(macro.first, macro.second);
 		}
 
-		if (const size_t cache_id = std::hash<std::string>()(attributes); effect.cache_id == cache_id)
-		{
-			auto a = 0;
-			a = 1;
-		}
-		else
+		if (const size_t cache_id = std::hash<std::string>()(attributes); effect.cache_id != cache_id)
 		{
 			std::string source;
 			if (load_source_cache(effect.source_file, cache_id, source))
@@ -909,8 +904,8 @@ bool reshade::runtime::load_source_cache(const std::filesystem::path &effect, co
 {
 	std::error_code ec;
 
-	std::filesystem::path path = g_reshade_dll_path.parent_path() / L"reshade-shaders" / L"Intermediate" / effect.stem();
-	path += "-" + std::to_string(hash) + ".hlsl";
+	std::filesystem::path path = g_reshade_dll_path.parent_path() / L"reshade-shaders" / L"Intermediate";
+	path /= _renderer_name + '-' + effect.stem().u8string() + '-' + std::to_string(hash) + ".hlsl";
 
 	if (const uintmax_t size = std::filesystem::file_size(path, ec); ec.value() == 0)
 		if (std::ifstream file(path, std::ios::in | std::ios::binary); file.is_open())
@@ -920,8 +915,8 @@ bool reshade::runtime::load_source_cache(const std::filesystem::path &effect, co
 }
 bool reshade::runtime::save_source_cache(const std::filesystem::path &effect, const size_t hash, const std::string &source)
 {
-	std::filesystem::path path = g_reshade_dll_path.parent_path() / L"reshade-shaders" / L"Intermediate" / effect.stem();
-	path += "-" + std::to_string(hash) + ".hlsl";
+	std::filesystem::path path = g_reshade_dll_path.parent_path() / L"reshade-shaders" / "Intermediate";
+	path /= _renderer_name + '-' + effect.stem().u8string() + '-'+ std::to_string(hash) + ".hlsl";
 
 	if (std::ofstream file(path, std::ios::out | std::ios::binary); file.is_open())
 		return file.write(source.data(), source.size()), true;
@@ -929,13 +924,13 @@ bool reshade::runtime::save_source_cache(const std::filesystem::path &effect, co
 	return false;
 }
 
-bool reshade::runtime::load_shader_cache(const std::string &renderer, const reshade::effect_data &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, std::vector<char> &cso)
+bool reshade::runtime::load_shader_cache(const std::filesystem::path &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, std::vector<char> &cso)
 {
 	std::hash<std::string> hasher;
 	std::error_code ec;
 
 	std::filesystem::path path = g_reshade_dll_path.parent_path() / L"reshade-shaders" / L"Intermediate";
-	path /= renderer + '-' + effect.source_file.stem().u8string() + '-' + entry_point + '-' + std::to_string(hasher(hlsl) ^ hasher(attributes)) + ".cso";
+	path /= _renderer_name + '-' + effect.stem().u8string() + '-' + entry_point + '-' + std::to_string(hasher(hlsl) ^ hasher(attributes)) + ".cso";
 
 	if (const uintmax_t size = std::filesystem::file_size(path, ec); ec.value() == 0)
 		if (std::ifstream file(path, std::ios::in | std::ios::binary); file.is_open())
@@ -943,12 +938,12 @@ bool reshade::runtime::load_shader_cache(const std::string &renderer, const resh
 
 	return false;
 }
-bool reshade::runtime::save_shader_cache(const std::string &renderer, const reshade::effect_data &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, const std::vector<char> &cso)
+bool reshade::runtime::save_shader_cache(const std::filesystem::path &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, const std::vector<char> &cso)
 {
 	std::hash<std::string> hasher;
 
 	std::filesystem::path path = g_reshade_dll_path.parent_path() / L"reshade-shaders" / L"Intermediate";
-	path /= renderer + '-' + effect.source_file.stem().u8string() + '-' + entry_point + '-' + std::to_string(hasher(hlsl) ^ hasher(attributes)) + ".cso";
+	path /= _renderer_name + '-' + effect.stem().u8string() + '-' + entry_point + '-' + std::to_string(hasher(hlsl) ^ hasher(attributes)) + ".cso";
 
 	if (std::ofstream file(path, std::ios::out | std::ios::binary); file.is_open())
 		return file.write(cso.data(), cso.size()), true;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -137,10 +137,10 @@ namespace reshade
 		/// <summary>
 		/// Compile effect from the specified source file and initialize textures, uniforms and techniques.
 		/// </summary>
-		/// <param name="path">Current preset for compilation.</param>
-		/// <param name="path">The path to an effect source code file.</param>
+		/// <param name="preset">Current preset for compilation.</param>
+		/// <param name="effect">The path to an effect source code file.</param>
 		/// <param name="out_id">The ID of the effect.</param>
-		void load_effect(const reshade::ini_file &preset, const std::filesystem::path &path, size_t &out_id);
+		void load_effect(const reshade::ini_file &preset, reshade::effect_data &effect, size_t &out_id);
 		/// <summary>
 		/// Load all effects found in the effect search paths.
 		/// </summary>
@@ -170,8 +170,8 @@ namespace reshade
 		/// </summary>
 		void update_and_render_effects();
 
-		bool load_source_cache(const std::filesystem::path &effect, const std::string &attributes, std::string &source);
-		bool save_source_cache(const std::filesystem::path &effect, const std::string &attributes, const std::string &source);
+		bool load_source_cache(const std::filesystem::path &effect, const size_t hash, std::string &source);
+		bool save_source_cache(const std::filesystem::path &effect, const size_t hash, const std::string &source);
 
 		bool load_shader_cache(const std::string &renderer, const reshade::effect_data &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, std::vector<char> &cso);
 		bool save_shader_cache(const std::string &renderer, const reshade::effect_data &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, const std::vector<char> &cso);
@@ -299,6 +299,7 @@ namespace reshade
 		std::vector<size_t> _reload_compile_queue;
 		std::atomic<size_t> _reload_remaining_effects = 0;
 		std::vector<effect_data> _loaded_effects;
+		std::unordered_map<std::wstring, effect_data> _recent_effects;
 		std::vector<std::thread> _worker_threads;
 
 		int _date[4] = {};

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -168,6 +168,10 @@ namespace reshade
 		/// Apply post-processing effects to the frame.
 		/// </summary>
 		void update_and_render_effects();
+
+		bool load_shader_cache(const std::string &renderer, const std::string &hlsl, const std::string &attributes, std::vector<uint8_t> &cso);
+		bool save_shader_cache(const std::string &renderer, const std::string &hlsl, const std::string &attributes, std::vector<uint8_t> &cso);
+
 		/// <summary>
 		/// Render all passes in a technique.
 		/// </summary>

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -173,8 +173,8 @@ namespace reshade
 		bool load_source_cache(const std::filesystem::path &effect, const size_t hash, std::string &source);
 		bool save_source_cache(const std::filesystem::path &effect, const size_t hash, const std::string &source);
 
-		bool load_shader_cache(const std::string &renderer, const reshade::effect_data &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, std::vector<char> &cso);
-		bool save_shader_cache(const std::string &renderer, const reshade::effect_data &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, const std::vector<char> &cso);
+		bool load_shader_cache(const std::filesystem::path &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, std::vector<char> &cso);
+		bool save_shader_cache(const std::filesystem::path &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, const std::vector<char> &cso);
 
 		/// <summary>
 		/// Render all passes in a technique.
@@ -198,6 +198,7 @@ namespace reshade
 		unsigned int _vendor_id = 0;
 		unsigned int _device_id = 0;
 		unsigned int _renderer_id = 0;
+		std::string _renderer_name;
 		unsigned int _backbuffer_color_depth = 8;
 		uint64_t _framecount = 0;
 		unsigned int _vertices = 0;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -137,9 +137,10 @@ namespace reshade
 		/// <summary>
 		/// Compile effect from the specified source file and initialize textures, uniforms and techniques.
 		/// </summary>
+		/// <param name="path">Current preset for compilation.</param>
 		/// <param name="path">The path to an effect source code file.</param>
 		/// <param name="out_id">The ID of the effect.</param>
-		void load_effect(const std::filesystem::path &path, size_t &out_id);
+		void load_effect(const reshade::ini_file &preset, const std::filesystem::path &path, size_t &out_id);
 		/// <summary>
 		/// Load all effects found in the effect search paths.
 		/// </summary>
@@ -169,8 +170,11 @@ namespace reshade
 		/// </summary>
 		void update_and_render_effects();
 
-		bool load_shader_cache(const std::string &renderer, const std::string &hlsl, const std::string &attributes, std::vector<uint8_t> &cso);
-		bool save_shader_cache(const std::string &renderer, const std::string &hlsl, const std::string &attributes, std::vector<uint8_t> &cso);
+		bool load_source_cache(const std::filesystem::path &effect, const std::string &attributes, std::string &source);
+		bool save_source_cache(const std::filesystem::path &effect, const std::string &attributes, const std::string &source);
+
+		bool load_shader_cache(const std::string &renderer, const reshade::effect_data &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, std::vector<char> &cso);
+		bool save_shader_cache(const std::string &renderer, const reshade::effect_data &effect, const std::string &entry_point, const std::string &hlsl, const std::string &attributes, const std::vector<char> &cso);
 
 		/// <summary>
 		/// Render all passes in a technique.

--- a/source/runtime_objects.hpp
+++ b/source/runtime_objects.hpp
@@ -51,9 +51,9 @@ namespace reshade
 		bool compile_sucess = false;
 		bool runtime_loaded = false;
 		std::string errors;
-		std::string preamble;
 		reshadefx::module module;
 		std::filesystem::path source_file;
+		size_t cache_id = 0;
 		size_t storage_offset = 0, storage_size = 0;
 	};
 

--- a/source/runtime_objects.hpp
+++ b/source/runtime_objects.hpp
@@ -53,7 +53,7 @@ namespace reshade
 		std::string errors;
 		reshadefx::module module;
 		std::filesystem::path source_file;
-		size_t cache_id = 0;
+		size_t source_id = 0;
 		size_t storage_offset = 0, storage_size = 0;
 	};
 

--- a/source/vulkan/runtime_vk.cpp
+++ b/source/vulkan/runtime_vk.cpp
@@ -85,6 +85,7 @@ reshade::vulkan::runtime_vk::runtime_vk(VkDevice device, VkPhysicalDevice physic
 	_device(device), _physical_device(physical_device), vk(device_table)
 {
 	_renderer_id = 0x20000;
+	_renderer_name = "Vulkan";
 
 	instance_table.GetPhysicalDeviceMemoryProperties(physical_device, &_memory_props);
 

--- a/tools/fxc.cpp
+++ b/tools/fxc.cpp
@@ -151,11 +151,11 @@ int main(int argc, char *argv[])
 
 	std::unique_ptr<reshadefx::codegen> backend;
 	if (print_glsl)
-		backend.reset(reshadefx::create_codegen_glsl(debug_info, false));
+		backend.reset(reshadefx::create_codegen_glsl(debug_info));
 	else if (print_hlsl)
-		backend.reset(reshadefx::create_codegen_hlsl(shader_model, debug_info, false));
+		backend.reset(reshadefx::create_codegen_hlsl(shader_model, debug_info));
 	else
-		backend.reset(reshadefx::create_codegen_spirv(true, debug_info, false));
+		backend.reset(reshadefx::create_codegen_spirv(true, debug_info));
 
 	if (!parser.parse(pp.output(), backend.get()))
 	{


### PR DESCRIPTION
This pull request has following changes:
* Cache preprocessed effect files. (It is about the "Generated HLSL".)
* Cache compiled effects.

Total time of loading 161 effects in my PC:
(preprocess & parse time) + (compile time) = (Total time until display splash screen)
First load (no cache): 12.3 sec + 20.7 sec = 33.0 sec
~Second load (cached): 6.8 sec + 3.1 sec = 9.9 sec~
Second load (cached): 2.5 sec + 2.7 sec = 5.2 sec (https://github.com/crosire/reshade/pull/154/commits/3b66b11e9a6668a4c1138b86f22ba01f89fd61b8)