### PR TITLE
Several VR fixes, DX10 Support

### DIFF
--- a/source/d3d10/d3d10_impl_swapchain.cpp
+++ b/source/d3d10/d3d10_impl_swapchain.cpp
@@ -194,21 +194,22 @@ bool reshade::d3d10::swapchain_impl::on_layer_submit(UINT eye, ID3D10Texture2D *
 	if (region_width == 0 || region_height == 0)
 		return false;
 
-	//convert the source format to the typeless format
-	const api::format convertedSourceFormat = api::format_to_typeless(convert_format(source_desc.Format));
+	const api::format source_format = convert_format(source_desc.Format);
 
 	//due to rounding errors with float calculation of the bounds we have use a tolerance of 1 pixel per eye (2pixel in total)
 	const INT widthDiff = std::abs(static_cast<INT>(target_width) - static_cast<INT>(_width));
 
-	if (widthDiff > 2 || region_height != _height || convertedSourceFormat != _backbuffer_format)
+	if (widthDiff > 2 || region_height != _height || source_format != _backbuffer_format)
 	{
 		on_reset();
 
-		source_desc.Width = target_width;
+		source_desc.Width = target_width;	
 		source_desc.Height = region_height;
 		source_desc.MipLevels = 1;
 		source_desc.ArraySize = 1;
-		source_desc.Format = convert_format(convertedSourceFormat);
+
+		// convert source format to typeless
+		source_desc.Format = convert_format(api::format_to_typeless(source_format));
 
 		source_desc.BindFlags = D3D10_BIND_RENDER_TARGET | D3D10_BIND_SHADER_RESOURCE;
 
@@ -222,7 +223,7 @@ bool reshade::d3d10::swapchain_impl::on_layer_submit(UINT eye, ID3D10Texture2D *
 		_is_vr = true;
 		_width = target_width;
 		_height = region_height;
-		_backbuffer_format = convertedSourceFormat;
+		_backbuffer_format = source_format;
 
 		//assign the backuffer to the resolved buffer and release the original backbuffer
 		_backbuffer_resolved = _backbuffer;

--- a/source/d3d10/d3d10_impl_swapchain.cpp
+++ b/source/d3d10/d3d10_impl_swapchain.cpp
@@ -101,8 +101,6 @@ bool reshade::d3d10::swapchain_impl::on_init()
 		assert(swap_desc.BufferUsage & DXGI_USAGE_RENDER_TARGET_OUTPUT);
 
 		_backbuffer_resolved = _backbuffer;
-		_backbuffer->Release();
-		assert(_backbuffer.ref_count() == 1);																																							 
 	}
 
 	_width = swap_desc.BufferDesc.Width;

--- a/source/d3d10/d3d10_impl_swapchain.cpp
+++ b/source/d3d10/d3d10_impl_swapchain.cpp
@@ -30,7 +30,8 @@ reshade::d3d10::swapchain_impl::swapchain_impl(device_impl *device, IDXGISwapCha
 		}
 	}
 
-	on_init();
+	if (_orig != nullptr)
+		on_init();
 }
 reshade::d3d10::swapchain_impl::~swapchain_impl()
 {
@@ -100,6 +101,8 @@ bool reshade::d3d10::swapchain_impl::on_init()
 		assert(swap_desc.BufferUsage & DXGI_USAGE_RENDER_TARGET_OUTPUT);
 
 		_backbuffer_resolved = _backbuffer;
+		_backbuffer->Release();
+		assert(_backbuffer.ref_count() == 1);																																							 
 	}
 
 	_width = swap_desc.BufferDesc.Width;
