### PR TITLE
update some intrinsic

### DIFF
--- a/source/effect_symbol_table.cpp
+++ b/source/effect_symbol_table.cpp
@@ -122,6 +122,8 @@ unsigned int reshadefx::type::rank(const type &src, const type &dst)
 		return src.definition == dst.definition ? 32 : 0; // Structs are only compatible if they are the same type
 	if (!src.is_numeric() || !dst.is_numeric())
 		return src.base == dst.base ? 32 : 0; // Numeric values are not compatible with other types
+	if (src.is_matrix() && (!dst.is_matrix() || src.cols != dst.cols || src.rows != dst.rows))
+		return 0; // matrix trunc or dimention not match
 
 	// This table is based on the following rules:
 	//  - Floating point has a higher rank than integer types

--- a/source/effect_symbol_table_intrinsics.inl
+++ b/source/effect_symbol_table_intrinsics.inl
@@ -1221,7 +1221,13 @@ IMPLEMENT_INTRINSIC_SPIRV(normalize, 0, {
 
 // ret transpose(x)
 DEFINE_INTRINSIC(transpose, 0, float2x2, float2x2)
+DEFINE_INTRINSIC(transpose, 0, float2x3, float3x2)
+DEFINE_INTRINSIC(transpose, 0, float2x4, float4x2)
+DEFINE_INTRINSIC(transpose, 0, float3x2, float2x3)
 DEFINE_INTRINSIC(transpose, 0, float3x3, float3x3)
+DEFINE_INTRINSIC(transpose, 0, float3x4, float4x3)
+DEFINE_INTRINSIC(transpose, 0, float4x2, float2x4)
+DEFINE_INTRINSIC(transpose, 0, float4x3, float3x4)
 DEFINE_INTRINSIC(transpose, 0, float4x4, float4x4)
 IMPLEMENT_INTRINSIC_GLSL(transpose, 0, {
 	code += "transpose(" + id_to_name(args[0].base) + ')';
@@ -1353,7 +1359,7 @@ IMPLEMENT_INTRINSIC_SPIRV(mul, 1, {
 
 DEFINE_INTRINSIC(mul, 2, int2x2, int, int2x2)
 DEFINE_INTRINSIC(mul, 2, int2x3, int, int2x3)
-DEFINE_INTRINSIC(mul, 2, int2x3, int, int2x3)
+DEFINE_INTRINSIC(mul, 2, int2x4, int, int2x4)
 DEFINE_INTRINSIC(mul, 2, int3x2, int, int3x2)
 DEFINE_INTRINSIC(mul, 2, int3x3, int, int3x3)
 DEFINE_INTRINSIC(mul, 2, int3x4, int, int3x4)
@@ -1362,7 +1368,7 @@ DEFINE_INTRINSIC(mul, 2, int4x3, int, int4x3)
 DEFINE_INTRINSIC(mul, 2, int4x4, int, int4x4)
 DEFINE_INTRINSIC(mul, 2, float2x2, float, float2x2)
 DEFINE_INTRINSIC(mul, 2, float2x3, float, float2x3)
-DEFINE_INTRINSIC(mul, 2, float2x3, float, float2x3)
+DEFINE_INTRINSIC(mul, 2, float2x4, float, float2x4)
 DEFINE_INTRINSIC(mul, 2, float3x2, float, float3x2)
 DEFINE_INTRINSIC(mul, 2, float3x3, float, float3x3)
 DEFINE_INTRINSIC(mul, 2, float3x4, float, float3x4)


### PR DESCRIPTION
* fix missing mul(scaler, mat2x4) intrinsic overload
* add transpose(non-square-matrix) intrinsics
* add new rule for type ranking, remove compatibility for matrix trunc

btw, I meant to ask is `input.cpp` has the correct encoding? 
git clone always ends up with errors with `u8"OEM ß"` `u8"Ü"` etc.

also `runtime_vk.cpp` is missing reference to `api::format_to_typeless(...)` from `reshade_api_format_tuils.hpp`