### PR TITLE
Small VR improvements

### DIFF
--- a/ReShade.vcxproj
+++ b/ReShade.vcxproj
@@ -520,6 +520,7 @@
     <ClInclude Include="source\opengl\runtime_gl.hpp" />
     <ClInclude Include="source\opengl\runtime_gl_objects.hpp" />
     <ClInclude Include="source\opengl\state_block_gl.hpp" />
+    <ClInclude Include="source\openvr\reshade_vr.hpp" />
     <ClInclude Include="source\runtime.hpp" />
     <ClInclude Include="source\runtime_objects.hpp" />
     <ClInclude Include="source\vulkan\format_utils.hpp" />

--- a/ReShade.vcxproj.filters
+++ b/ReShade.vcxproj.filters
@@ -494,6 +494,9 @@
     <ClInclude Include="res\version.h">
       <Filter>resources</Filter>
     </ClInclude>
+    <ClInclude Include="source\openvr\reshade_vr.hpp">
+      <Filter>core\api</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="res\resource.rc">

--- a/source/openvr/openvr.cpp
+++ b/source/openvr/openvr.cpp
@@ -14,11 +14,20 @@
 #include "opengl/runtime_gl.hpp"
 #include "vulkan/vulkan_hooks.hpp"
 #include "vulkan/runtime_vk.hpp"
+#include "reshade_vr.hpp"
 #include <openvr.h>
 
 static std::pair<reshade::runtime *, vr::ETextureType> s_vr_runtime = { nullptr, vr::TextureType_Invalid };
 
 extern lockfree_table<void *, reshade::vulkan::device_impl *, 16> g_vulkan_devices;
+
+namespace reshade::vr
+{
+	runtime *vr_runtime()
+	{
+		return s_vr_runtime.first;
+	}
+}
 
 static bool on_submit_d3d11(vr::EVREye, ID3D11Texture2D *texture, const vr::VRTextureBounds_t *bounds)
 {

--- a/source/openvr/reshade_vr.hpp
+++ b/source/openvr/reshade_vr.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "runtime.hpp"
+
+namespace reshade::vr
+{
+	runtime *vr_runtime();
+}

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -22,6 +22,8 @@
 #include <stb_image_write.h>
 #include <stb_image_resize.h>
 
+#include "openvr/reshade_vr.hpp"
+
 bool resolve_path(std::filesystem::path &path)
 {
 	std::error_code ec;
@@ -1505,6 +1507,12 @@ void reshade::runtime::save_config() const
 
 	for (const auto &callback : _save_config_callables)
 		callback(config);
+
+	if (vr::vr_runtime() != nullptr)
+	{
+		vr::vr_runtime()->load_config();
+		vr::vr_runtime()->load_current_preset();
+	}
 }
 
 void reshade::runtime::load_current_preset()
@@ -1727,6 +1735,9 @@ void reshade::runtime::save_current_preset() const
 			}
 		}
 	}
