### PR TITLE
Track depth textures for VR

### DIFF
--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -179,6 +179,20 @@ namespace reshade { namespace api
 	};
 
 	/// <summary>
+	/// Describes a rectangular region in a resource.
+	/// </summary>
+	struct region
+	{
+		uint32_t left;
+		uint32_t top;
+		uint32_t right;
+		uint32_t bottom;
+
+		constexpr uint32_t width() const { return right - left; }
+		constexpr uint32_t height() const { return bottom - top; }
+	};
+
+	/// <summary>
 	/// An opaque handle to a resource object (buffer, texture, ...).
 	/// Resources created by the application are only guaranteed to be valid during event callbacks.
 	/// If you want to use one outside that scope, first ensure the resource is still valid via <see cref="device::check_resource_handle_valid"/>.

--- a/source/addon/generic_depth.cpp
+++ b/source/addon/generic_depth.cpp
@@ -245,14 +245,18 @@ static void on_init_device(device *device)
 	config.get("DEPTH", "DepthCopyBeforeClears", device_state.selected_depth_stencil.preserve_depth_buffers);
 	config.get("DEPTH", "DepthCopyAtClearIndex", device_state.selected_depth_stencil.force_clear_index);
 	config.get("DEPTH", "UseAspectRatioHeuristics", device_state.use_aspect_ratio_heuristics);
+	config.get("DEPTH", "VRFirstEyeCopyAtClearIndex", device_state.vr_depth_stencil[0].force_clear_index);
 
 	if (device_state.selected_depth_stencil.force_clear_index == std::numeric_limits<uint32_t>::max())
 		device_state.selected_depth_stencil.force_clear_index  = 0;
+	if (device_state.vr_depth_stencil[0].force_clear_index == std::numeric_limits<uint32_t>::max())
+		device_state.vr_depth_stencil[0].force_clear_index  = 0;
 
 	for (int i = 0; i < 2; ++i)
 	{
 		device_state.vr_depth_stencil[i].preserve_depth_buffers = device_state.selected_depth_stencil.preserve_depth_buffers;
-		device_state.vr_depth_stencil[i].force_clear_index = device_state.selected_depth_stencil.force_clear_index;
+		if (device_state.vr_depth_stencil[i].force_clear_index == 0)
+			device_state.vr_depth_stencil[i].force_clear_index = device_state.selected_depth_stencil.force_clear_index;
 	}
 }
 static void on_destroy_device(device *device)
@@ -852,6 +856,7 @@ static void draw_debug_menu(effect_runtime *runtime, void *)
 		config.set("DEPTH", "DepthCopyBeforeClears", device_state.selected_depth_stencil.preserve_depth_buffers);
 		config.set("DEPTH", "DepthCopyAtClearIndex", device_state.selected_depth_stencil.force_clear_index);
 		config.set("DEPTH", "UseAspectRatioHeuristics", device_state.use_aspect_ratio_heuristics);
+		config.set("DEPTH", "VRFirstEyeCopyAtClearIndex", device_state.vr_depth_stencil[0].force_clear_index);
 	}
 }
 #endif

--- a/source/addon/generic_depth.cpp
+++ b/source/addon/generic_depth.cpp
@@ -37,6 +37,7 @@ struct depth_stencil_info
 	draw_stats current_stats; // Stats since last clear operation
 	std::vector<clear_stats> clears;
 	bool copied_during_frame = false;
+	std::chrono::high_resolution_clock::time_point last_drawcall;
 };
 
 struct state_tracking
