### PR TITLE
Added JPEG as a screenshot format option.

### DIFF
--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1091,6 +1091,7 @@ void reshade::runtime::load_config()
 	config.get("GENERAL", "ScreenshotSaveUI", _screenshot_save_ui);
 	config.get("GENERAL", "ScreenshotSaveBefore", _screenshot_save_before);
 	config.get("GENERAL", "ScreenshotIncludePreset", _screenshot_include_preset);
+	config.get("GENERAL", "ScreenshotJPEGQuality", _screenshot_jpeg_quality);
 	config.get("GENERAL", "ScreenshotClearAlpha", _screenshot_clear_alpha);
 
 	config.get("GENERAL", "NoDebugInfo", _no_debug_info);
@@ -1138,6 +1139,7 @@ void reshade::runtime::save_config() const
 	config.set("GENERAL", "ScreenshotSaveUI", _screenshot_save_ui);
 	config.set("GENERAL", "ScreenshotSaveBefore", _screenshot_save_before);
 	config.set("GENERAL", "ScreenshotIncludePreset", _screenshot_include_preset);
+	config.set("GENERAL", "ScreenshotJPEGQuality", _screenshot_jpeg_quality);
 	config.set("GENERAL", "ScreenshotClearAlpha", _screenshot_clear_alpha);
 
 	config.set("GENERAL", "NoDebugInfo", _no_debug_info);
@@ -1401,7 +1403,7 @@ void reshade::runtime::save_screenshot(const std::wstring &postfix, const bool s
 	sprintf_s(filename, " %.4d-%.2d-%.2d %.2d-%.2d-%.2d", _date[0], _date[1], _date[2], hour, minute, seconds);
 
 	const std::wstring least = (_screenshot_path.is_relative() ? g_target_executable_path.parent_path() / _screenshot_path : _screenshot_path) / g_target_executable_path.stem().concat(filename);
-	const std::wstring screenshot_path = least + postfix + (_screenshot_format == 0 ? L".bmp" : L".png");
+	const std::wstring screenshot_path = least + postfix + (_screenshot_format == 0 ? L".bmp" : _screenshot_format == 1 ? L".png" : L".jpeg");
 
 	LOG(INFO) << "Saving screenshot to " << screenshot_path << " ...";
 
@@ -1428,6 +1430,9 @@ void reshade::runtime::save_screenshot(const std::wstring &postfix, const bool s
 				break;
 			case 1:
 				_screenshot_save_success = stbi_write_png_to_func(write_callback, file, _width, _height, 4, data.data(), 0) != 0;
+				break;
+			case 2:
+				_screenshot_save_success = stbi_write_jpg_to_func(write_callback, file, _width, _height, 4, data.data(), _screenshot_jpeg_quality) != 0;
 				break;
 			}
 

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1412,7 +1412,8 @@ void reshade::runtime::save_screenshot(const std::wstring &postfix, const bool s
 	if (std::vector<uint8_t> data(_width * _height * 4); capture_screenshot(data.data()))
 	{
 		// Clear alpha channel
-		if (_screenshot_clear_alpha)
+		// The alpha channel doesn't need to be cleared if we're saving a JPEG, stbi ignores it
+		if (_screenshot_clear_alpha && _screenshot_format != 2)
 			for (uint32_t h = 0; h < _height; ++h)
 				for (uint32_t w = 0; w < _width; ++w)
 					data[(h * _width + w) * 4 + 3] = 0xFF;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -317,6 +317,7 @@ namespace reshade
 		std::filesystem::path _screenshot_path;
 		std::filesystem::path _last_screenshot_file;
 		std::chrono::high_resolution_clock::time_point _last_screenshot_time;
+		unsigned int _screenshot_jpeg_quality = 90;
 
 		// === Preset Switching ===
 		bool _preset_save_success = true;

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -1084,8 +1084,9 @@ void reshade::runtime::draw_ui_settings()
 
 		if (_screenshot_format == 2)
 			modified |= ImGui::SliderInt("JPEG Quality", reinterpret_cast<int *>(&_screenshot_jpeg_quality), 1, 100);
+		else
+			modified |= ImGui::Checkbox("Clear alpha channel", &_screenshot_clear_alpha);
 
-		modified |= ImGui::Checkbox("Clear alpha channel", &_screenshot_clear_alpha);
 		modified |= ImGui::Checkbox("Include current preset", &_screenshot_include_preset);
 		modified |= ImGui::Checkbox("Save before and after images", &_screenshot_save_before);
 		modified |= ImGui::Checkbox("Save separate user interface image", &_screenshot_save_ui);

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -1080,7 +1080,11 @@ void reshade::runtime::draw_ui_settings()
 		_ignore_shortcuts |= ImGui::IsItemActive();
 
 		modified |= imgui_directory_input_box("Screenshot Path", _screenshot_path, _file_selection_path);
-		modified |= ImGui::Combo("Screenshot Format", reinterpret_cast<int *>(&_screenshot_format), "Bitmap (*.bmp)\0Portable Network Graphics (*.png)\0");
+		modified |= ImGui::Combo("Screenshot Format", reinterpret_cast<int *>(&_screenshot_format), "Bitmap (*.bmp)\0Portable Network Graphics (*.png)\0JPEG (*.jpeg)\0");
+
+		if (_screenshot_format == 2)
+			modified |= ImGui::SliderInt("JPEG Quality", reinterpret_cast<int *>(&_screenshot_jpeg_quality), 1, 100);
+
 		modified |= ImGui::Checkbox("Clear alpha channel", &_screenshot_clear_alpha);
 		modified |= ImGui::Checkbox("Include current preset", &_screenshot_include_preset);
 		modified |= ImGui::Checkbox("Save before and after images", &_screenshot_save_before);


### PR DESCRIPTION
I found out that `stbi_image_write` does support JPEG compression, so it was pretty easy to add support for the format.

Upon testing it seems to work just fine, I've also added it to the UI, with a quality slider (from 1 to 100) that shows up when the JPEG format is selected.

It actually appears to save faster than PNG with lower file sizes, even at 100 quality, so that's nice.

I've also hidden the clear alpha option from the GUI when JPEG is selected and modified `reshade::runtime::save_screenshot()` so that the alpha isn't cleared if JPEG is selected, since stbi automatically ignores the alpha channel.