### PR TITLE
Add config option to disable GPU statistics gathering

### DIFF
--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1438,6 +1438,8 @@ void reshade::runtime::load_config()
 	config.get("GENERAL", "PresetPath", _current_preset_path);
 	config.get("GENERAL", "PresetTransitionDelay", _preset_transition_delay);
 
+	config.get("GENERAL", "GatherGPUStatistics", _gather_gpu_statistics);
+
 	// Fall back to temp directory if cache path does not exist
 	if (_intermediate_cache_path.empty() || !resolve_path(_intermediate_cache_path))
 	{
@@ -1493,6 +1495,8 @@ void reshade::runtime::save_config() const
 		relative_preset_path = L"." / relative_preset_path;
 	config.set("GENERAL", "PresetPath", relative_preset_path);
 	config.set("GENERAL", "PresetTransitionDelay", _preset_transition_delay);
+
+	config.set("GENERAL", "GatherGPUStatistics", _gather_gpu_statistics);
 
 	config.set("SCREENSHOT", "ClearAlpha", _screenshot_clear_alpha);
 	config.set("SCREENSHOT", "FileFormat", _screenshot_format);

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -247,6 +247,9 @@ namespace reshade
 		std::vector<texture> _textures;
 		std::vector<technique> _techniques;
 
+		// === Statistics ===
+		bool _gather_gpu_statistics = true;
+
 	private:
 		/// <summary>
 		/// Compare current version against the latest published one.

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -1368,6 +1368,8 @@ void reshade::runtime::draw_gui_settings()
 
 		if (ImGui::Button("Clear effect cache", ImVec2(ImGui::CalcItemWidth(), 0)))
 			clear_effect_cache();
+
+		modified |= ImGui::Checkbox("Gather GPU statistics", &_gather_gpu_statistics);
 	}
 
 	if (ImGui::CollapsingHeader("Screenshots", ImGuiTreeNodeFlags_DefaultOpen))


### PR DESCRIPTION
There is currently a long-standing bug in the NVIDIA driver where any kind of frame profiling can cause sudden frame drops/spikes in VR, making the playing experience choppy and rather unpleasant. I've had at least one report where ReShade caused this issue with Skyrim VR.

Therefore, I added a config option to disable GPU performance queries. I don't know if this feature is useful beyond circumventing this particular driver bug. But until NVIDIA finally fixes it, some VR users would probably need it to actually be able to use ReShade, so I thought I'd at least post it here for consideration if NVIDIA keeps taking their time.

For reference: https://www.nvidia.com/en-us/geforce/forums/game-ready-drivers/13/402768/valve-index-missing-dropped-frames-since-nvidia-d/