### PR TITLE
Added missing dinput8 method (GetdfDIJoystick)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Thumbs.db
 /res/[Vv]ersion.h
 /setup/Config/*.ini
 /setup/Properties/AssemblyInfo.cs
+
+# JetBrains IDEA project files
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,3 @@ Thumbs.db
 /res/[Vv]ersion.h
 /setup/Config/*.ini
 /setup/Properties/AssemblyInfo.cs
-
-# JetBrains IDEA project files
-.idea/

--- a/res/exports.def
+++ b/res/exports.def
@@ -462,5 +462,8 @@ EXPORTS
 	WSARecv = HookWSARecv @91 PRIVATE
 	WSARecvFrom = HookWSARecvFrom @93 PRIVATE
 
-	; dinput8.dll
+	; dinput8.dll (did not add the shared calls here)
 	DirectInput8Create PRIVATE
+	GetdfDIJoystick PRIVATE
+	
+

--- a/res/exports.def
+++ b/res/exports.def
@@ -462,8 +462,6 @@ EXPORTS
 	WSARecv = HookWSARecv @91 PRIVATE
 	WSARecvFrom = HookWSARecvFrom @93 PRIVATE
 
-	; dinput8.dll (did not add the shared calls here)
+	; dinput8.dll
 	DirectInput8Create PRIVATE
 	GetdfDIJoystick PRIVATE
-	
-

--- a/source/windows/dinput8.cpp
+++ b/source/windows/dinput8.cpp
@@ -1,11 +1,26 @@
 /*
- * Copyright (C) 2021 Patrick Mours. All rights reserved.
+ * Copyright (C) 2014 Patrick Mours. All rights reserved.
  * License: https://github.com/crosire/reshade#license
  */
 
+// set direct input version to directx8 to remove the compiler warning
+#define DIRECTINPUT_VERSION 0x0800
+
 #include "dll_log.hpp"
 #include "hook_manager.hpp"