@@ -110,6 +113,20 @@ bool reshade::d3d10::swapchain_impl::on_init()
 }
 void reshade::d3d10::swapchain_impl::on_reset()
 {
+	if (_backbuffer != nullptr)
+	{
+		unsigned int add_references = 0;
+		// Resident Evil 3 releases all references to the back buffer before calling 'IDXGISwapChain::ResizeBuffers', even ones it does not own
+		// Releasing the references ReShade owns would then make the count negative, which consequently breaks DXGI validation, so reset those references here
+		if (_backbuffer.ref_count() == 0)
+			add_references = _backbuffer == _backbuffer_resolved ? 2 : 1;
+		// Add the reference back that was released because of Unreal Engine 4
+		else if (_backbuffer == _backbuffer_resolved)
+			add_references = 1;
+
+		for (unsigned int i = 0; i < add_references; ++i)
+			_backbuffer->AddRef();
+	}																																	 
 	runtime::on_reset();
 
 #if RESHADE_ADDON
@@ -163,4 +180,82 @@ void reshade::d3d10::swapchain_impl::on_present()
 
 	// Apply previous state from application
 	_app_state.apply_and_release();
+}
+
+bool reshade::d3d10::swapchain_impl::on_layer_submit(UINT eye, ID3D10Texture2D *source, const float bounds[4], ID3D10Texture2D **target)
+{
+	assert(eye < 2 && source != nullptr);
+
+	D3D10_TEXTURE2D_DESC source_desc = {};
+	source->GetDesc(&source_desc);
+
+	if (source_desc.SampleDesc.Count > 1)
+		return false; // When the resource is multisampled, 'CopySubresourceRegion' can only copy whole subresources
+
+	D3D10_BOX source_region = { 0, 0, 0, source_desc.Width, source_desc.Height, 1 };
+	if (bounds != nullptr)
+	{
+		source_region.left = static_cast<UINT>(std::floor(source_desc.Width * std::min(bounds[0], bounds[2])));
+		source_region.top  = static_cast<UINT>(std::floor(source_desc.Height * std::min(bounds[1], bounds[3])));
+		source_region.right = static_cast<UINT>(std::ceil(source_desc.Width * std::max(bounds[0], bounds[2])));
+		source_region.bottom = static_cast<UINT>(std::ceil(source_desc.Height * std::max(bounds[1], bounds[3])));
+	}
+
+	const UINT region_width = source_region.right - source_region.left;
+	const UINT target_width = region_width * 2;
+	const UINT region_height = source_region.bottom - source_region.top;
+
+	if (region_width == 0 || region_height == 0)
+		return false;
+
+	//convert the source format to the typeless format
+	const api::format convertedSourceFormat = api::format_to_typeless(convert_format(source_desc.Format));
+
+	//due to rounding errors with float calculation of the bounds we have use a tolerance of 1 pixel per eye (2pixel in total)
+	const INT widthDiff = std::abs(static_cast<INT>(target_width) - static_cast<INT>(_width));
+
+	if (widthDiff > 2 || region_height != _height || convertedSourceFormat != _backbuffer_format)
+	{
+		on_reset();
+
+		source_desc.Width = target_width;
+		source_desc.Height = region_height;
+		source_desc.MipLevels = 1;
+		source_desc.ArraySize = 1;
+		source_desc.Format = convert_format(convertedSourceFormat);
+
+		source_desc.BindFlags = D3D10_BIND_RENDER_TARGET | D3D10_BIND_SHADER_RESOURCE;
+
+		if (HRESULT hr = static_cast<device_impl *>(_device)->_orig->CreateTexture2D(&source_desc, nullptr, &_backbuffer); FAILED(hr))
+		{
+			LOG(ERROR) << "Failed to create region texture!" << " HRESULT is " << hr << '.';
+			LOG(DEBUG) << "> Details: Width = " << source_desc.Width << ", Height = " << source_desc.Height << ", Format = " << source_desc.Format;
+			return false;
+		}
+
+		_is_vr = true;
+		_width = target_width;
+		_height = region_height;
+		_backbuffer_format = convertedSourceFormat;
+
+		//assign the backuffer to the resolved buffer and release the original backbuffer
+		_backbuffer_resolved = _backbuffer;
+		_backbuffer->Release();
+		assert(_backbuffer.ref_count() == 1);
+
+#if RESHADE_ADDON
+		invoke_addon_event<addon_event::init_swapchain>(this);
+#endif
+
+		if (!runtime::on_init(nullptr))
+			return false;
+	}
+
+	// Copy region of the source texture (in case of an array texture, copy from the layer corresponding to the current eye)
+	ID3D10Device *const device = static_cast<device_impl *>(_graphics_queue)->_orig;
+	device->CopySubresourceRegion(_backbuffer.get(), 0, eye * region_width, 0, 0, source, source_desc.ArraySize == 2 ? eye : 0, &source_region);
+
+	*target = _backbuffer.get();
+
+	return true;
 }

--- a/source/d3d10/d3d10_impl_swapchain.cpp
+++ b/source/d3d10/d3d10_impl_swapchain.cpp
@@ -217,15 +217,12 @@ bool reshade::d3d10::swapchain_impl::on_layer_submit(UINT eye, ID3D10Texture2D *
 			return false;
 		}
 
+		_backbuffer_resolved = _backbuffer;
+
 		_is_vr = true;
 		_width = target_width;
 		_height = region_height;
 		_backbuffer_format = source_format;
-
-		// Assign the backuffer to the resolved buffer and release the original backbuffer
-		_backbuffer_resolved = _backbuffer;
-		_backbuffer->Release();
-		assert(_backbuffer.ref_count() == 1);
 
 #if RESHADE_ADDON
 		invoke_addon_event<addon_event::init_swapchain>(this);

--- a/source/d3d10/d3d10_impl_swapchain.cpp
+++ b/source/d3d10/d3d10_impl_swapchain.cpp
@@ -113,20 +113,6 @@ bool reshade::d3d10::swapchain_impl::on_init()
 }
 void reshade::d3d10::swapchain_impl::on_reset()
 {
-	if (_backbuffer != nullptr)
-	{
-		unsigned int add_references = 0;
-		// Resident Evil 3 releases all references to the back buffer before calling 'IDXGISwapChain::ResizeBuffers', even ones it does not own
-		// Releasing the references ReShade owns would then make the count negative, which consequently breaks DXGI validation, so reset those references here
-		if (_backbuffer.ref_count() == 0)
-			add_references = _backbuffer == _backbuffer_resolved ? 2 : 1;
-		// Add the reference back that was released because of Unreal Engine 4
-		else if (_backbuffer == _backbuffer_resolved)
-			add_references = 1;
-
-		for (unsigned int i = 0; i < add_references; ++i)
-			_backbuffer->AddRef();
-	}																																	 
 	runtime::on_reset();
 
 #if RESHADE_ADDON

--- a/source/d3d10/d3d10_impl_swapchain.hpp
+++ b/source/d3d10/d3d10_impl_swapchain.hpp
@@ -27,6 +27,7 @@ namespace reshade::d3d10
 		bool on_init();
 		void on_reset();
 		void on_present();
+		bool on_layer_submit(UINT eye, ID3D10Texture2D *source, const float bounds[4], ID3D10Texture2D **target);
 
 	private:
 		state_block _app_state;

--- a/source/d3d11/d3d11_impl_swapchain.cpp
+++ b/source/d3d11/d3d11_impl_swapchain.cpp
@@ -237,15 +237,15 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 			return false;
 		}
 
+		_backbuffer_resolved = _backbuffer;
+		// Clear additional reference because of Unreal Engine 4 workaround (see 'on_init' and 'on_reset')
+		_backbuffer->Release();
+		assert(_backbuffer.ref_count() == 1);
+
 		_is_vr = true;
 		_width = target_width;
 		_height = region_height;
 		_backbuffer_format = source_format;