+
+	if (vr::vr_runtime() != nullptr)
+		vr::vr_runtime()->load_current_preset();
 }
 
 bool reshade::runtime::switch_to_next_preset(std::filesystem::path filter_path, bool reversed)

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -184,7 +184,11 @@ void reshade::runtime::on_present()
 	if (!_ignore_shortcuts)
 	{
 		if (_input->is_key_pressed(_effects_key_data, _force_shortcut_modifiers))
+		{
 			_effects_enabled = !_effects_enabled;
+			if (vr::vr_runtime() != nullptr && vr::vr_runtime() != this)
+				vr::vr_runtime()->_effects_enabled = _effects_enabled;
+		}
 
 		if (_input->is_key_pressed(_screenshot_key_data, _force_shortcut_modifiers))
 			_should_save_screenshot = true; // Notify 'update_and_render_effects' that we want to save a screenshot next frame

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1129,6 +1129,14 @@ void reshade::runtime::update_and_render_effects()
 	if (!_effects_enabled)
 		return;
 
+	if (vr::vr_runtime() != nullptr && vr::vr_runtime() != this) {
+		// In VR mode, effects should not be applied to the window unless GUI is active
+#if RESHADE_GUI
+		if (!_show_overlay)
+#endif
+			return;
+	}
+
 	// Update special uniform variables
 	for (effect &effect : _effects)
 	{

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -1574,6 +1574,7 @@ void reshade::runtime::draw_gui_statistics()
 		vr::vr_runtime()->draw_gui_statistics();
 		return;
 	}
+	const float factor = vr::vr_runtime() == this ? 2 : 1;
 
 	unsigned int cpu_digits = 1;
 	unsigned int gpu_digits = 1;
@@ -1626,8 +1627,8 @@ void reshade::runtime::draw_gui_statistics()
 		ImGui::TextUnformatted(g_target_executable_path.filename().u8string().c_str());
 		ImGui::Text("%d-%d-%d %d", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour * 3600 + tm.tm_min * 60 + tm.tm_sec);
 		ImGui::Text("%u B", g_network_traffic);
-		ImGui::Text("%.2f fps", _imgui_context->IO.Framerate);
-		ImGui::Text("%*.3f ms CPU", cpu_digits + 4, post_processing_time_cpu * 1e-6f);
+		ImGui::Text("%.2f fps", _imgui_context->IO.Framerate / factor);
+		ImGui::Text("%*.3f ms CPU", cpu_digits + 4, post_processing_time_cpu * 1e-6f * factor);
 
 		ImGui::EndGroup();
 		ImGui::SameLine(ImGui::GetWindowWidth() * 0.66666666f);
@@ -1642,7 +1643,7 @@ void reshade::runtime::draw_gui_statistics()
 		ImGui::NewLine();
 		ImGui::Text("%*.3f ms", gpu_digits + 4, _last_frame_duration.count() * 1e-6f);
 		if (post_processing_time_gpu != 0)
-			ImGui::Text("%*.3f ms GPU", gpu_digits + 4, (post_processing_time_gpu * 1e-6f));
+			ImGui::Text("%*.3f ms GPU", gpu_digits + 4, (post_processing_time_gpu * 1e-6f * factor));
 
 		ImGui::EndGroup();
 	}
@@ -1672,7 +1673,7 @@ void reshade::runtime::draw_gui_statistics()
 				continue;
 
 			if (technique.average_cpu_duration != 0)
-				ImGui::Text("%*.3f ms CPU", cpu_digits + 4, technique.average_cpu_duration * 1e-6f);
+				ImGui::Text("%*.3f ms CPU", cpu_digits + 4, technique.average_cpu_duration * 1e-6f * factor);
 			else
 				ImGui::NewLine();
 		}
@@ -1688,7 +1689,7 @@ void reshade::runtime::draw_gui_statistics()
 
 			// GPU timings are not available for all APIs
 			if (technique.average_gpu_duration != 0)
-				ImGui::Text("%*.3f ms GPU", gpu_digits + 4, technique.average_gpu_duration * 1e-6f);
+				ImGui::Text("%*.3f ms GPU", gpu_digits + 4, technique.average_gpu_duration * 1e-6f * factor);
 			else
 				ImGui::NewLine();
 		}

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -3,6 +3,7 @@
  * License: https://github.com/crosire/reshade#license
  */
 
+#include "openvr/reshade_vr.hpp"
 #if RESHADE_GUI
 
 #include "version.h"
@@ -1567,6 +1568,13 @@ void reshade::runtime::draw_gui_settings()
 }
 void reshade::runtime::draw_gui_statistics()
 {
+	if (vr::vr_runtime() != nullptr && vr::vr_runtime() != this)
+	{
+		// if VR mode is enabled, the VR runtime's statistics are the ones we are actually interested in
+		vr::vr_runtime()->draw_gui_statistics();
+		return;
+	}
+
 	unsigned int cpu_digits = 1;
 	unsigned int gpu_digits = 1;
 	uint64_t post_processing_time_cpu = 0;


### PR DESCRIPTION
Here are a few quick changes which help the experience in VR mode:

- ensure the VR runtime reflects changes made to the config or the preset in the window runtime's GUI
- do not apply effects to the window view in VR mode unless the GUI is active. This is to not waste GPU performance in VR, but still allow easy editing of the preset. Although perhaps this should be a config option?
- show statistics from the VR runtime, not the window runtime. I also applied a quick hack to show more "accurate" times seeing that the VR runtime's on_present is called twice per frame. It's admittedly not pretty.

I'm not sure if I found the cleanest way to implement these changes. I'm open to suggestions :)