### PR TITLE
Fixed hook queuing flag

### DIFF
--- a/source/hook_manager.cpp
+++ b/source/hook_manager.cpp
@@ -354,7 +354,7 @@ bool reshade::hooks::install(const char *name, hook::address target, hook::addre
 	hook.replacement = replacement;
 
 	return install_internal(name, hook, hook_method::function_hook) &&
-		(!queue_enable || hook::apply_queued_actions()); // Can optionally only queue up the hooks instead of installing them right away
+		(queue_enable || hook::apply_queued_actions()); // Can optionally only queue up the hooks instead of installing them right away
 }
 bool reshade::hooks::install(const char *name, hook::address vtable[], unsigned int offset, hook::address replacement)
 {


### PR DESCRIPTION
`hook::apply_queued_actions()` was getting called immediately for `queue_enable == true` (probably not important, but it does cause every thread in the process to be suspended every time a single hook is installed)