-
-		// Assign the backuffer to the resolved buffer and release the original backbuffer
-		_backbuffer_resolved = _backbuffer;
-		_backbuffer->Release();
-		assert(_backbuffer.ref_count() == 1);
 
 #if RESHADE_ADDON
 		invoke_addon_event<addon_event::init_swapchain>(this);

--- a/source/d3d11/d3d11_impl_swapchain.cpp
+++ b/source/d3d11/d3d11_impl_swapchain.cpp
@@ -243,8 +243,10 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 		_height = region_height;
 		_backbuffer_format = convertedSourceFormat;
 
-		//assign the backuffer to the resolved buffer
+		//assign the backuffer to the resolved buffer and release the original backbuffer
 		_backbuffer_resolved = _backbuffer;
+		_backbuffer->Release();
+		assert(_backbuffer.ref_count() == 1);
 
 #if RESHADE_ADDON
 		invoke_addon_event<addon_event::init_swapchain>(this);

--- a/source/d3d11/d3d11_impl_swapchain.cpp
+++ b/source/d3d11/d3d11_impl_swapchain.cpp
@@ -236,6 +236,9 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 		_height = region_height;
 		_backbuffer_format = convert_format(source_desc.Format);
 
+		//assign the backuffer to the resolved buffer
+		_backbuffer_resolved = _backbuffer;
+
 #if RESHADE_ADDON
 		invoke_addon_event<addon_event::init_swapchain>(this);
 #endif

