### PR TITLE
Fix gcc warnings

### DIFF
--- a/source/effect_codegen_spirv.cpp
+++ b/source/effect_codegen_spirv.cpp
@@ -1138,6 +1138,8 @@ private:
 						assert(op.from.is_integral());
 						spv_op = op.from.is_signed() ? spv::OpConvertSToF : spv::OpConvertUToF;
 						break;
+					default:
+						break;
 					}
 
 					result = add_instruction(spv_op, convert_type(op.to))
@@ -1246,6 +1248,8 @@ private:
 					break;
 				}
 				assert(false);
+				break;
+			default:
 				break;
 			}
 		}
@@ -1358,6 +1362,8 @@ private:
 					}
 					break;
 				}
+				default:
+					break;
 			}
 		}
 

--- a/source/effect_expression.cpp
+++ b/source/effect_expression.cpp
@@ -345,6 +345,8 @@ bool reshadefx::expression::evaluate_constant_expression(reshadefx::tokenid op)
 		for (unsigned int i = 0; i < type.components(); ++i)
 			constant.as_uint[i] = ~constant.as_uint[i];
 		break;
+	default:
+		break;
 	}
 
 	return true;
@@ -518,6 +520,8 @@ bool reshadefx::expression::evaluate_constant_expression(reshadefx::tokenid op, 
 		else
 			for (unsigned int i = 0; i < type.components(); ++i)
 				constant.as_uint[i] >>= rhs.as_uint[i];
+		break;
+	default:
 		break;
 	}
 

--- a/source/effect_expression.cpp
+++ b/source/effect_expression.cpp
@@ -209,7 +209,7 @@ void reshadefx::expression::add_cast_operation(const reshadefx::type &cast_type)
 	{
 		assert(!type.is_array() && !cast_type.is_array());
 
-		chain.push_back({ operation::op_cast, type, cast_type });
+		chain.push_back({ operation::op_cast, type, cast_type, 0, { 0 } });
 	}
 
 	type = cast_type;
@@ -218,7 +218,7 @@ void reshadefx::expression::add_member_access(unsigned int index, const reshadef
 {
 	assert(type.is_struct());
 
-	chain.push_back({ operation::op_member, type, in_type, index });
+	chain.push_back({ operation::op_member, type, in_type, index, { 0 } });
 
 	// The type is now the type of the member that was accessed
 	type = in_type;
@@ -244,7 +244,7 @@ void reshadefx::expression::add_dynamic_index_access(uint32_t index_expression)
 		type.rows = 1;
 	}
 
-	chain.push_back({ operation::op_dynamic_index, prev_type, type, index_expression });
+	chain.push_back({ operation::op_dynamic_index, prev_type, type, index_expression, { 0 } });
 }
 void reshadefx::expression::add_constant_index_access(unsigned int index)
 {
@@ -290,7 +290,7 @@ void reshadefx::expression::add_constant_index_access(unsigned int index)
 	}
 	else
 	{
-		chain.push_back({ operation::op_constant_index, prev_type, type, index });
+		chain.push_back({ operation::op_constant_index, prev_type, type, index, { 0 } });
 	}
 }
 void reshadefx::expression::add_swizzle_access(const signed char swizzle[4], unsigned int length)
@@ -314,7 +314,7 @@ void reshadefx::expression::add_swizzle_access(const signed char swizzle[4], uns
 	}
 	else if (length == 1 && prev_type.is_vector()) // Use indexing when possible since the code generation logic is simpler in SPIR-V
 	{
-		chain.push_back({ operation::op_constant_index, prev_type, type, static_cast<uint32_t>(swizzle[0]) });
+		chain.push_back({ operation::op_constant_index, prev_type, type, static_cast<uint32_t>(swizzle[0]), { 0 } });
 	}
 	else
 	{

--- a/source/effect_preprocessor.cpp
+++ b/source/effect_preprocessor.cpp
@@ -342,6 +342,8 @@ void reshadefx::preprocessor::parse()
 			if (!expect(tokenid::end_of_line))
 				consume_until(tokenid::end_of_line);
 			continue;
+		default:
+			break;
 		}
 
 		if (skip)
@@ -775,6 +777,8 @@ bool reshadefx::preprocessor::evaluate_expression()
 		case tokenid::pipe_pipe:
 			op = op_or;
 			break;
