### PR TITLE
Updates for VR support in Madness engine games such as AMS2

### DIFF
--- a/res/exports.def
+++ b/res/exports.def
@@ -428,9 +428,12 @@ EXPORTS
 	wglUseFontOutlinesW PRIVATE
 
 	; openvr_api[64].dll
+	VR_Init PRIVATE
 	VR_InitInternal2 PRIVATE
+	VR_Shutdown PRIVATE
 	VR_ShutdownInternal PRIVATE
 	VR_GetGenericInterface PRIVATE
+	VRCompositor PRIVATE
 
 	; vulkan-1.dll
 	vkCreateDevice PRIVATE

--- a/source/d3d11/runtime_d3d11.cpp
+++ b/source/d3d11/runtime_d3d11.cpp
@@ -319,7 +319,7 @@ bool reshade::d3d11::runtime_impl::on_layer_submit(UINT eye, ID3D11Texture2D *so
 		source_desc.MipLevels = 1;
 		source_desc.ArraySize = 1;
 		source_desc.Format = make_dxgi_format_typeless(source_desc.Format);
-		source_desc.BindFlags = D3D11_BIND_RENDER_TARGET;
+		source_desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
 
 		if (HRESULT hr = _device->CreateTexture2D(&source_desc, nullptr, &_backbuffer); FAILED(hr))
 		{

--- a/source/openvr/openvr.cpp
+++ b/source/openvr/openvr.cpp
@@ -15,6 +15,7 @@
 #include "vulkan/vulkan_hooks.hpp"
 #include "vulkan/runtime_vk.hpp"
 #include <openvr.h>
+#include <set>
 
 static std::pair<reshade::runtime *, vr::ETextureType> s_vr_runtime = { nullptr, vr::TextureType_Invalid };
 
@@ -373,6 +374,14 @@ HOOK_EXPORT uint32_t VR_CALLTYPE VR_InitInternal2(vr::EVRInitError *peError, vr:
 
 	return  reshade::hooks::call(VR_InitInternal2)(peError, eApplicationType, pStartupInfo);
 }
+
+HOOK_EXPORT uint32_t VR_CALLTYPE VR_Init(vr::EVRInitError* peError, vr::EVRApplicationType eApplicationType, const char* pStartupInfo = nullptr)
+{
+	LOG(INFO) << "Redirecting " << "VR_Init" << '(' << "peError = " << peError << ", eApplicationType = " << eApplicationType << ", pStartupInfo = " << (pStartupInfo != nullptr ? pStartupInfo : "0") << ')' << " ...";
+
+	return  reshade::hooks::call(VR_Init)(peError, eApplicationType, nullptr);
+}
+
 HOOK_EXPORT void     VR_CALLTYPE VR_ShutdownInternal()
 {
 	LOG(INFO) << "Redirecting " << "VR_ShutdownInternal" << '(' << ')' << " ...";
@@ -398,6 +407,31 @@ HOOK_EXPORT void     VR_CALLTYPE VR_ShutdownInternal()
 	reshade::hooks::call(VR_ShutdownInternal)();
 }
 
+HOOK_EXPORT void     VR_CALLTYPE VR_Shutdown()
+{
+	LOG(INFO) << "Redirecting " << "VR_Shutdown" << '(' << ')' << " ...";
+
+	switch (s_vr_runtime.second)
+	{
+	case vr::TextureType_DirectX:
+		delete static_cast<reshade::d3d11::runtime_impl*>(s_vr_runtime.first);
+		break;
+	case vr::TextureType_DirectX12:
+		delete static_cast<reshade::d3d12::runtime_impl*>(s_vr_runtime.first);
+		break;
+	case vr::TextureType_OpenGL:
+		delete static_cast<reshade::opengl::runtime_impl*>(s_vr_runtime.first);
+		break;
+	case vr::TextureType_Vulkan:
+		delete static_cast<reshade::vulkan::runtime_impl*>(s_vr_runtime.first);
+		break;
+	}
+
+	s_vr_runtime = { nullptr, vr::TextureType_Invalid };
+
+	reshade::hooks::call(VR_Shutdown)();
+}
+
 HOOK_EXPORT void *   VR_CALLTYPE VR_GetGenericInterface(const char *pchInterfaceVersion, vr::EVRInitError *peError)
 {
 	assert(pchInterfaceVersion != nullptr);
@@ -421,4 +455,21 @@ HOOK_EXPORT void *   VR_CALLTYPE VR_GetGenericInterface(const char *pchInterface
 	}
 	
 	return interface_instance;
+}
+
+HOOK_EXPORT void* VR_CALLTYPE VRCompositor()
+{
+	static std::set<void*> installed;
+
+	void* const compositor_instance = reshade::hooks::call(VRCompositor)();
+
+	if (compositor_instance && installed.count(compositor_instance) == 0)
+	{
+		// This is just for ProjectCARS2 / AMS2 and done through trial and error (IVRCompositor_010)
+		// Need a way to work out what the Compositor version is. VR_GetGenericInterface isn't called so don't get to hook it there.
+		reshade::hooks::install("IVRCompositor::Submit", vtable_from_instance(static_cast<vr::IVRCompositor*>(compositor_instance)), 4, reinterpret_cast<reshade::hook::address>(IVRCompositor_Submit_009));
+		installed.insert(compositor_instance);
+	}
+
+	return compositor_instance;
 }


### PR DESCRIPTION
PR to open discussion for AMS2 VR.

These are a few changes to enable ReShade to work on Automobilista 2 in VR. The current implementation and the existing PRs from fholger don't work for AMS2 so I did a little digging. AMS2 / PC2 (Madness Engine) might be a bit of an oddity as you can only load it through Steam for VR mode and the dxgi.dll and d3d11.dll libraries are supplied through SteamVR (or at least are loaded from the Steam folder). This means that the correct name for injecting the ReShade dll doesn't work. However using opengl32.dll does allow it to be loaded, even though it's not an opengl game.

Additionally it uses some old OpenVR helper functions to initialise and submit that aren't caught by the current hooks. I've added new hooks to allow ReShade to load and apply shaders to VR successfully, however because the GetGenericInterface function doesn't get caught by the existing hook we can't tell what version of the compositor is used, so the installed hook for the submit is specific to AMS2 / PC2 and may not work for other games that use the old VRInit method. I tried iterating through all possible interface versions and manually calling GetGenericInterface but they all worked up to the current 027 version. Not sure how else this could be done?

Another interesting issue was that the call to CreateTexture2D failed in the d3d11 runtime on submit. It appears that AMS2 also requires D3D11_BIND_SHADER_RESOURCE flag to be set. I tested this on a couple of other games and it still works but this probably needs more thought.