### PR TITLE
Uitweaks

### DIFF
--- a/source/imgui_widgets.cpp
+++ b/source/imgui_widgets.cpp
@@ -235,7 +235,9 @@ bool imgui_path_list(const char *label, std::vector<std::filesystem::path> &path
 			if (ImGui::IsKeyDown(0x12))
 			{
 				res = true;
-				paths.push_back(default_path);
+
+				// Take last the last path of the list if possible.
+				paths.push_back(paths.empty() ? default_path : paths.back());
 			}
 			else
 			{

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1165,7 +1165,7 @@ void reshade::runtime::load_config()
 	config.get("INPUT", "KeyScreenshot", _screenshot_key_data);
 	config.get("INPUT", "KeyPreviousPreset", _prev_preset_key_data);
 	config.get("INPUT", "KeyNextPreset", _next_preset_key_data);
-	config.get("INPUT", "KeyPerformance", _performance_mode_key_data);
+	config.get("INPUT", "KeyPerformanceMode", _performance_mode_key_data);
 	config.get("INPUT", "ForceShortcutModifiers", _force_shortcut_modifiers);
 
 	config.get("GENERAL", "PerformanceMode", _performance_mode);
@@ -1213,7 +1213,7 @@ void reshade::runtime::save_config() const
 	config.set("INPUT", "KeyScreenshot", _screenshot_key_data);
 	config.set("INPUT", "KeyPreviousPreset", _prev_preset_key_data);
 	config.set("INPUT", "KeyNextPreset", _next_preset_key_data);
-	config.set("INPUT", "KeyPerformance", _performance_mode_key_data);
+	config.set("INPUT", "KeyPerformanceMode", _performance_mode_key_data);
 	config.set("INPUT", "ForceShortcutModifiers", _force_shortcut_modifiers);
 
 	config.set("GENERAL", "PerformanceMode", _performance_mode);

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -83,6 +83,7 @@ reshade::runtime::runtime() :
 	_screenshot_key_data(),
 	_prev_preset_key_data(),
 	_next_preset_key_data(),
+	_performance_mode_key_data(),
 	_configuration_path(g_reshade_config_path),
 	_screenshot_path(g_target_executable_path.parent_path())
 {

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -190,6 +190,13 @@ void reshade::runtime::on_present()
 			if (_input->is_key_pressed(_reload_key_data, _force_shortcut_modifiers))
 				load_effects();
 
+			if (_input->is_key_pressed(_performance_mode_key_data, _force_shortcut_modifiers))
+			{
+				_performance_mode = !_performance_mode;
+				save_config();
+				load_effects();
+			}
+
 			if (const bool reversed = _input->is_key_pressed(_prev_preset_key_data, _force_shortcut_modifiers);
 				reversed || _input->is_key_pressed(_next_preset_key_data, _force_shortcut_modifiers))
 			{
@@ -1145,6 +1152,7 @@ void reshade::runtime::load_config()
 	config.get("INPUT", "KeyScreenshot", _screenshot_key_data);
 	config.get("INPUT", "KeyPreviousPreset", _prev_preset_key_data);
 	config.get("INPUT", "KeyNextPreset", _next_preset_key_data);
+	config.get("INPUT", "KeyPerformance", _performance_mode_key_data);
 	config.get("INPUT", "ForceShortcutModifiers", _force_shortcut_modifiers);
 
 	config.get("GENERAL", "PerformanceMode", _performance_mode);
@@ -1192,6 +1200,7 @@ void reshade::runtime::save_config() const
 	config.set("INPUT", "KeyScreenshot", _screenshot_key_data);
 	config.set("INPUT", "KeyPreviousPreset", _prev_preset_key_data);
 	config.set("INPUT", "KeyNextPreset", _next_preset_key_data);
+	config.set("INPUT", "KeyPerformance", _performance_mode_key_data);
 	config.set("INPUT", "ForceShortcutModifiers", _force_shortcut_modifiers);
 
 	config.set("GENERAL", "PerformanceMode", _performance_mode);

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -336,6 +336,9 @@ namespace reshade
 		std::filesystem::path _current_preset_path;
 		std::chrono::high_resolution_clock::time_point _last_preset_switching_time;
 
+		// === Performance Mode
+		unsigned int _performance_mode_key_data[4];
+
 #if RESHADE_GUI
 		void init_ui();
 		void deinit_ui();

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -1080,6 +1080,9 @@ void reshade::runtime::draw_ui_settings()
 		modified |= imgui_key_input("Next Preset Key", _next_preset_key_data, *_input);
 		_ignore_shortcuts |= ImGui::IsItemActive();
 
+		modified |= imgui_key_input("Performance Mode Toggle Key", _performance_mode_key_data, *_input);
+		_ignore_shortcuts |= ImGui::IsItemActive();
+
 		modified |= ImGui::SliderInt("Preset transition", reinterpret_cast<int *>(&_preset_transition_delay), 0, 10 * 1000);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Makes a smooth transition, but only for floating point values.\nRecommended for multiple presets that contain the same shaders, otherwise set this to zero.\nValues are in milliseconds.");


### PR DESCRIPTION
I've made two changes to the UI/UX:

- Added a performance mode toggle key.
  - This was an idea TreyM suggested in the Discord code chat, I thought it was neat and pretty simple to implement.
- Made it so that new effect/texture paths added with the "alt-click" copy the last entry if the list isn't empty.
  - I did this so it'd be faster to add a ton of repositories in the same location. For example, if I have all my repos at `C:\Projects\ReShade\`,  I can add an entry to `C:\Projects\ReShade\reshade-shaders\Shaders`, duplicate it a few times and then change the names, much faster than having to copy and then paste each entry individually.