@@ -329,6 +330,7 @@ static void on_draw(command_list *cmd_list, uint32_t vertices, uint32_t instance
 	counters.current_stats.vertices += vertices * instances;
 	counters.current_stats.drawcalls += 1;
 	std::memcpy(counters.current_stats.last_viewport, state.current_viewport, 6 * sizeof(float));
+	counters.last_drawcall = std::chrono::high_resolution_clock::now();
 }
 static void on_draw_indexed(command_list *cmd_list, uint32_t indices, uint32_t instances, uint32_t, int32_t, uint32_t)
 {

--- a/source/openvr/openvr.cpp
+++ b/source/openvr/openvr.cpp
@@ -45,6 +45,7 @@ static bool on_submit_d3d11(vr::EVREye, ID3D11Texture2D *texture, const vr::VRTe
 
 	D3D11_BOX region = { 0, 0, 0, tex_desc.Width, tex_desc.Height, 1 };
 
+	RESHADE_ADDON_EVENT(present, s_vr_runtime.first->get_command_queue(), s_vr_runtime.first);
 	return static_cast<reshade::d3d11::runtime_impl *>(s_vr_runtime.first)->on_present(texture, region, nullptr);
 }
 static bool on_submit_d3d12(vr::EVREye, const vr::D3D12TextureData_t *texture, const vr::VRTextureBounds_t *bounds)
@@ -65,6 +66,7 @@ static bool on_submit_d3d12(vr::EVREye, const vr::D3D12TextureData_t *texture, c
 
 	D3D12_BOX region = { 0, 0, 0, static_cast<UINT>(tex_desc.Width), tex_desc.Height, 1 };
 
+	RESHADE_ADDON_EVENT(present, s_vr_runtime.first->get_command_queue(), s_vr_runtime.first);
 	// Resource should be in D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE state at this point
 	return static_cast<reshade::d3d12::runtime_impl *>(s_vr_runtime.first)->on_present(texture->m_pResource, region, nullptr);
 }
@@ -86,6 +88,7 @@ static bool on_submit_opengl(vr::EVREye, GLuint object, bool is_rbo, bool is_arr
 
 	GLint region[4] = { 0, 0, static_cast<GLint>(object_desc.width), static_cast<GLint>(object_desc.height) };
 
+	RESHADE_ADDON_EVENT(present, s_vr_runtime.first->get_command_queue(), s_vr_runtime.first);
 	return static_cast<reshade::opengl::runtime_impl *>(s_vr_runtime.first)->on_present(object, is_rbo, is_array, object_desc.width, object_desc.height, region);
 }
 static bool on_submit_vulkan(vr::EVREye, const vr::VRVulkanTextureData_t *texture, bool with_array_data, const vr::VRTextureBounds_t *bounds)
@@ -115,6 +118,7 @@ static bool on_submit_vulkan(vr::EVREye, const vr::VRVulkanTextureData_t *textur
 
 	const uint32_t layer_index = with_array_data ? static_cast<const vr::VRVulkanTextureArrayData_t *>(texture)->m_unArrayIndex : 0;
 
+	RESHADE_ADDON_EVENT(present, s_vr_runtime.first->get_command_queue(), s_vr_runtime.first);
 	// Image should be in VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL layout at this point
 	std::vector<VkSemaphore> wait_semaphores;
 	return static_cast<reshade::vulkan::runtime_impl *>(s_vr_runtime.first)->on_present(

--- a/source/openvr/openvr.cpp
+++ b/source/openvr/openvr.cpp
@@ -42,13 +42,6 @@ static bool on_submit_d3d11(vr::EVREye, ID3D11Texture2D *texture, const vr::VRTe
 	texture->GetDesc(&tex_desc);
 
 	D3D11_BOX region = { 0, 0, 0, tex_desc.Width, tex_desc.Height, 1 };
-	if (bounds != nullptr)
-	{
-		region.left = static_cast<UINT>(region.right * std::min(bounds->uMin, bounds->uMax));
-		region.top =   static_cast<UINT>(region.bottom * std::min(bounds->vMin, bounds->vMax));
-		region.right = static_cast<UINT>(region.right * std::max(bounds->uMin, bounds->uMax));
-		region.bottom = static_cast<UINT>(region.bottom * std::max(bounds->vMin, bounds->vMax));
-	}
 
 	return static_cast<reshade::d3d11::runtime_impl *>(s_vr_runtime.first)->on_present(texture, region, nullptr);
 }
@@ -69,13 +62,6 @@ static bool on_submit_d3d12(vr::EVREye, const vr::D3D12TextureData_t *texture, c
 	const D3D12_RESOURCE_DESC tex_desc = texture->m_pResource->GetDesc();
 
 	D3D12_BOX region = { 0, 0, 0, static_cast<UINT>(tex_desc.Width), tex_desc.Height, 1 };
-	if (bounds != nullptr)
-	{
-		region.left = static_cast<UINT>(region.right * std::min(bounds->uMin, bounds->uMax));
-		region.top =   static_cast<UINT>(region.bottom * std::min(bounds->vMin, bounds->vMax));
-		region.right = static_cast<UINT>(region.right * std::max(bounds->uMin, bounds->uMax));
-		region.bottom = static_cast<UINT>(region.bottom * std::max(bounds->vMin, bounds->vMax));
-	}
 
 	// Resource should be in D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE state at this point
 	return static_cast<reshade::d3d12::runtime_impl *>(s_vr_runtime.first)->on_present(texture->m_pResource, region, nullptr);
@@ -97,13 +83,6 @@ static bool on_submit_opengl(vr::EVREye, GLuint object, bool is_rbo, bool is_arr
 		reshade::opengl::make_resource_handle(is_rbo ? GL_RENDERBUFFER : GL_TEXTURE, object), nullptr, nullptr);
 
 	GLint region[4] = { 0, 0, static_cast<GLint>(object_desc.width), static_cast<GLint>(object_desc.height) };
-	if (bounds != nullptr)
-	{
-		region[0] = static_cast<GLint>(object_desc.width * std::min(bounds->uMin, bounds->uMax));
-		region[1] = static_cast<GLint>(object_desc.height * std::min(bounds->vMin, bounds->vMax));
-		region[2] = static_cast<GLint>(object_desc.width * std::max(bounds->uMin, bounds->uMax));
-		region[3] = static_cast<GLint>(object_desc.height * std::max(bounds->vMin, bounds->vMax));
-	}
 
 	return static_cast<reshade::opengl::runtime_impl *>(s_vr_runtime.first)->on_present(object, is_rbo, is_array, object_desc.width, object_desc.height, region);
 }
@@ -131,13 +110,6 @@ static bool on_submit_vulkan(vr::EVREye, const vr::VRVulkanTextureData_t *textur
 		VkOffset2D { 0, 0 },
 		VkExtent2D { texture->m_nWidth, texture->m_nHeight }
 	};
-	if (bounds != nullptr)
-	{
-		region.offset.x = static_cast<int32_t>(texture->m_nWidth * std::min(bounds->uMin, bounds->uMax));
-		region.extent.width = static_cast<uint32_t>(texture->m_nWidth * std::max(bounds->uMin, bounds->uMax) - region.offset.x);
-		region.offset.y = static_cast<int32_t>(texture->m_nHeight * std::min(bounds->vMin, bounds->vMax));
-		region.extent.height = static_cast<uint32_t>(texture->m_nHeight * std::max(bounds->vMin, bounds->vMax) - region.offset.y);
-	}
 
 	const uint32_t layer_index = with_array_data ? static_cast<const vr::VRVulkanTextureArrayData_t *>(texture)->m_unArrayIndex : 0;
 

--- a/source/openvr/openvr.cpp
+++ b/source/openvr/openvr.cpp
@@ -215,6 +215,8 @@ IVRCompositor_Submit_Impl(6, 008, {
 		break;
 	} })
 IVRCompositor_Submit_Impl(4, 009, {
+	if (pTexture->handle == nullptr)
+		return vr::VRCompositorError_InvalidTexture;
 	switch (pTexture->eType)
 	{
 	case vr::TextureType_DirectX:
@@ -225,6 +227,8 @@ IVRCompositor_Submit_Impl(4, 009, {
 		break;
 	} })
 IVRCompositor_Submit_Impl(5, 012, {
+	if (pTexture->handle == nullptr)
+		return vr::VRCompositorError_InvalidTexture;
 	switch (pTexture->eType)
 	{
 	case vr::TextureType_DirectX:

--- a/source/openvr/reshade_vr.hpp
+++ b/source/openvr/reshade_vr.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "reshade_api.hpp"
+
+namespace reshade::vr
+{
+	struct submit_info
+	{
+		static constexpr uint8_t GUID[16] = { 0x20, 0x98, 0x62, 0x08, 0xA2, 0x5E, 0x47, 0x43, 0xBC, 0x2B, 0x42, 0xF2, 0xA6, 0x23, 0xBB, 0xB6 };
+
+		uint8_t eye = 0;
+		api::resource_handle color = {0};
+		api::resource_handle depth = {0};
+		api::region region;
+	};
+}


### PR DESCRIPTION
This took a while, but I now have depth support working on a range of Unity and Unreal VR games, and Skyrim. 

Disclaimer: many effects using depth are probably too expensive for VR, anyway, and are also prone to shimmering artefacts due to slight mismatches in calculation between the two eyes. Therefore, this feature is probably not as useful for VR as for flat games. So not supporting depth for VR games in favour of a simpler VR integration is definitely an option :)

Anyway, here is a rough rundown of what I had to do to get depth working:

### Getting color and depth texture dimensions to match
The majority of games I encountered seem to be using a single big texture for both eyes during submit, and consequently their depth texture is the same. So far, Reshade has copied the submitted region for each eye and processed them separately, then copied the region back. To get a matching depth texture during post-processing, this would require to also do a regional copy of the depth texture. Unfortunately, D3D11's `CopySubResourceRegion` does not support that for depth/stencil textures, and so you'd have to use a (compute) shader for the copy. 
I did originally plan to add a `copy_resource_region` function to the `command_list` interface, but I found no clean way to implement a compute shader call within `d3d11::device_context_impl`.

Instead, I now always give the full color texture to the runtime, so that the original depth texture will match. If the game sends the same texture for both eyes with different regions, I only call the runtime for the first submit, so that we don't process both eyes twice in a frame. It's a bit less elegant, but appears to also be ever so slightly faster for games that use the single big texture approach.

(This also invalidates my statistics hack in the other PR, but that's probably a good thing :D )

### Communicating with the depth plugin
To properly track the depth textures for VR, the depth addon needs a few extra pieces of information from the runtime. For a starter, it needs to even recognize that it's dealing with a VR runtime, and it also needs the current eye and the submitted region to differentiate between the possible depth setups in a VR renderer. I added a small struct with a `set_data` call on the runtime that the depth addon can retrieve.

### Tracking the depth textures
Given that there can be up to two separate depth textures, the state in the `state_tracking_context` (selected texture, view, potential backup) needed to be replicated for the VR eyes. So I extracted them into their own struct. I also added a timestamp of the last drawcall to the counters so that we can decide which depth texture belongs to which eye (if separate textures are used). Most games probably render the left eye first, so that's the default assumption, but I also added a config option to swap the eyes if necessary.

### Dealing with the options for depth setup in VR
I've encountered a couple of different ways that depth textures may be used in VR games, and this is the way I deal with them:

* single big texture for color and depth containing both eyes: this one is straight-forward, as it works pretty much the same as for flat games. Just find the best match for the color texture resolution and provide that. The majority of Unity and Unreal games as well as Skyrim/FO4 use this approach.
* single small texture reused for both eyes: in this case, you have to make an (extra) copy of the depth texture on clear for the first eye. When the game finds only a single matching depth texture, it will automatically set this one up to be copied on clear. If needed, there's also an extra config option to force the clear index for this first eye. I've encountered this setup in 'Elven Assassin', and with this approach depth is working.
* separate small textures for each eye: this is where the timestamp of the last drawcall comes into play to assign the textures to each eye. Aside from that, it's straight-forward.
* separate small textures for color, single big depth texture: 'Talos Principle' does that, and I assume other Croteam games (Serious Sam) probably do this as well. I assume they also have a single big color buffer somewhere, but they submit individual color textures for each eyes. Therefore, the depth texture will not match the color texture size, and without implementing a region copy for depth textures, this case is not solvable and hence not supported in this PR...