### PR TITLE
fix issues with building on gcc

### DIFF
--- a/source/effect_expression.cpp
+++ b/source/effect_expression.cpp
@@ -5,7 +5,7 @@
 
 #include "effect_lexer.hpp"
 #include "effect_codegen.hpp"
-#include <cmath> // fmodf
+#include <cmath> // fmod
 #include <cassert>
 #include <cstring> // memcpy, memset
 #include <algorithm> // std::min, std::max
@@ -310,7 +310,7 @@ bool reshadefx::expression::evaluate_constant_expression(reshadefx::tokenid op, 
 				if (rhs.as_float[i] == 0)
 					constant.as_float[i] = std::numeric_limits<float>::quiet_NaN();
 				else
-					constant.as_float[i] = std::fmodf(constant.as_float[i], rhs.as_float[i]);
+					constant.as_float[i] = std::fmod(constant.as_float[i], rhs.as_float[i]);
 		}
 		else if (type.is_signed()) {
 			for (unsigned int i = 0; i < type.components(); ++i)

--- a/source/effect_preprocessor.cpp
+++ b/source/effect_preprocessor.cpp
@@ -126,7 +126,11 @@ bool reshadefx::preprocessor::append_file(const std::filesystem::path &path)
 
 	_success = true; // Clear success flag before parsing a new file
 
+#ifdef _WIN32
 	push(std::move(data), path.u8string());
+#else
+	push(std::move(data), path.string());
+#endif
 	parse();
 
 	return _success;
@@ -619,7 +623,11 @@ void reshadefx::preprocessor::parse_include()
 			if (std::filesystem::exists(filepath = include_path / filename, ec))
 				break;
 
+#ifdef _WIN32
 	const std::string filepath_string = filepath.u8string();
+#else
+	const std::string filepath_string = filepath.string();
+#endif
 
 	// Detect recursive include and abort to avoid infinite loop
 	if (std::find_if(_input_stack.begin(), _input_stack.end(),


### PR DESCRIPTION
std::fmod with float arguments should be the same as std::fmodf, for some reason gcc has no std::fmodf.
