### PR TITLE
Fix for hooking DXGI on D3D multi-gpu and Optimus systems.

### DIFF
--- a/source/d3d11/d3d11.cpp
+++ b/source/d3d11/d3d11.cpp
@@ -8,6 +8,8 @@
 #include "d3d11_device.hpp"
 #include "d3d11_device_context.hpp"
 
+extern thread_local bool inPresentCall;
+
 HOOK_EXPORT HRESULT WINAPI D3D11CreateDevice(IDXGIAdapter *pAdapter, D3D_DRIVER_TYPE DriverType, HMODULE Software, UINT Flags, const D3D_FEATURE_LEVEL *pFeatureLevels, UINT FeatureLevels, UINT SDKVersion, ID3D11Device **ppDevice, D3D_FEATURE_LEVEL *pFeatureLevel, ID3D11DeviceContext **ppImmediateContext)
 {
 	LOG(INFO) << "Redirecting D3D11CreateDevice" << '('
@@ -56,6 +58,11 @@ HOOK_EXPORT HRESULT WINAPI D3D11CreateDeviceAndSwapChain(IDXGIAdapter *pAdapter,
 	if (FAILED(hr))
 	{
 		LOG(WARN) << "D3D11CreateDeviceAndSwapChain failed with error code " << hr << '!';
+		return hr;
+	}
+
+	if (inPresentCall && !ppSwapChain)
+	{
 		return hr;
 	}
 

--- a/source/dxgi/dxgi_swapchain.cpp
+++ b/source/dxgi/dxgi_swapchain.cpp
@@ -15,6 +15,8 @@
 #include "d3d12/runtime_d3d12.hpp"
 #include <algorithm>
 
+thread_local bool inPresentCall = false;
+
 DXGISwapChain::DXGISwapChain(D3D10Device *device, IDXGISwapChain  *original, const std::shared_ptr<reshade::runtime> &runtime) :
 	_orig(original),
 	_interface_version(0),
@@ -276,10 +278,12 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::GetDevice(REFIID riid, void **ppDevice)
 
 HRESULT STDMETHODCALLTYPE DXGISwapChain::Present(UINT SyncInterval, UINT Flags)
 {
+	inPresentCall = true;
 	runtime_present(Flags);
 
 	const HRESULT hr = _orig->Present(SyncInterval, Flags);
 	handle_runtime_loss(hr);
+	inPresentCall = false;
 	return hr;
 }
 HRESULT STDMETHODCALLTYPE DXGISwapChain::GetBuffer(UINT Buffer, REFIID riid, void **ppSurface)


### PR DESCRIPTION
Basically, detect if the call to D3D11CreateDevice is coming from the DXGI / D3D runtime itself via WDDM and in this case do _not_ return a proxy D3D11 device.