+		default:
+			break;
 		}
 
 		switch (_token)
@@ -1185,6 +1189,8 @@ void reshadefx::preprocessor::create_macro_replacement_list(macro &macro)
 				}
 				break;
 			}
+			default:
+				break;
 		}
 
 		macro.replacement_list += _current_token_raw_data;

--- a/source/effect_preprocessor.hpp
+++ b/source/effect_preprocessor.hpp
@@ -50,7 +50,7 @@ namespace reshadefx
 		/// <param name="name">The name of the macro to define.</param>
 		/// <param name="value">The value to define that macro to.</param>
 		/// <returns></returns>
-		bool add_macro_definition(const std::string &name, std::string value = "1") { return add_macro_definition(name, macro { std::move(value) }); }
+		bool add_macro_definition(const std::string &name, std::string value = "1") { return add_macro_definition(name, macro { std::move(value), { }, 0, 0 }); }
 
 		/// <summary>
 		/// Open the specified file, parse its contents and append them to the output.

--- a/source/effect_symbol_table.cpp
+++ b/source/effect_symbol_table.cpp
@@ -19,7 +19,7 @@ struct intrinsic
 		function.return_type = ret_type;
 		function.parameter_list.reserve(arg_types.size());
 		for (const type &arg_type : arg_types)
-			function.parameter_list.push_back({ arg_type });
+			function.parameter_list.push_back({ arg_type, "", "", { }, 0 });
 	}
 
 	unsigned int id;

--- a/source/effect_symbol_table_intrinsics.inl
+++ b/source/effect_symbol_table_intrinsics.inl
@@ -513,8 +513,8 @@ IMPLEMENT_INTRINSIC_HLSL(saturate, 0, {
 	code += "saturate(" + id_to_name(args[0].base) + ')';
 	})
 IMPLEMENT_INTRINSIC_SPIRV(saturate, 0, {
-	const spv::Id constant_one = emit_constant(args[0].type, { 1.0f, 1.0f, 1.0f, 1.0f });
-	const spv::Id constant_zero = emit_constant(args[0].type, { 0.0f, 0.0f, 0.0f, 0.0f });
+	const spv::Id constant_one = emit_constant(args[0].type, { { 1.0f, 1.0f, 1.0f, 1.0f }, "", { } });
+	const spv::Id constant_zero = emit_constant(args[0].type, { { 0.0f, 0.0f, 0.0f, 0.0f }, "", { } });
 
 	return add_instruction(spv::OpExtInst, convert_type(res_type))
 		.add(_glsl_ext)
@@ -564,7 +564,7 @@ IMPLEMENT_INTRINSIC_HLSL(rcp, 0, {
 		code += "1.0 / " + id_to_name(args[0].base);
 	})
 IMPLEMENT_INTRINSIC_SPIRV(rcp, 0, {
-	const spv::Id constant_one = emit_constant(args[0].type, { 1.0f, 1.0f, 1.0f, 1.0f });
+	const spv::Id constant_one = emit_constant(args[0].type, { { 1.0f, 1.0f, 1.0f, 1.0f }, "", { } });
 
 	return add_instruction(spv::OpFDiv, convert_type(res_type))
 		.add(constant_one)
@@ -687,7 +687,7 @@ IMPLEMENT_INTRINSIC_SPIRV(log10, 0, {
 		.result;
 
 	const spv::Id log10 = emit_constant(args[0].type, /* log2(10) */
-		{ 3.321928f, 3.321928f, 3.321928f, 3.321928f });
+		{ { 3.321928f, 3.321928f, 3.321928f, 3.321928f }, "", { } });
 
 	return add_instruction(spv::OpFDiv, convert_type(res_type))
 		.add(log2)


### PR DESCRIPTION
This fixes `-Wswitch` and `-Wmissing-field-initializers`.

There are still `-Wchar-subscripts` warnings in `effect_lexer.cpp`, for example here: https://github.com/crosire/reshade/blob/1773c0f23ab7bb067f9a9544c6f0a304708997b1/source/effect_lexer.cpp#L669

but I didn't know an easy way to fix those.

Well and `-Wunknown-pragmas` is still left, but I think you want those. :frog: