### PR TITLE
Application crosstalk feature

### DIFF
--- a/source/d3d12/d3d12_command_list.cpp
+++ b/source/d3d12/d3d12_command_list.cpp
@@ -94,21 +94,10 @@ HRESULT STDMETHODCALLTYPE D3D12GraphicsCommandList::GetPrivateData(REFGUID guid,
 	return _orig->GetPrivateData(guid, pDataSize, pData);
 }
 
-static const GUID crosstalk_fake_guid = { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } };
-static const uint64_t crosstalk_magic = 0x505670b7c18ff478;
-
 HRESULT STDMETHODCALLTYPE D3D12GraphicsCommandList::SetPrivateData(REFGUID guid, UINT DataSize, const void *pData)
 {
-	if (!memcmp(&guid, &crosstalk_fake_guid, sizeof(GUID)) && (DataSize == sizeof(reshade::d3d12::crosstalk::entry)))
-	{
-		auto entry = (reshade::d3d12::crosstalk::entry*)pData;
-
-		if (entry->magic == crosstalk_magic)
-		{
-			reshade::d3d12::crosstalk::set_crosstalk_resource(entry->ct_idx, entry->res);
-		}
+	if (reshade::d3d12::crosstalk::check_call(guid, DataSize, pData))
 		return S_OK;
-	}
 
 	return _orig->SetPrivateData(guid, DataSize, pData);
 }

--- a/source/d3d12/runtime_d3d12.cpp
+++ b/source/d3d12/runtime_d3d12.cpp
@@ -75,6 +75,17 @@ namespace reshade::d3d12
 		transition.Transition.StateAfter = to;
 		list->ResourceBarrier(1, &transition);
 	}
+
+	com_ptr<ID3D12Resource> glob_crostalk_resarray[crosstalk::ResNames::COUNT];
+
+	void crosstalk::set_crosstalk_resource(int ct_index, ID3D12Resource* res)
+	{
+		glob_crostalk_resarray[ct_index] = res;
+	}
+	ID3D12Resource* crosstalk::get_crosstalk_resource(int ct_index)
+	{
+		return glob_crostalk_resarray[ct_index].get();
+	}
 }
 
 reshade::d3d12::runtime_d3d12::runtime_d3d12(ID3D12Device *device, ID3D12CommandQueue *queue, IDXGISwapChain3 *swapchain, state_tracking_context *state_tracking) :
@@ -1012,6 +1023,10 @@ bool reshade::d3d12::runtime_d3d12::init_effect(size_t index)
 					effect_data.depth_texture_binding = srv_handle;
 				}
 #endif
+				if (texture.unique_name == "__crosstalk_game_3d_color")
+				{
+					resource = crosstalk::get_crosstalk_resource(crosstalk::ResNames::COLOR);
+				}
 
 				if (resource != nullptr)
 				{

--- a/source/d3d12/runtime_d3d12.cpp
+++ b/source/d3d12/runtime_d3d12.cpp
@@ -1023,9 +1023,14 @@ bool reshade::d3d12::runtime_d3d12::init_effect(size_t index)
 					effect_data.depth_texture_binding = srv_handle;
 				}
 #endif
-				if (texture.unique_name == "__crosstalk_game_3d_color")
+				if (texture.unique_name == "V__crosstalk_game_3d_color")
 				{
 					resource = crosstalk::get_crosstalk_resource(crosstalk::ResNames::COLOR);
+				}
+
+				if (texture.unique_name == "V__crosstalk_game_3d_depth")
+				{
+					resource = crosstalk::get_crosstalk_resource(crosstalk::ResNames::DEPTH);
 				}
 
 				if (resource != nullptr)

--- a/source/d3d12/runtime_d3d12.hpp
+++ b/source/d3d12/runtime_d3d12.hpp
@@ -11,6 +11,43 @@
 
 namespace reshade::d3d12
 {
+	class crosstalk
+	{
+
+	public:
+		enum ResNames
+		{
+			COLOR = 0,
+			DEPTH = 1,
+			ZPREPASS = 2,
+			GBUF_0 = 3,
+			GBUF_1 = 4,
+			GBUF_2 = 5,
+			GBUF_3 = 6,
+			GBUF_4 = 7,
+			OVERLAY_0 = 8,
+			OVERLAY_1 = 9,
+			OVERLAY_2 = 10,
+			OVERLAY_3 = 11,
+			OPAQUE_GEOMETRY = 12,
+			TRANSP_GEOMETRY = 13,
+			COUNT = 14
+		};
+
+		struct entry
+		{
+			uint64_t magic;
+			uint64_t ct_idx;
+			union {
+				char* info;
+				ID3D12Resource* res;
+			};
+		};
+
+		static void set_crosstalk_resource(int ct_index, ID3D12Resource* res);
+		static ID3D12Resource* get_crosstalk_resource(int ct_index);
+	};
+
 	class runtime_d3d12 : public runtime
 	{
 		static const uint32_t NUM_IMGUI_BUFFERS = 5;

--- a/source/d3d12/runtime_d3d12.hpp
+++ b/source/d3d12/runtime_d3d12.hpp
@@ -13,6 +13,8 @@ namespace reshade::d3d12
 {
 	class crosstalk
 	{
+		static const GUID fake_guid;
+		static const uint64_t magic;
 
 	public:
 		enum ResNames
@@ -39,13 +41,16 @@ namespace reshade::d3d12
 			uint64_t magic;
 			uint64_t ct_idx;
 			union {
-				char* info;
+				void* ptr;
 				ID3D12Resource* res;
 			};
 		};
 
+		static bool check_call(REFGUID guid, UINT DataSize, const void* pData);
 		static void set_crosstalk_resource(int ct_index, ID3D12Resource* res);
-		static ID3D12Resource* get_crosstalk_resource(int ct_index);
+		static ID3D12Resource* get_crosstalk_resource(ResNames ct_index);
+
+		static void replace_texture(const texture& texture, com_ptr<ID3D12Resource>& resource);
 	};
 
 	class runtime_d3d12 : public runtime


### PR DESCRIPTION
Hi. I want to add an ability to supply data to reshade from games/mods.

For example supplying depth buffer without heuristics or 3d scene without UI
by reshade independent code i.e. without specific forks.
(real story behind that is various requests from Guild Wars 2 community to make a modern
version of https://github.com/04348/Gw2Hook and also some other requests)

I did make some hacky implementation for dx12, that uses command list SetPrivateData
function to supply needed data using magic guid and data checks.
Supplied data is later used on effect reload to replace texture resources with specific names.

General idea works, but it will be nice to hear
some comments about that, before making more changes.