-#include <Windows.h>
+#include <dinput.h>
+//#include <combaseapi.h> // for dll load and unload hooks
+//#include <OleCtl.h> // server register
+
+/*
+ dinput8.dll exports
+2 (0x0002), 1 (0x00000001), DllCanUnloadNow, 0x00015220, None
+1 (0x0001), N/A, DirectInput8Create, 0x00002230, None
+3 (0x0003), 2 (0x00000002), DllGetClassObject, 0x00015330, None
+4 (0x0004), 3 (0x00000003), DllRegisterServer, 0x00024740, None
+5 (0x0005), 4 (0x00000004), DllUnregisterServer, 0x000249c0, None
+6 (0x0006), 5 (0x00000005), GetdfDIJoystick, 0x0000a1c0, None
+*/
 
 HOOK_EXPORT HRESULT WINAPI DirectInput8Create(HINSTANCE hinst, DWORD dwVersion, REFIID riidltf, LPVOID *ppvOut, LPUNKNOWN punkOuter)
 {
@@ -19,3 +34,46 @@ HOOK_EXPORT HRESULT WINAPI DirectInput8Create(HINSTANCE hinst, DWORD dwVersion, 
 
 	return hr;
 }
+
+
+HOOK_EXPORT LPCDIDATAFORMAT WINAPI GetdfDIJoystick()
+{
+	static const auto trampoline = reshade::hooks::call(GetdfDIJoystick);
+	return trampoline();
+}
+
+
+/**
+ * The methods below are shared the use of the following interfaces from combaseapi.h & OleCtl.h
+ * Note: there might be other future hooks that will use the same methods from this section
+ * It might be best to move them to a seperate class when they are needed
+ */
+
+/* Removed for now
+HOOK_EXPORT HRESULT STDAPICALLTYPE DllCanUnloadNow(void)
+{
+	static const auto trampoline = reshade::hooks::call(DllCanUnloadNow);
+	return trampoline();
+}
+
+HOOK_EXPORT HRESULT STDAPICALLTYPE  DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID FAR* ppv)
+{
+	static const auto trampoline = reshade::hooks::call(DllGetClassObject);
+	return trampoline(rclsid,riid,ppv);
+}
+
+
+HOOK_EXPORT HRESULT STDAPICALLTYPE DllRegisterServer(void)
+{
+	static const auto trampoline = reshade::hooks::call(DllRegisterServer);
+	return trampoline();
+}
+
+
+HOOK_EXPORT HRESULT STDAPICALLTYPE DllUnregisterServer(void)
+{
+	static const auto trampoline = reshade::hooks::call(DllUnregisterServer);
+	return trampoline();
+}
+*/
+

--- a/source/windows/dinput8.cpp
+++ b/source/windows/dinput8.cpp
@@ -3,24 +3,12 @@
  * License: https://github.com/crosire/reshade#license
  */
 
-// set direct input version to directx8 to remove the compiler warning
+// Set version to DirectInput 8 to avoid warning
 #define DIRECTINPUT_VERSION 0x0800
 
 #include "dll_log.hpp"
 #include "hook_manager.hpp"
 #include <dinput.h>
-//#include <combaseapi.h> // for dll load and unload hooks
-//#include <OleCtl.h> // server register
-
-/*
- dinput8.dll exports
-2 (0x0002), 1 (0x00000001), DllCanUnloadNow, 0x00015220, None
-1 (0x0001), N/A, DirectInput8Create, 0x00002230, None
-3 (0x0003), 2 (0x00000002), DllGetClassObject, 0x00015330, None
-4 (0x0004), 3 (0x00000003), DllRegisterServer, 0x00024740, None
-5 (0x0005), 4 (0x00000004), DllUnregisterServer, 0x000249c0, None
-6 (0x0006), 5 (0x00000005), GetdfDIJoystick, 0x0000a1c0, None
-*/
 
 HOOK_EXPORT HRESULT WINAPI DirectInput8Create(HINSTANCE hinst, DWORD dwVersion, REFIID riidltf, LPVOID *ppvOut, LPUNKNOWN punkOuter)
 {
@@ -35,45 +23,8 @@ HOOK_EXPORT HRESULT WINAPI DirectInput8Create(HINSTANCE hinst, DWORD dwVersion, 
 	return hr;
 }
 
-
 HOOK_EXPORT LPCDIDATAFORMAT WINAPI GetdfDIJoystick()
 {
 	static const auto trampoline = reshade::hooks::call(GetdfDIJoystick);
 	return trampoline();
 }
-
-
-/**
- * The methods below are shared the use of the following interfaces from combaseapi.h & OleCtl.h
- * Note: there might be other future hooks that will use the same methods from this section
- * It might be best to move them to a seperate class when they are needed
- */
-
-/* Removed for now
-HOOK_EXPORT HRESULT STDAPICALLTYPE DllCanUnloadNow(void)
-{
-	static const auto trampoline = reshade::hooks::call(DllCanUnloadNow);
-	return trampoline();
-}
-
-HOOK_EXPORT HRESULT STDAPICALLTYPE  DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID FAR* ppv)
-{
-	static const auto trampoline = reshade::hooks::call(DllGetClassObject);
-	return trampoline(rclsid,riid,ppv);
-}
-
-
-HOOK_EXPORT HRESULT STDAPICALLTYPE DllRegisterServer(void)
-{
-	static const auto trampoline = reshade::hooks::call(DllRegisterServer);
-	return trampoline();
-}
-
-
-HOOK_EXPORT HRESULT STDAPICALLTYPE DllUnregisterServer(void)
-{
-	static const auto trampoline = reshade::hooks::call(DllUnregisterServer);
-	return trampoline();
-}
-*/
-

--- a/source/windows/dinput8.cpp
+++ b/source/windows/dinput8.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Patrick Mours. All rights reserved.
+ * Copyright (C) 2021 Patrick Mours. All rights reserved.
  * License: https://github.com/crosire/reshade#license
  */
 


### PR DESCRIPTION
There was one dedicated method left if forgot to add into the hook. There are some other ones but they seem to be shared by OLE com interface but i guess they are not needed.

Sorry for the recreation of the pull request. Wanted to clean up that git mess I created...