### PR TITLE
Add Gather overload

### DIFF
--- a/source/effect_symbol_table_intrinsics.inl
+++ b/source/effect_symbol_table_intrinsics.inl
@@ -1733,7 +1733,6 @@ IMPLEMENT_INTRINSIC_SPIRV(tex2Dfetch, 1, {
 // ret tex2DgatherR(s, coords)
 // ret tex2DgatherR(s, coords, offset)
 // ret tex2DgatherR(s, coords, offset0, offset1, offset2, offset3)
-
 DEFINE_INTRINSIC(tex2DgatherR, 0, float4, sampler, float2)
 DEFINE_INTRINSIC(tex2DgatherR, 1, float4, sampler, float2, int2)
 DEFINE_INTRINSIC(tex2DgatherR, 2, float4, sampler, float2, int2, int2, int2, int2)
@@ -1830,15 +1829,18 @@ IMPLEMENT_INTRINSIC_SPIRV(tex2DgatherR, 2, {
 	add_capability(spv::CapabilityImageGatherExtended);
 
 	const spv::Id component = emit_constant(0u);
+	const spv::Id offsets = add_instruction(spv::OpConstantComposite, convert_type({ reshadefx::type::t_int, 2, 1, 0, 4 }), _types_and_constants)
+		.add(args[2].base)
+		.add(args[3].base)
+		.add(args[4].base)
+		.add(args[5].base)
+		.result;
 	return add_instruction(spv::OpImageGather, convert_type(res_type))
 		.add(args[0].base)
 		.add(args[1].base)
 		.add(component)
 		.add(spv::ImageOperandsConstOffsetsMask)
-		.add(args[2].base)
-		.add(args[3].base)
-		.add(args[4].base)
-		.add(args[5].base)
+		.add(offsets)
 		.result;
 	})
 // ret tex2DgatherG(s, coords)
@@ -1940,15 +1942,18 @@ IMPLEMENT_INTRINSIC_SPIRV(tex2DgatherG, 2, {
 	add_capability(spv::CapabilityImageGatherExtended);
 
 	const spv::Id component = emit_constant(1u);
+	const spv::Id offsets = add_instruction(spv::OpConstantComposite, convert_type({ reshadefx::type::t_int, 2, 1, 0, 4 }), _types_and_constants)
+		.add(args[2].base)
+		.add(args[3].base)
+		.add(args[4].base)
+		.add(args[5].base)
+		.result;
 	return add_instruction(spv::OpImageGather, convert_type(res_type))
 		.add(args[0].base)
 		.add(args[1].base)
 		.add(component)
 		.add(spv::ImageOperandsConstOffsetsMask)
-		.add(args[2].base)
-		.add(args[3].base)
-		.add(args[4].base)
-		.add(args[5].base)
+		.add(offsets)
 		.result;
 	})
 // ret tex2DgatherB(s, coords)
@@ -2050,15 +2055,18 @@ IMPLEMENT_INTRINSIC_SPIRV(tex2DgatherB, 2, {
 	add_capability(spv::CapabilityImageGatherExtended);
 
 	const spv::Id component = emit_constant(2u);
+	const spv::Id offsets = add_instruction(spv::OpConstantComposite, convert_type({ reshadefx::type::t_int, 2, 1, 0, 4 }), _types_and_constants)
+		.add(args[2].base)
+		.add(args[3].base)
+		.add(args[4].base)
+		.add(args[5].base)
+		.result;
 	return add_instruction(spv::OpImageGather, convert_type(res_type))
 		.add(args[0].base)
 		.add(args[1].base)
 		.add(component)
 		.add(spv::ImageOperandsConstOffsetsMask)
-		.add(args[2].base)
-		.add(args[3].base)
-		.add(args[4].base)
-		.add(args[5].base)
+		.add(offsets)
 		.result;
 	})
 // ret tex2DgatherA(s, coords)
@@ -2160,15 +2168,18 @@ IMPLEMENT_INTRINSIC_SPIRV(tex2DgatherA, 2, {
 	add_capability(spv::CapabilityImageGatherExtended);
 
 	const spv::Id component = emit_constant(3u);
+	const spv::Id offsets = add_instruction(spv::OpConstantComposite, convert_type({ reshadefx::type::t_int, 2, 1, 0, 4 }), _types_and_constants)
+		.add(args[2].base)
+		.add(args[3].base)
+		.add(args[4].base)
+		.add(args[5].base)
+		.result;
 	return add_instruction(spv::OpImageGather, convert_type(res_type))
 		.add(args[0].base)
 		.add(args[1].base)
 		.add(component)
 		.add(spv::ImageOperandsConstOffsetsMask)
-		.add(args[2].base)
-		.add(args[3].base)
-		.add(args[4].base)
-		.add(args[5].base)
+		.add(offsets)
 		.result;
 	})
 // tex2Dstore(s, coords, value)


### PR DESCRIPTION
template: `tex2Dgather#(sampler2D s, float2 uv, int2 offset0, int2 offset1, int2 offset2, int2 offset3)`

https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/t2d-gatherred-s-float-int2-int2-int2-int2-

https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/textureGatherOffsets.xhtml

https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpImageGather with `ConstOffsets`

the function provides performance gain similar to `tex2Dgather#(sampler2D s, float2 uv)` but with ability to address texels not immediate neighbor.
