### PR TITLE
Fixes issue with mouse staying in a tiny box when the overlay was opened in some games

### DIFF
--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -828,6 +828,12 @@ void reshade::runtime::draw_gui()
 	_input->block_mouse_input(_input_processing_mode != 0 && _show_overlay && (imgui_io.WantCaptureMouse || _input_processing_mode == 2));
 	_input->block_keyboard_input(_input_processing_mode != 0 && _show_overlay && (imgui_io.WantCaptureKeyboard || _input_processing_mode == 2));
 
+	if (_input->is_blocking_mouse_input())
+	{
+		// Some games setup ClipCursor with a tiny area which could make the cursor stay in that area instead of the whole window
+		ClipCursor(nullptr);
+	}
+	
 	if (ImDrawData *const draw_data = ImGui::GetDrawData();
 		draw_data != nullptr && draw_data->CmdListsCount != 0 && draw_data->TotalVtxCount != 0)
 		render_imgui_draw_data(draw_data);


### PR DESCRIPTION
This fixes the issue in e.g. WatchDogs Legion where the mouse is in a tiny rectangle due to the game's use of ClipCursor. Adding a call to ClipCursor(nullptr) solves this. The solution implemented isn't checking whether it's necessary to reset it to the full desktop so in the future it might be necessary for some games which can't deal with this to first call GetClipCursor to determine the current active clip cursor area, compare that to the client area of the window of the active hWnd imgui is rendering to and if the clipcursor area is smaller, call ClipCursor(nullptr). 