### PR TITLE
Change the type of variable used to manage shared textures

### DIFF
--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -512,7 +512,7 @@ bool reshade::runtime::load_effect(const std::filesystem::path &path, size_t eff
 				}
 
 				if (std::find(existing_texture->shared.begin(), existing_texture->shared.end(), effect_index) == existing_texture->shared.end())
-					existing_texture->shared.emplace_back(effect_index);
+					existing_texture->shared.push_back(effect_index);
 
 				// Always make shared textures render targets, since they may be used as such in a different effect
 				existing_texture->render_target = true;
@@ -541,8 +541,10 @@ bool reshade::runtime::load_effect(const std::filesystem::path &path, size_t eff
 							texture.unique_name, existing_texture->unique_name);
 
 				if (std::find(existing_texture->shared.begin(), existing_texture->shared.end(), effect_index) == existing_texture->shared.end())
-					existing_texture->shared.emplace_back(effect_index);
+					existing_texture->shared.push_back(effect_index);
 
+				existing_texture->render_target = true;
+				existing_texture->storage_access = true;
 				continue;
 			}
 		}
@@ -554,8 +556,8 @@ bool reshade::runtime::load_effect(const std::filesystem::path &path, size_t eff
 		else if (!texture.semantic.empty())
 			effect.errors += "warning: " + texture.unique_name + ": unknown semantic '" + texture.semantic + "'\n";
 
-		if (std::find(texture.shared.begin(), texture.shared.end(), effect_index) == texture.shared.end())
-			texture.shared.emplace_back(effect_index);
+		// This is the first effect using this texture
+		texture.shared.push_back(effect_index);
 
 		new_textures.push_back(std::move(texture));
 	}
@@ -704,9 +706,9 @@ void reshade::runtime::load_textures()
 	_textures_loaded = true;
 }
 
-void reshade::runtime::unload_effect(size_t index)
+void reshade::runtime::unload_effect(size_t effect_index)
 {
-	assert(index < _effects.size());
+	assert(effect_index < _effects.size());
 
 #if RESHADE_GUI
 	_preview_texture = nullptr;
@@ -717,9 +719,9 @@ void reshade::runtime::unload_effect(size_t index)
 
 	// Destroy textures belonging to this effect
 	_textures.erase(std::remove_if(_textures.begin(), _textures.end(),
-		[this, index](texture &tex) {
-			if (tex.shared.erase(std::remove_if(tex.shared.begin(), tex.shared.end(), [index](size_t effect_index) { return index == effect_index;}), tex.shared.end());
-				tex.shared.empty()) {
+		[this, effect_index](texture &tex) {
+			tex.shared.erase(std::remove(tex.shared.begin(), tex.shared.end(), effect_index), tex.shared.end());
+			if (tex.shared.empty()) {
 				destroy_texture(tex);
 				return true;
 			}
@@ -727,12 +729,12 @@ void reshade::runtime::unload_effect(size_t index)
 		}), _textures.end());
 	// Clean up techniques belonging to this effect
 	_techniques.erase(std::remove_if(_techniques.begin(), _techniques.end(),
-		[index](const technique &tech) {
-			return tech.effect_index == index;
+		[effect_index](const technique &tech) {
+			return tech.effect_index == effect_index;
 		}), _techniques.end());
 
 	// Do not clear source file, so that an 'unload_effect' immediately followed by a 'load_effect' which accesses that works
-	effect &effect = _effects[index];;
+	effect &effect = _effects[effect_index];;
 	effect.rendering = false;
 	effect.compiled = false;
 	effect.errors.clear();
@@ -820,7 +822,7 @@ void reshade::runtime::update_and_render_effects()
 		for (texture &texture : _textures)
 		{
 			// Always create shared textures, since they may be in use by this effect already
-			if (texture.impl == nullptr && (texture.effect_index == effect_index || texture.shared.size() >= 2))
+			if (texture.impl == nullptr && (texture.effect_index == effect_index || texture.shared.size() > 1))
 			{
 				if (!init_texture(texture))
 				{

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -164,13 +164,13 @@ namespace reshade
 		/// <summary>
 		/// Initialize resources for the effect and load the effect module.
 		/// </summary>
-		/// <param name="index">The ID of the effect.</param>
-		virtual bool init_effect(size_t index) = 0;
+		/// <param name="effect_index">The ID of the effect.</param>
+		virtual bool init_effect(size_t effect_index) = 0;
 		/// <summary>
 		/// Unload the specified effect.
 		/// </summary>
-		/// <param name="index">The ID of the effect.</param>
-		virtual void unload_effect(size_t index);
+		/// <param name="effect_index">The ID of the effect.</param>
+		virtual void unload_effect(size_t effect_index);
 		/// <summary>
 		/// Unload all effects currently loaded.
 		/// </summary>

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -155,8 +155,8 @@ namespace reshade
 		/// Compile effect from the specified source file and initialize textures, uniforms and techniques.
 		/// </summary>
 		/// <param name="path">The path to an effect source code file.</param>
-		/// <param name="index">The ID of the effect.</param>
-		bool load_effect(const std::filesystem::path &path, size_t index);
+		/// <param name="effect_index">The ID of the effect.</param>
+		bool load_effect(const std::filesystem::path &path, size_t effect_index);
 		/// <summary>
 		/// Load all effects found in the effect search paths.
 		/// </summary>

--- a/source/runtime_objects.hpp
+++ b/source/runtime_objects.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "effect_module.hpp"
+#include <unordered_set>
 
 namespace reshade
 {
@@ -102,7 +103,7 @@ namespace reshade
 		void *impl = nullptr;
 		size_t effect_index = std::numeric_limits<size_t>::max();
 		texture_reference impl_reference = texture_reference::none;
-		bool shared = false;
+		std::unordered_set<size_t> shared;
 		bool loaded = false;
 	};
 

--- a/source/runtime_objects.hpp
+++ b/source/runtime_objects.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "effect_module.hpp"
-#include <unordered_set>
 
 namespace reshade
 {
@@ -103,7 +102,7 @@ namespace reshade
 		void *impl = nullptr;
 		size_t effect_index = std::numeric_limits<size_t>::max();
 		texture_reference impl_reference = texture_reference::none;
-		std::unordered_set<size_t> shared;
+		std::vector<size_t> shared;
 		bool loaded = false;
 	};
 


### PR DESCRIPTION
The second commit is optional. User can check who read and wrote it.

![texture_shared](https://user-images.githubusercontent.com/71371622/93738503-e9ce8400-fc20-11ea-9a25-26287f187578.png)