--- a/source/d3d11/d3d11_impl_swapchain.cpp
+++ b/source/d3d11/d3d11_impl_swapchain.cpp
@@ -221,11 +221,6 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 
 	if (widthDiff > 2 || region_height != _height || convertedSourceFormat != _backbuffer_format)
 	{
-		LOG(DEBUG) << "Recreate texture: width " << _width << ", target_width " << target_width << ",_height " << _height << ", region_height " << region_height
-			<< ", backbuffer format " << convert_format(_backbuffer_format) << ", converted source format "<< convert_format(convertedSourceFormat);
-
-		LOG(DEBUG) << "Source width " << source_desc.Width << " , bound0 " << bounds[0] << ", bounds2 " << bounds[2] << ", region_width " << region_width;
-
 		on_reset();
 
 		source_desc.Width = target_width;

--- a/source/d3d11/d3d11_impl_swapchain.cpp
+++ b/source/d3d11/d3d11_impl_swapchain.cpp
@@ -213,15 +213,22 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 	if (region_width == 0 || region_height == 0)
 		return false;
 
-	if (target_width != _width || region_height != _height || convert_format(source_desc.Format) != _backbuffer_format)
+	//convert the source format to the typeless format
+	const api::format convertedSourceFormat = api::format_to_typeless(convert_format(source_desc.Format));
+
+	if (target_width != _width || region_height != _height || convertedSourceFormat != _backbuffer_format)
 	{
+		LOG(DEBUG) << "Recreate texture: width " << _width << ", target_width " << target_width << ",_height " << _height << ", region_height " << region_height
+			<< ", backbuffer format " << convert_format(_backbuffer_format) << ", converted source format "<< convert_format(convertedSourceFormat) ;
+
 		on_reset();
 
 		source_desc.Width = target_width;
 		source_desc.Height = region_height;
 		source_desc.MipLevels = 1;
 		source_desc.ArraySize = 1;
-		source_desc.Format = convert_format(api::format_to_typeless(convert_format(source_desc.Format)));
+		source_desc.Format = convert_format(convertedSourceFormat);
+
 		source_desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
 
 		if (HRESULT hr = static_cast<device_impl *>(_device)->_orig->CreateTexture2D(&source_desc, nullptr, &_backbuffer); FAILED(hr))
@@ -234,7 +241,7 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 		_is_vr = true;
 		_width = target_width;
 		_height = region_height;
-		_backbuffer_format = convert_format(source_desc.Format);
+		_backbuffer_format = convertedSourceFormat;
 
 		//assign the backuffer to the resolved buffer
 		_backbuffer_resolved = _backbuffer;

--- a/source/d3d11/d3d11_impl_swapchain.cpp
+++ b/source/d3d11/d3d11_impl_swapchain.cpp
@@ -213,13 +213,12 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 	if (region_width == 0 || region_height == 0)
 		return false;
 
-	//convert the source format to the typeless format
-	const api::format convertedSourceFormat = api::format_to_typeless(convert_format(source_desc.Format));
+	const api::format source_format = convert_format(source_desc.Format);
 
 	//due to rounding errors with float calculation of the bounds we have use a tolerance of 1 pixel per eye (2pixel in total)
 	const INT widthDiff = std::abs(static_cast<INT>(target_width) - static_cast<INT>(_width));
 
-	if (widthDiff > 2 || region_height != _height || convertedSourceFormat != _backbuffer_format)
+	if (widthDiff > 2 || region_height != _height || source_format != _backbuffer_format)
 	{
 		on_reset();
 
@@ -227,7 +226,9 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 		source_desc.Height = region_height;
 		source_desc.MipLevels = 1;
 		source_desc.ArraySize = 1;
-		source_desc.Format = convert_format(convertedSourceFormat);
+
+		// convert source format to typeless
+		source_desc.Format = convert_format(api::format_to_typeless(source_format));
 
 		source_desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
 
@@ -241,7 +242,7 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 		_is_vr = true;
 		_width = target_width;
 		_height = region_height;
-		_backbuffer_format = convertedSourceFormat;
+		_backbuffer_format = source_format;
 
 		//assign the backuffer to the resolved buffer and release the original backbuffer
 		_backbuffer_resolved = _backbuffer;

--- a/source/d3d11/d3d11_impl_swapchain.cpp
+++ b/source/d3d11/d3d11_impl_swapchain.cpp
@@ -187,6 +187,7 @@ void reshade::d3d11::swapchain_impl::on_present()
 	// Apply previous state from application
 	_app_state.apply_and_release();
 }
+
 bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *source, const float bounds[4], ID3D11Texture2D **target)
 {
 	assert(eye < 2 && source != nullptr);
@@ -213,12 +214,12 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 	if (region_width == 0 || region_height == 0)
 		return false;
 
+	// Due to rounding errors with the bounds we have to use a tolerance of 1 pixel per eye (2 pixels in total)
+	const  INT width_difference = std::abs(static_cast<INT>(target_width) - static_cast<INT>(_width));
+
 	const api::format source_format = convert_format(source_desc.Format);
 
-	//due to rounding errors with float calculation of the bounds we have use a tolerance of 1 pixel per eye (2pixel in total)
-	const INT widthDiff = std::abs(static_cast<INT>(target_width) - static_cast<INT>(_width));
-
-	if (widthDiff > 2 || region_height != _height || source_format != _backbuffer_format)
+	if (width_difference > 2 || region_height != _height || source_format != _backbuffer_format)
 	{
 		on_reset();
 
@@ -226,10 +227,7 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 		source_desc.Height = region_height;
 		source_desc.MipLevels = 1;
 		source_desc.ArraySize = 1;
-
-		// convert source format to typeless
 		source_desc.Format = convert_format(api::format_to_typeless(source_format));
-
 		source_desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
 
 		if (HRESULT hr = static_cast<device_impl *>(_device)->_orig->CreateTexture2D(&source_desc, nullptr, &_backbuffer); FAILED(hr))
@@ -244,7 +242,7 @@ bool reshade::d3d11::swapchain_impl::on_layer_submit(UINT eye, ID3D11Texture2D *
 		_height = region_height;
 		_backbuffer_format = source_format;
 
-		//assign the backuffer to the resolved buffer and release the original backbuffer
+		// Assign the backuffer to the resolved buffer and release the original backbuffer
 		_backbuffer_resolved = _backbuffer;
 		_backbuffer->Release();
 		assert(_backbuffer.ref_count() == 1);

--- a/source/d3d12/d3d12_impl_swapchain.cpp
+++ b/source/d3d12/d3d12_impl_swapchain.cpp
@@ -175,6 +175,7 @@ bool reshade::d3d12::swapchain_impl::on_present(ID3D12Resource *source, HWND hwn
 	on_present();
 	return true;
 }
+
 bool reshade::d3d12::swapchain_impl::on_layer_submit(UINT eye, ID3D12Resource *source, const float bounds[4], ID3D12Resource **target)
 {
 	assert(eye < 2 && source != nullptr);
@@ -200,13 +201,12 @@ bool reshade::d3d12::swapchain_impl::on_layer_submit(UINT eye, ID3D12Resource *s
 	if (region_width == 0 || region_height == 0)
 		return false;
 
-	//convert the source format to the typeless format
-	const api::format convertedSourceFormat = api::format_to_typeless(convert_format(source_desc.Format));
+	// Due to rounding errors with the bounds we have to use a tolerance of 1 pixel per eye (2 pixels in total)
+	const  INT width_difference = std::abs(static_cast<INT>(target_width) - static_cast<INT>(_width));
 
-	//due to rounding errors with float calculation of the bounds we have use a tolerance of 1 pixel per eye (2pixel in total)
-	const INT widthDiff = std::abs(static_cast<INT>(target_width) - static_cast<INT>(_width));
+	const api::format source_format = convert_format(source_desc.Format);
 
-	if (widthDiff > 2 || region_height != _height || convertedSourceFormat != _backbuffer_format)
+	if (width_difference > 2 || region_height != _height || source_format != _backbuffer_format)
 	{
 		on_reset();
 
@@ -216,7 +216,7 @@ bool reshade::d3d12::swapchain_impl::on_layer_submit(UINT eye, ID3D12Resource *s
 		source_desc.Height = region_height;
 		source_desc.DepthOrArraySize = 1;
 		source_desc.MipLevels = 1;
-		source_desc.Format = convert_format(convertedSourceFormat);
+		source_desc.Format = convert_format(api::format_to_typeless(source_format));
 
 		const D3D12_HEAP_PROPERTIES heap_props = { D3D12_HEAP_TYPE_DEFAULT };
 
@@ -230,7 +230,7 @@ bool reshade::d3d12::swapchain_impl::on_layer_submit(UINT eye, ID3D12Resource *s
 		_is_vr = true;
 		_width = target_width;
 		_height = region_height;
-		_backbuffer_format = convertedSourceFormat;
+		_backbuffer_format = source_format;
 
 #if RESHADE_ADDON
 		invoke_addon_event<addon_event::init_swapchain>(this);

--- a/source/opengl/opengl_impl_device.cpp
+++ b/source/opengl/opengl_impl_device.cpp
@@ -1705,6 +1705,7 @@ reshade::api::resource_desc reshade::opengl::device_impl::get_resource_desc(api:
 		internal_format = (object == GL_DEPTH_STENCIL_ATTACHMENT || object == GL_DEPTH_ATTACHMENT || object == GL_STENCIL_ATTACHMENT) ? _default_depth_format : _default_color_format;
 		break;
 	default:
+		LOG(DEBUG) << "Could not find supported resource type for target " << target;
 		assert(false);
 		break;
 	}

--- a/source/opengl/opengl_impl_device.cpp
+++ b/source/opengl/opengl_impl_device.cpp
@@ -1705,7 +1705,6 @@ reshade::api::resource_desc reshade::opengl::device_impl::get_resource_desc(api:
 		internal_format = (object == GL_DEPTH_STENCIL_ATTACHMENT || object == GL_DEPTH_ATTACHMENT || object == GL_STENCIL_ATTACHMENT) ? _default_depth_format : _default_color_format;
 		break;
 	default:
-		LOG(DEBUG) << "Could not find supported resource type for target " << target;
 		assert(false);
 		break;
 	}

--- a/source/opengl/opengl_impl_swapchain.cpp
+++ b/source/opengl/opengl_impl_swapchain.cpp
@@ -154,12 +154,13 @@ void reshade::opengl::swapchain_impl::on_present(bool default_fbo)
 	// Apply previous state from application
 	_app_state.apply(_compatibility_context);
 }
+
 bool reshade::opengl::swapchain_impl::on_layer_submit(uint32_t eye, GLuint source_object, bool is_rbo, bool is_array, const float bounds[4], GLuint *target_rbo)
 {
 	assert(eye < 2 && source_object != 0);
 
 	api::resource_desc object_desc = get_resource_desc( 
-		reshade::opengl::make_resource_handle(is_rbo ? GL_RENDERBUFFER : (is_array? GL_TEXTURE_2D_ARRAY: GL_TEXTURE_2D), source_object));
+		reshade::opengl::make_resource_handle(is_rbo ? GL_RENDERBUFFER : (is_array ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D), source_object));
 
 	GLint source_region[4] = { 0, 0, static_cast<GLint>(object_desc.texture.width), static_cast<GLint>(object_desc.texture.height) };
 	if (bounds != nullptr)
@@ -173,10 +174,10 @@ bool reshade::opengl::swapchain_impl::on_layer_submit(uint32_t eye, GLuint sourc
 	const GLint region_width = source_region[2] - source_region[0];
 	object_desc.texture.width = region_width * 2;
 
-	//due to rounding errors with float calculation of the bounds we have use a tolerance of 1 pixel per eye (2pixel in total)
-	const INT widthDiff = std::abs(static_cast<INT>(object_desc.texture.width) - static_cast<INT>(_width));
+	// Due to rounding errors with the bounds we have to use a tolerance of 1 pixel per eye (2 pixels in total)
+	const int32_t width_difference = std::abs(static_cast<int32_t>(object_desc.texture.width) - static_cast<int32_t>(_width));
 
-	if (widthDiff  > 2 || object_desc.texture.height != _height)
+	if (width_difference> 2 || object_desc.texture.height != _height)
 	{
 		on_reset();
 

--- a/source/opengl/opengl_impl_swapchain.cpp
+++ b/source/opengl/opengl_impl_swapchain.cpp
@@ -158,8 +158,7 @@ bool reshade::opengl::swapchain_impl::on_layer_submit(uint32_t eye, GLuint sourc
 {
 	assert(eye < 2 && source_object != 0);
 
-	reshade::api::resource_desc object_desc = get_resource_desc(
-		reshade::opengl::make_resource_handle(is_rbo ? GL_RENDERBUFFER : GL_TEXTURE, source_object));
+	reshade::api::resource_desc object_desc = get_resource_desc( reshade::opengl::make_resource_handle(is_rbo ? GL_RENDERBUFFER : (is_array? GL_TEXTURE_2D_ARRAY: GL_TEXTURE_2D), source_object));
 
 	GLint source_region[4] = { 0, 0, static_cast<GLint>(object_desc.texture.width), static_cast<GLint>(object_desc.texture.height) };
 	if (bounds != nullptr)

--- a/source/opengl/opengl_impl_swapchain.cpp
+++ b/source/opengl/opengl_impl_swapchain.cpp
@@ -163,16 +163,19 @@ bool reshade::opengl::swapchain_impl::on_layer_submit(uint32_t eye, GLuint sourc
 	GLint source_region[4] = { 0, 0, static_cast<GLint>(object_desc.texture.width), static_cast<GLint>(object_desc.texture.height) };
 	if (bounds != nullptr)
 	{
-		source_region[0] = static_cast<GLint>(object_desc.texture.width * std::min(bounds[0], bounds[2]));
-		source_region[1] = static_cast<GLint>(object_desc.texture.height * std::min(bounds[1], bounds[3]));
-		source_region[2] = static_cast<GLint>(object_desc.texture.width * std::max(bounds[0], bounds[2]));
-		source_region[3] = static_cast<GLint>(object_desc.texture.height * std::max(bounds[1], bounds[3]));
+		source_region[0] = static_cast<GLint>(std::floor(object_desc.texture.width * std::min(bounds[0], bounds[2])));
+		source_region[1] = static_cast<GLint>(std::floor(object_desc.texture.height * std::min(bounds[1], bounds[3])));
+		source_region[2] = static_cast<GLint>(std::ceil(object_desc.texture.width * std::max(bounds[0], bounds[2])));
+		source_region[3] = static_cast<GLint>(std::ceil(object_desc.texture.height * std::max(bounds[1], bounds[3])));
 	}
 
 	const GLint region_width = source_region[2] - source_region[0];
 	object_desc.texture.width = region_width * 2;
 
-	if (object_desc.texture.width != _width || object_desc.texture.height != _height)
+	//due to rounding errors with float calculation of the bounds we have use a tolerance of 1 pixel per eye (2pixel in total)
+	const INT widthDiff = std::abs(static_cast<INT>(object_desc.texture.width) - static_cast<INT>(_width));
+
+	if (widthDiff  > 2 || object_desc.texture.height != _height)
 	{
 		on_reset();
 

--- a/source/opengl/opengl_impl_swapchain.cpp
+++ b/source/opengl/opengl_impl_swapchain.cpp
@@ -159,7 +159,7 @@ bool reshade::opengl::swapchain_impl::on_layer_submit(uint32_t eye, GLuint sourc
 {
 	assert(eye < 2 && source_object != 0);
 
-	api::resource_desc object_desc = get_resource_desc( 
+	api::resource_desc object_desc = get_resource_desc(
 		reshade::opengl::make_resource_handle(is_rbo ? GL_RENDERBUFFER : (is_array ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D), source_object));
 
 	GLint source_region[4] = { 0, 0, static_cast<GLint>(object_desc.texture.width), static_cast<GLint>(object_desc.texture.height) };

--- a/source/openvr/openvr.cpp
+++ b/source/openvr/openvr.cpp
@@ -41,46 +41,6 @@ static inline vr::VRTextureBounds_t calc_side_by_side_bounds(vr::EVREye eye, con
 	return bounds;
 }
 
-/*
-Get the device api based on the texture type
-*/
-static inline boolean isD3D10(void *pTexture)
-{
-	//do swapchain check for quick checks if set
-	if(s_vr_swapchain.first != nullptr){
-		return s_vr_swapchain.first->get_device()->get_api() == reshade::api::device_api::d3d10;
-	}
-
-	/*
-	* As DX10 and DX11 are very simular it is not easy to detect from texture type if it is
-	* A ID3D10Texture2D or ID3D11Texture2D texture, therfore it is fetched from the device that reshade stores in the
-	* private data of the device itself. 
-	*/
-	ID3D10Texture2D *dxTexture = static_cast<ID3D10Texture2D *>(pTexture);
-	
-	//fetch device from texture
-	com_ptr<ID3D10Device> device;
-	dxTexture->GetDevice(&device);
-
-	// check is if the texture is a DX10 texture
-	if(device.get() != nullptr){
-		D3D10Device *device_proxy = nullptr;
-		UINT data_size = sizeof(device_proxy);
-
-		//try to fetch device from private data
-		if(SUCCEEDED(device->GetPrivateData(__uuidof(D3D10Device), &data_size, reinterpret_cast<void *>(&device_proxy)))){
-			if(device_proxy != nullptr ){
-				// check if device really using the DX10 api
-				return device_proxy->get_api() == reshade::api::device_api::d3d10;
-			}
-		}
-	}
-	 
-	// assume it is DX11. DX12 has its own vr TextureType in the compositor
-	return false;
-}
-
-
 static vr::EVRCompositorError on_submit_d3d10(vr::EVREye eye, ID3D10Texture2D *texture, const vr::VRTextureBounds_t *bounds, vr::EVRSubmitFlags flags,
 	std::function<vr::EVRCompositorError(vr::EVREye eye, void *texture, const vr::VRTextureBounds_t *bounds, vr::EVRSubmitFlags flags)> submit)
 {
@@ -144,6 +104,15 @@ static vr::EVRCompositorError on_submit_d3d11(vr::EVREye eye, ID3D11Texture2D *t
 	com_ptr<ID3D11Device> device;
 	D3D11Device *device_proxy = nullptr; // Was set via 'SetPrivateData', so do not use a 'com_ptr' here, since 'GetPrivateData' will not add a reference
 	texture->GetDevice(&device);
+
+	// check if the passed texture is actually a D3D10 texture.
+	// This must be done on the device as the interface of the texture would succeed even when it is a D3D11 texture
+	if (com_ptr<ID3D10Device> device10;
+		device->QueryInterface(&device10) == S_OK){
+		// Whoops, this is actually a D3D10 texture, redirect ...
+		return on_submit_d3d10(eye, reinterpret_cast<ID3D10Texture2D *>(texture), bounds, flags, submit);
+	}
+
 	if (UINT data_size = sizeof(device_proxy);
 		FAILED(device->GetPrivateData(__uuidof(D3D11Device), &data_size, reinterpret_cast<void *>(&device_proxy))))
 		goto normal_submit; // No proxy device found, so just submit normally
@@ -405,12 +374,7 @@ VR_Interface_Impl(IVRCompositor, Submit, 6, 007, {
 	switch (eTextureType)
 	{
 	case vr::TextureType_DirectX:
-		//switch between DX10 & DX11
-		if(isD3D10(pTexture)){
-			return on_submit_d3d10(eEye, static_cast<ID3D10Texture2D *>(pTexture), pBounds, vr::Submit_Default, submit_lambda);
-		} else {
-			return on_submit_d3d11(eEye, static_cast<ID3D11Texture2D *>(pTexture), pBounds, vr::Submit_Default, submit_lambda);
-		}
+		return on_submit_d3d11(eEye, static_cast<ID3D11Texture2D *>(pTexture), pBounds, vr::Submit_Default, submit_lambda);
 	case vr::TextureType_OpenGL: 
 		return submit_lambda(eEye, pTexture, pBounds, vr::Submit_Default); // Unsupported because overwritting would require the 'vr::Submit_GlRenderBuffer' flag, which did not yet exist in this OpenVR version
 	default:
@@ -429,12 +393,7 @@ VR_Interface_Impl(IVRCompositor, Submit, 6, 008, {
 	switch (eTextureType)
 	{
 	case vr::TextureType_DirectX:
-		//switch between DX10 & DX11
-		if(isD3D10(pTexture)){
-			return on_submit_d3d10(eEye, static_cast<ID3D10Texture2D *>(pTexture), pBounds, nSubmitFlags, submit_lambda);
-		} else {
-			return on_submit_d3d11(eEye, static_cast<ID3D11Texture2D *>(pTexture), pBounds, nSubmitFlags, submit_lambda);
-		}
+		return on_submit_d3d11(eEye, static_cast<ID3D11Texture2D *>(pTexture), pBounds, nSubmitFlags, submit_lambda);
 	case vr::TextureType_OpenGL: 
 		return on_submit_opengl(eEye, static_cast<GLuint>(reinterpret_cast<uintptr_t>(pTexture)), pBounds, nSubmitFlags, submit_lambda);
 	default:
@@ -458,12 +417,7 @@ VR_Interface_Impl(IVRCompositor, Submit, 4, 009, {
 	switch (pTexture->eType)
 	{
 	case vr::TextureType_DirectX:
-		//switch between DX10 & DX11
-		if(isD3D10(pTexture->handle)){
-			return on_submit_d3d10(eEye, static_cast<ID3D10Texture2D *>(pTexture->handle), pBounds, nSubmitFlags, submit_lambda);
-		} else {
-			return on_submit_d3d11(eEye, static_cast<ID3D11Texture2D *>(pTexture->handle), pBounds, nSubmitFlags, submit_lambda);
-		}
+		return on_submit_d3d11(eEye, static_cast<ID3D11Texture2D *>(pTexture->handle), pBounds, nSubmitFlags, submit_lambda);
 	case vr::TextureType_OpenGL:
 		return on_submit_opengl(eEye, static_cast<GLuint>(reinterpret_cast<uintptr_t>(pTexture->handle)), pBounds, nSubmitFlags, submit_lambda);
 	default:
@@ -505,12 +459,7 @@ VR_Interface_Impl(IVRCompositor, Submit, 5, 012, {
 	switch (pTexture->eType)
 	{
 	case vr::TextureType_DirectX:
-		// switch between DX10 & DX11
-		if(isD3D10(pTexture->handle)){
-			return on_submit_d3d10(eEye, static_cast<ID3D10Texture2D *>(pTexture->handle), pBounds, nSubmitFlags, submit_lambda);
-		} else {
-			return on_submit_d3d11(eEye, static_cast<ID3D11Texture2D *>(pTexture->handle), pBounds, nSubmitFlags, submit_lambda);
-		}
+		return on_submit_d3d11(eEye, static_cast<ID3D11Texture2D *>(pTexture->handle), pBounds, nSubmitFlags, submit_lambda);
 	case vr::TextureType_DirectX12:
 		return on_submit_d3d12(eEye, static_cast<const vr::D3D12TextureData_t *>(pTexture->handle), pBounds, nSubmitFlags, submit_lambda);
 	case vr::TextureType_OpenGL:

--- a/source/openvr/openvr.cpp
+++ b/source/openvr/openvr.cpp
@@ -29,10 +29,12 @@ static inline vr::VRTextureBounds_t calc_side_by_side_bounds(vr::EVREye eye, con
 	vr::VRTextureBounds_t bounds = (eye != vr::Eye_Right) ?
 		vr::VRTextureBounds_t { 0.0f, 0.0f, 0.5f, 1.0f } : // Left half of the texture
 		vr::VRTextureBounds_t { 0.5f, 0.0f, 1.0f, 1.0f };  // Right half of the texture
+
 	if (orig_bounds != nullptr && orig_bounds->uMin > orig_bounds->uMax)
 		std::swap(bounds.uMin, bounds.uMax);
 	if (orig_bounds != nullptr && orig_bounds->vMin > orig_bounds->vMax)
 		std::swap(bounds.vMin, bounds.vMax);
+
 	return bounds;
 }
 
@@ -65,8 +67,9 @@ static vr::EVRCompositorError on_submit_d3d11(vr::EVREye eye, ID3D11Texture2D *t
 		reinterpret_cast<const float *>(bounds),
 		&target_texture))
 	{
-	normal_submit:
+		normal_submit:
 		// Failed to initialize effect runtime or copy the eye texture, so submit normally without applying effects
+		LOG(DEBUG) << "Failed to initialize effect runtime or copy the eye texture for eye " << eye;
 		return submit(eye, texture, bounds, flags);
 	}
 

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -2709,10 +2709,9 @@ void reshade::runtime::draw_variable_editor()
 			}
 
 			// Reloading an effect file invalidates all textures, but the statistics window may already have drawn references to those, so need to reset it
-			ImGuiWindow *statisticsWindow = ImGui::FindWindowByName("Statistics");
-			if(statisticsWindow != nullptr){
-				statisticsWindow->DrawList->CmdBuffer.clear();
-			}
+			if (ImGuiWindow *const statistics_window = ImGui::FindWindowByName("Statistics");
+				statistics_window != nullptr)
+				statistics_window->DrawList->CmdBuffer.clear();
 		}
 	}
 
@@ -3061,7 +3060,9 @@ void reshade::runtime::draw_technique_editor()
 		reload_effect(force_reload_effect, true);
 
 		// Reloading an effect file invalidates all textures, but the statistics window may already have drawn references to those, so need to reset it
-		ImGui::FindWindowByName("Statistics")->DrawList->CmdBuffer.clear();
+		if (ImGuiWindow *const statistics_window = ImGui::FindWindowByName("Statistics");
+			statistics_window != nullptr)
+			statistics_window->DrawList->CmdBuffer.clear();
 	}
 }
 
@@ -3160,7 +3161,9 @@ void reshade::runtime::draw_code_editor(editor_instance &instance)
 			reload_effect(instance.effect_index);
 
 			// Reloading an effect file invalidates all textures, but the statistics window may already have drawn references to those, so need to reset it
-			ImGui::FindWindowByName("Statistics")->DrawList->CmdBuffer.clear();
+			if (ImGuiWindow *const statistics_window = ImGui::FindWindowByName("Statistics");
+				statistics_window != nullptr)
+				statistics_window->DrawList->CmdBuffer.clear();
 		}
 	}
 

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -2694,7 +2694,10 @@ void reshade::runtime::draw_variable_editor()
 			}
 
 			// Reloading an effect file invalidates all textures, but the statistics window may already have drawn references to those, so need to reset it
-			ImGui::FindWindowByName("Statistics")->DrawList->CmdBuffer.clear();
+			ImGuiWindow *statisticsWindow = ImGui::FindWindowByName("Statistics");
+			if(statisticsWindow != nullptr){
+				statisticsWindow->DrawList->CmdBuffer.clear();
+			}
 		}
 	}
 

--- a/source/runtime_gui_vr.cpp
+++ b/source/runtime_gui_vr.cpp
@@ -136,7 +136,8 @@ void reshade::runtime::draw_gui_vr()
 
 	imgui_io.KeysDown[0x08] = false;
 	imgui_io.KeysDown[0x09] = false;
-
+	imgui_io.KeysDown[0x0D] = false;
+	
 	vr::VREvent_t ev;
 	while (s_overlay->PollNextOverlayEvent(s_main_handle, &ev, sizeof(ev)))
 	{
@@ -183,6 +184,8 @@ void reshade::runtime::draw_gui_vr()
 				imgui_io.KeysDown[0x08] = true;
 			if (ev.data.keyboard.cNewInput[0] == '\t')
 				imgui_io.KeysDown[0x09] = true;
+			if (ev.data.keyboard.cNewInput[0] == '\n')
+				imgui_io.KeysDown[0x0D] = true;
 			for (int i = 0; i < 8 && ev.data.keyboard.cNewInput[i] != 0; ++i)
 				imgui_io.AddInputCharacter(ev.data.keyboard.cNewInput[i]);
 			break;

--- a/source/runtime_gui_vr.cpp
+++ b/source/runtime_gui_vr.cpp
@@ -137,7 +137,7 @@ void reshade::runtime::draw_gui_vr()
 	imgui_io.KeysDown[0x08] = false;
 	imgui_io.KeysDown[0x09] = false;
 	imgui_io.KeysDown[0x0D] = false;
-	
+
 	vr::VREvent_t ev;
 	while (s_overlay->PollNextOverlayEvent(s_main_handle, &ev, sizeof(ev)))
 	{

--- a/source/runtime_gui_vr.cpp
+++ b/source/runtime_gui_vr.cpp
@@ -254,6 +254,7 @@ void reshade::runtime::draw_gui_vr()
 
 	switch (_device->get_api())
 	{
+	case api::device_api::d3d10:
 	case api::device_api::d3d11:
 		texture.handle = reinterpret_cast<void *>(_vr_overlay_texture.handle);
 		texture.eType = vr::TextureType_DirectX;

--- a/source/vulkan/vulkan_impl_swapchain.cpp
+++ b/source/vulkan/vulkan_impl_swapchain.cpp
@@ -178,6 +178,7 @@ void reshade::vulkan::swapchain_impl::on_present(VkQueue queue, const uint32_t s
 		static_cast<command_queue_impl *>(_graphics_queue)->flush_immediate_command_list(wait);
 	}
 }
+
 bool reshade::vulkan::swapchain_impl::on_layer_submit(uint32_t eye, VkImage source, const VkExtent2D &source_extent, VkFormat source_format, VkSampleCountFlags source_samples, uint32_t source_layer_index, const float bounds[4], VkImage *target_image)
 {
 	assert(eye < 2 && source != VK_NULL_HANDLE);
@@ -197,10 +198,10 @@ bool reshade::vulkan::swapchain_impl::on_layer_submit(uint32_t eye, VkImage sour
 
 	VkCommandBuffer cmd_list = VK_NULL_HANDLE;
 
-	//due to rounding errors with float calculation of the bounds we have use a tolerance of 1 pixel per eye (2pixel in total)
-	const INT widthDiff = std::abs(static_cast<INT>(target_extent.width) - static_cast<INT>(_width));
+	// Due to rounding errors with the bounds we have to use a tolerance of 1 pixel per eye (2 pixels in total)
+	const int32_t width_difference = std::abs(static_cast<int32_t>(target_extent.width) - static_cast<int32_t>(_width));
 
-	if (widthDiff > 2 || target_extent.height != _height || convert_format(source_format) != _backbuffer_format)
+	if (width_difference > 2 || target_extent.height != _height || convert_format(source_format) != _backbuffer_format)
 	{
 		on_reset();
 

--- a/source/vulkan/vulkan_impl_swapchain.cpp
+++ b/source/vulkan/vulkan_impl_swapchain.cpp
@@ -216,10 +216,6 @@ bool reshade::vulkan::swapchain_impl::on_layer_submit(uint32_t eye, VkImage sour
 			return false;
 		}
 
-		_width = target_extent.width;
-		_height = target_extent.height;
-		_backbuffer_format = convert_format(source_format);
-
 		_swapchain_images.resize(1);
 		_swapchain_images[0] = (VkImage)image.handle;
 


### PR DESCRIPTION
I could restore the VR functionality(DX11) in the latest source code to work again after the render target rework (commit ebf94113 ) It was caused that the backbuffer_resolved was not set on the vr submit for DX11.

After it tool a long time today to find the culprit I could start to work on serveral issues I encountered on VR with reshade:
- Fixed round errors would cause that the VR backbuffer is recreated very often and causing the left eye to flicker or black out completly
- Fixed OpenGL implementation pass the proper texture type. Now Google Earth works with reshade and other opengl VR implementations
- Fixed texture format typless check on DX11 and DX12 causing to permanently recreate the VR backbuffer on some games.

There are still things left I want to fix but they might need more time as i still need to get a better understanding of the code.
- Game crash when the "preprocessor definitions" are openend through the Steam VR dashboard reshade UI
- Reshade effect on off flicker caused by dynamic resolution switching like HL-Alyx does. This is certainly an issue of a frame delay when the runtime gets reset and initialized again after each resolution switch. Not sure on how to fix that properly.

Let me know if the code is ok like that or if you need some adjustments made to it.