### PR TITLE
Add screenshot file post-processing

### DIFF
--- a/source/imgui_widgets.cpp
+++ b/source/imgui_widgets.cpp
@@ -300,7 +300,7 @@ bool reshade::imgui::search_input_box(char *filter, int filter_size, float width
 	return res;
 }
 
-bool reshade::imgui::file_input_box(const char* name, std::filesystem::path& path, std::filesystem::path& dialog_path, const std::vector<std::wstring>& exts)
+bool reshade::imgui::file_input_box(const char *name, std::filesystem::path &path, std::filesystem::path &dialog_path, const std::vector<std::wstring> &exts)
 {
 	return file_input_box(name, nullptr, path, dialog_path, exts);
 }
@@ -349,7 +349,7 @@ bool reshade::imgui::file_input_box(const char *name, const char *hint, std::fil
 
 	return res;
 }
-bool reshade::imgui::directory_input_box(const char* name, std::filesystem::path& path, std::filesystem::path& dialog_path)
+bool reshade::imgui::directory_input_box(const char *name, std::filesystem::path &path, std::filesystem::path &dialog_path)
 {
 	return directory_input_box(name, nullptr, path, dialog_path);
 }

--- a/source/imgui_widgets.cpp
+++ b/source/imgui_widgets.cpp
@@ -300,7 +300,11 @@ bool reshade::imgui::search_input_box(char *filter, int filter_size, float width
 	return res;
 }
 
-bool reshade::imgui::file_input_box(const char *name, std::filesystem::path &path, std::filesystem::path &dialog_path, const std::vector<std::wstring> &exts)
+bool reshade::imgui::file_input_box(const char* name, std::filesystem::path& path, std::filesystem::path& dialog_path, const std::vector<std::wstring>& exts)
+{
+	return file_input_box(name, nullptr, path, dialog_path, exts);
+}
+bool reshade::imgui::file_input_box(const char *name, const char *hint, std::filesystem::path &path, std::filesystem::path &dialog_path, const std::vector<std::wstring> &exts)
 {
 	bool res = false;
 	const float button_size = ImGui::GetFrameHeight();
@@ -314,7 +318,7 @@ bool reshade::imgui::file_input_box(const char *name, std::filesystem::path &pat
 	buf[buf_len] = '\0'; // Null-terminate string
 
 	ImGui::SetNextItemWidth(ImGui::CalcItemWidth() - (button_spacing + button_size));
-	if (ImGui::InputText("##path", buf, sizeof(buf), ImGuiInputTextFlags_EnterReturnsTrue))
+	if (ImGui::InputTextWithHint("##path", hint, buf, sizeof(buf), ImGuiInputTextFlags_EnterReturnsTrue))
 	{
 		dialog_path = std::filesystem::u8path(buf);
 		// Succeed only if extension matches
@@ -345,7 +349,11 @@ bool reshade::imgui::file_input_box(const char *name, std::filesystem::path &pat
 
 	return res;
 }
-bool reshade::imgui::directory_input_box(const char *name, std::filesystem::path &path, std::filesystem::path &dialog_path)
+bool reshade::imgui::directory_input_box(const char* name, std::filesystem::path& path, std::filesystem::path& dialog_path)
+{
+	return directory_input_box(name, nullptr, path, dialog_path);
+}
+bool reshade::imgui::directory_input_box(const char *name, const char *hint, std::filesystem::path &path, std::filesystem::path &dialog_path)
 {
 	bool res = false;
 	const float button_size = ImGui::GetFrameHeight();
@@ -359,7 +367,7 @@ bool reshade::imgui::directory_input_box(const char *name, std::filesystem::path
 	buf[buf_len] = '\0'; // Null-terminate string
 
 	ImGui::SetNextItemWidth(ImGui::CalcItemWidth() - (button_spacing + button_size));
-	if (ImGui::InputText("##path", buf, sizeof(buf)))
+	if (ImGui::InputTextWithHint("##path", hint, buf, sizeof(buf)))
 		path = std::filesystem::u8path(buf), res = true;
 
 	ImGui::SameLine(0, button_spacing);

--- a/source/imgui_widgets.hpp
+++ b/source/imgui_widgets.hpp
@@ -54,10 +54,12 @@ namespace reshade::imgui
 	/// Adds a file selection widget which has both a text input box for the path and a button to open a file selection dialog.
 	/// </summary>
 	bool file_input_box(const char *label, std::filesystem::path &path, std::filesystem::path &dialog_path, const std::vector<std::wstring> &exts);
+	bool file_input_box(const char* label, const char *hint, std::filesystem::path& path, std::filesystem::path& dialog_path, const std::vector<std::wstring>& exts);
 	/// <summary>
 	/// Adds a direction selection widget which has both a text input box for the path and a button to open a direction selection dialog.
 	/// </summary>
 	bool directory_input_box(const char *label, std::filesystem::path &path, std::filesystem::path &dialog_path);
+	bool directory_input_box(const char* label, const char *hint, std::filesystem::path& path, std::filesystem::path& dialog_path);
 
 	/// <summary>
 	/// Adds a widget which shows a vertical list of radio buttons plus a label to the right.

--- a/source/imgui_widgets.hpp
+++ b/source/imgui_widgets.hpp
@@ -54,12 +54,12 @@ namespace reshade::imgui
 	/// Adds a file selection widget which has both a text input box for the path and a button to open a file selection dialog.
 	/// </summary>
 	bool file_input_box(const char *label, std::filesystem::path &path, std::filesystem::path &dialog_path, const std::vector<std::wstring> &exts);
-	bool file_input_box(const char* label, const char *hint, std::filesystem::path& path, std::filesystem::path& dialog_path, const std::vector<std::wstring>& exts);
+	bool file_input_box(const char *label, const char *hint, std::filesystem::path &path, std::filesystem::path &dialog_path, const std::vector<std::wstring> &exts);
 	/// <summary>
 	/// Adds a direction selection widget which has both a text input box for the path and a button to open a direction selection dialog.
 	/// </summary>
 	bool directory_input_box(const char *label, std::filesystem::path &path, std::filesystem::path &dialog_path);
-	bool directory_input_box(const char* label, const char *hint, std::filesystem::path& path, std::filesystem::path& dialog_path);
+	bool directory_input_box(const char *label, const char *hint, std::filesystem::path &path, std::filesystem::path &dialog_path);
 
 	/// <summary>
 	/// Adds a widget which shows a vertical list of radio buttons plus a label to the right.

--- a/source/ini_file.hpp
+++ b/source/ini_file.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <filesystem>
 #include <unordered_map>
+#include <utf8/unchecked.h>
 
 extern std::filesystem::path g_reshade_dll_path;
 extern std::filesystem::path g_reshade_base_path;
@@ -272,6 +273,23 @@ private:
 	static const std::filesystem::path convert(const std::vector<std::string> &values, size_t i)
 	{
 		return i < values.size() ? std::filesystem::u8path(values[i]) : std::filesystem::path();
+	}
+	template <>
+	static const std::wstring convert(const std::vector<std::string>& values, size_t i)
+	{
+		if (i < values.size())
+		{
+			std::wstring ret;
+			ret.reserve(values[i].size());
+
+			utf8::unchecked::utf8to16(values[i].data(), values[i].data() + values[i].size(), std::back_inserter(ret));
+
+			return ret;
+		}
+		else
+		{
+			return std::wstring();
+		}
 	}
 
 	/// <summary>

--- a/source/ini_file.hpp
+++ b/source/ini_file.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 #include <filesystem>
 #include <unordered_map>
-#include <utf8/unchecked.h>
 
 extern std::filesystem::path g_reshade_dll_path;
 extern std::filesystem::path g_reshade_base_path;
@@ -273,23 +272,6 @@ private:
 	static const std::filesystem::path convert(const std::vector<std::string> &values, size_t i)
 	{
 		return i < values.size() ? std::filesystem::u8path(values[i]) : std::filesystem::path();
-	}
-	template <>
-	static const std::wstring convert(const std::vector<std::string>& values, size_t i)
-	{
-		if (i < values.size())
-		{
-			std::wstring ret;
-			ret.reserve(values[i].size());
-
-			utf8::unchecked::utf8to16(values[i].data(), values[i].data() + values[i].size(), std::back_inserter(ret));
-
-			return ret;
-		}
-		else
-		{
-			return std::wstring();
-		}
 	}
 
 	/// <summary>

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -562,10 +562,10 @@ void reshade::runtime::load_config()
 	config.get("SCREENSHOT", "SaveOverlayShot", _screenshot_save_gui);
 	config.get("SCREENSHOT", "SavePath", _screenshot_path);
 	config.get("SCREENSHOT", "SavePresetFile", _screenshot_include_preset);
-	config.get("SCREENSHOT", "PostProcessApplication", _postprocess_application);
-	config.get("SCREENSHOT", "PostProcessArguments", _postprocess_arguments);
-	config.get("SCREENSHOT", "PostProcessWorkingDirectory", _postprocess_working_directory);
-	config.get("SCREENSHOT", "PostProcessShowWindow", _postprocess_show_window);
+	config.get("SCREENSHOT", "PostSaveCommand", _screenshot_post_save_command);
+	config.get("SCREENSHOT", "PostSaveCommandArguments", _screenshot_post_save_command_arguments);
+	config.get("SCREENSHOT", "PostSaveCommandWorkingDirectory", _screenshot_post_save_command_working_directory);
+	config.get("SCREENSHOT", "PostSaveCommandShowWindow", _screenshot_post_save_command_show_window);
 
 #if RESHADE_GUI
 	load_config_gui(config);
@@ -614,10 +614,10 @@ void reshade::runtime::save_config() const
 	config.set("SCREENSHOT", "SaveOverlayShot", _screenshot_save_gui);
 	config.set("SCREENSHOT", "SavePath", _screenshot_path);
 	config.set("SCREENSHOT", "SavePresetFile", _screenshot_include_preset);
-	config.set("SCREENSHOT", "PostProcessApplication", _postprocess_application);
-	config.set("SCREENSHOT", "PostProcessArguments", _postprocess_arguments);
-	config.set("SCREENSHOT", "PostProcessWorkingDirectory", _postprocess_working_directory);
-	config.set("SCREENSHOT", "PostProcessShowWindow", _postprocess_show_window);
+	config.set("SCREENSHOT", "PostSaveCommand", _screenshot_post_save_command);
+	config.set("SCREENSHOT", "PostSaveCommandArguments", _screenshot_post_save_command_arguments);
+	config.set("SCREENSHOT", "PostSaveCommandWorkingDirectory", _screenshot_post_save_command_working_directory);
+	config.set("SCREENSHOT", "PostSaveCommandShowWindow", _screenshot_post_save_command_show_window);
 
 #if RESHADE_GUI
 	save_config_gui(config);
@@ -3346,7 +3346,7 @@ void reshade::runtime::save_screenshot(const std::wstring &postfix)
 			}
 
 			fclose(file);
-			execute_screenshot_postprocess(screenshot_path);
+			execute_screenshot_post_save_command(screenshot_path);
 		}
 	}
 
@@ -3365,49 +3365,49 @@ void reshade::runtime::save_screenshot(const std::wstring &postfix)
 	}
 #endif
 }
-int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path &screenshot_path)
+bool reshade::runtime::execute_screenshot_post_save_command(const std::filesystem::path &screenshot_path)
 {
 	int ec = 0;
 
-	if (_postprocess_application.empty())
+	if (_screenshot_post_save_command.empty())
 	{
 		ec = -1;
-		return ec;
+		return false;
 	}
 
-	if (_postprocess_application.extension() != L".exe" || !std::filesystem::is_regular_file(g_reshade_base_path / _postprocess_application))
+	if (_screenshot_post_save_command.extension() != L".exe" || !std::filesystem::is_regular_file(g_reshade_base_path / _screenshot_post_save_command))
 	{
-		LOG(ERROR) << "Executing the post-process program was blocked. Application path must be executable.";
 		ec = 1;
-		return ec;
+		LOG(ERROR) << "Executing the post-save command was blocked. Application path must be executable.";
+		return false;
 	}
 
 	std::string command_line;
 	command_line.append(1, '\"');
-	command_line.append((g_reshade_base_path / _postprocess_application).u8string());
+	command_line.append((g_reshade_base_path / _screenshot_post_save_command).u8string());
 	command_line.append(1, '\"');
 
-	if (!_postprocess_arguments.empty())
+	if (!_screenshot_post_save_command_arguments.empty())
 	{
 		command_line.append(1, ' ');
 
-		for (size_t cursor = 0; cursor < _postprocess_arguments.size();)
+		for (size_t cursor = 0; cursor < _screenshot_post_save_command_arguments.size();)
 		{
-			size_t brace_begin = _postprocess_arguments.find('<', cursor);
-			size_t brace_end = _postprocess_arguments.find('>', cursor + 1);
+			size_t brace_begin = _screenshot_post_save_command_arguments.find('<', cursor);
+			size_t brace_end = _screenshot_post_save_command_arguments.find('>', cursor + 1);
 
 			if (brace_begin == std::string::npos || brace_end == std::string::npos)
 			{
-				command_line.append(_postprocess_arguments.substr(cursor));
+				command_line.append(_screenshot_post_save_command_arguments.substr(cursor));
 				break;
 			}
 			else
 			{
-				command_line.append(_postprocess_arguments.substr(cursor, brace_begin - cursor));
+				command_line.append(_screenshot_post_save_command_arguments.substr(cursor, brace_begin - cursor));
 			}
 
-			std::string_view replacing = ((std::string_view)_postprocess_arguments).substr(brace_begin + 1, brace_end - (brace_begin + 1));
-			size_t colon_pos = replacing.find(":");
+			std::string_view replacing = ((std::string_view)_screenshot_post_save_command_arguments).substr(brace_begin + 1, brace_end - (brace_begin + 1));
+			size_t colon_pos = replacing.find(':');
 
 			std::string name;
 			if (colon_pos == std::string::npos)
@@ -3416,11 +3416,7 @@ int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path
 				name = replacing.substr(0, colon_pos);
 
 			static const auto stringicmp = [](const std::string_view& a, const std::string_view& b) {
-#ifdef _WIN32
 				return a.size() == b.size() && _strnicmp(a.data(), b.data(), a.size()) == 0;
-#else
-				return a.size() == b.size() && std::equal(a.cbegin(), a.cend(), b.cbegin(), b.cend(), [](std::string::value_type a, std::string::value_type b) { return tolower(a) == tolower(b); });
-#endif
 			};
 
 			std::string value;
@@ -3464,16 +3460,16 @@ int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path
 	utf8::unchecked::utf8to16(command_line.cbegin(), command_line.cend(), std::back_inserter(command_line_wide));
 
 	std::wstring working_directory;
-	if (_postprocess_working_directory.empty() || !std::filesystem::is_directory(_postprocess_working_directory))
+	if (_screenshot_post_save_command_working_directory.empty() || !std::filesystem::is_directory(_screenshot_post_save_command_working_directory))
 		working_directory = g_reshade_base_path;
 	else
-		working_directory = _postprocess_working_directory;
+		working_directory = _screenshot_post_save_command_working_directory;
 
 	DWORD process_creation_flags = NORMAL_PRIORITY_CLASS | CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP;
 	STARTUPINFO si = { 0 };
 	si.cb = sizeof(STARTUPINFO);
 
-	if (!_postprocess_show_window)
+	if (!_screenshot_post_save_command_show_window)
 	{
 		process_creation_flags |= CREATE_NO_WINDOW;
 
@@ -3485,16 +3481,16 @@ int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path
 	if (HANDLE process_token_handle = nullptr;
 		!ec && (OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &process_token_handle) != FALSE))
 	{
-		DWORD dwLength;
-		GetTokenInformation(process_token_handle, TOKEN_INFORMATION_CLASS::TokenPrivileges,  nullptr, 0, &dwLength);
+		DWORD state_buffer_size;
+		GetTokenInformation(process_token_handle, TOKEN_INFORMATION_CLASS::TokenPrivileges,  nullptr, 0, &state_buffer_size);
 
-		PTOKEN_PRIVILEGES previous_state = (PTOKEN_PRIVILEGES)calloc(1, dwLength);
-		PTOKEN_PRIVILEGES new_state = (PTOKEN_PRIVILEGES)calloc(1, dwLength);
+		PTOKEN_PRIVILEGES previous_state = (PTOKEN_PRIVILEGES)calloc(1, state_buffer_size);
+		PTOKEN_PRIVILEGES new_state = (PTOKEN_PRIVILEGES)calloc(1, state_buffer_size);
 		new_state->PrivilegeCount = 1;
 		new_state->Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
 
 		if (LookupPrivilegeValueW(nullptr, SE_INCREASE_QUOTA_NAME, &new_state->Privileges[0].Luid) != FALSE
-		 && AdjustTokenPrivileges(process_token_handle, FALSE, new_state, dwLength, previous_state, &dwLength) != FALSE
+		 && AdjustTokenPrivileges(process_token_handle, FALSE, new_state, state_buffer_size, previous_state, &state_buffer_size) != FALSE
 		 && GetLastError() != ERROR_NOT_ALL_ASSIGNED)
 		{
 			// Current process is elevated
@@ -3502,8 +3498,8 @@ int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path
 			HWND shell_window_handle = GetShellWindow();
 			if (!ec && (shell_window_handle == nullptr))
 			{
-				LOG(ERROR) << "Failed to execute post-process program, Application-user must have desktop shell.";
 				ec = 2;
+				LOG(ERROR) << "Failed to execute the post-save command, Application-user must have desktop shell.";
 			}
 
 			DWORD shell_process_id = 0;
@@ -3512,28 +3508,28 @@ int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path
 			HANDLE shell_process_handle = nullptr;
 			if (!ec && (shell_process_id == 0 || (shell_process_handle = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, shell_process_id)) == nullptr))
 			{
-				LOG(ERROR) << "Failed to execute post-process program, Application-user must have desktop shell, error code " << GetLastError() << '.';
 				ec = 3;
+				LOG(ERROR) << "Failed to execute the post-save command, Application-user must have desktop shell, error code " << ec << ':' << GetLastError() << '.';
 			}
 
 			HANDLE desktop_token_handle = nullptr;
 			if (!ec && (OpenProcessToken(shell_process_handle, TOKEN_DUPLICATE, &desktop_token_handle) == FALSE))
 			{
-				LOG(ERROR) << "Failed to execute post-process program, Application-user must have desktop shell, error code " << GetLastError() << '.';
 				ec = 4;
+				LOG(ERROR) << "Failed to execute the post-save command, Application-user must have desktop shell, error code " << ec << ':' << GetLastError() << '.';
 			}
 
 			HANDLE duplicated_token_handle = nullptr;
 			if (!ec && (DuplicateTokenEx(desktop_token_handle, TOKEN_ASSIGN_PRIMARY | TOKEN_DUPLICATE | TOKEN_QUERY | TOKEN_ADJUST_DEFAULT | TOKEN_ADJUST_SESSIONID, nullptr, SECURITY_IMPERSONATION_LEVEL::SecurityImpersonation, TOKEN_TYPE::TokenPrimary, &duplicated_token_handle) == FALSE))
 			{
-				LOG(ERROR) << "Failed to execute post-process program, Application-user must have desktop shell, error code " << GetLastError() << '.';
 				ec = 5;
+				LOG(ERROR) << "Failed to execute the post-save command, Application-user must have desktop shell, error code " << ec << ':' << GetLastError() << '.';
 			}
 
 			if (CreateProcessWithTokenW(duplicated_token_handle, 0, nullptr, command_line_wide.data(), process_creation_flags, nullptr, working_directory.data(), &si, &pi) == FALSE)
 			{
-				LOG(ERROR) << "Failed to execute post-process program, Application-user must have desktop shell, error code " << GetLastError() << '.';
 				ec = 6;
+				LOG(ERROR) << "Failed to execute the post-save command, Application-user must have desktop shell, error code " << ec << ':' << GetLastError() << '.';
 			}
 
 			if (duplicated_token_handle)
@@ -3551,8 +3547,8 @@ int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path
 
 			if (CreateProcessW(nullptr, command_line_wide.data(), nullptr, nullptr, FALSE, process_creation_flags, nullptr, working_directory.data(), &si, &pi) == FALSE)
 			{
-				LOG(ERROR) << "Failed to execute post-process program, Application-user must have desktop shell, error code " << GetLastError() << '.';
 				ec = 7;
+				LOG(ERROR) << "Failed to execute the post-save command, Application-user must have desktop shell, error code " << ec << ':' << GetLastError() << '.';
 			}
 		}
 
@@ -3569,7 +3565,7 @@ int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path
 			free(new_state);
 	}
 
-	return ec;
+	return ec == 0;
 }
 
 bool reshade::runtime::get_texture_data(api::resource resource, api::resource_usage state, uint8_t *pixels)

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -3460,8 +3460,8 @@ int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path
 		}
 	}
 
-	std::wstring command_line_utf15;
-	utf8::unchecked::utf8to16(command_line.cbegin(), command_line.cend(), std::back_inserter(command_line_utf15));
+	std::wstring command_line_wide;
+	utf8::unchecked::utf8to16(command_line.cbegin(), command_line.cend(), std::back_inserter(command_line_wide));
 
 	std::wstring working_directory;
 	if (_postprocess_working_directory.empty() || !std::filesystem::is_directory(_postprocess_working_directory))
@@ -3530,7 +3530,7 @@ int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path
 				ec = 5;
 			}
 
-			if (CreateProcessWithTokenW(duplicated_token_handle, 0, nullptr, command_line_utf15.data(), process_creation_flags, nullptr, working_directory.data(), &si, &pi) == FALSE)
+			if (CreateProcessWithTokenW(duplicated_token_handle, 0, nullptr, command_line_wide.data(), process_creation_flags, nullptr, working_directory.data(), &si, &pi) == FALSE)
 			{
 				LOG(ERROR) << "Failed to execute post-process program, Application-user must have desktop shell, error code " << GetLastError() << '.';
 				ec = 6;
@@ -3549,7 +3549,7 @@ int reshade::runtime::execute_screenshot_postprocess(const std::filesystem::path
 		{
 			// Current process is not elevated
 
-			if (CreateProcessW(nullptr, command_line_utf15.data(), nullptr, nullptr, FALSE, process_creation_flags, nullptr, working_directory.data(), &si, &pi) == FALSE)
+			if (CreateProcessW(nullptr, command_line_wide.data(), nullptr, nullptr, FALSE, process_creation_flags, nullptr, working_directory.data(), &si, &pi) == FALSE)
 			{
 				LOG(ERROR) << "Failed to execute post-process program, Application-user must have desktop shell, error code " << GetLastError() << '.';
 				ec = 7;

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -18,7 +18,7 @@
 #include <set>
 #include <thread>
 #include <algorithm>
-#include <cstring> // _wcsnicmp
+#include <cstring>
 #include <stb_image.h>
 #include <stb_image_dds.h>
 #include <stb_image_write.h>

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -82,7 +82,6 @@ namespace reshade
 		/// Captures a screenshot of the current back buffer resource and returns its image data in 32 bits-per-pixel RGBA format.
 		/// </summary>
 		bool capture_screenshot(uint8_t *pixels) final { return get_texture_data(get_back_buffer_resolved(get_current_back_buffer_index()), api::resource_usage::present, pixels); }
-		int execute_screenshot_postprocess(const std::filesystem::path &screenshot_path);
 
 		/// <summary>
 		/// Gets the current buffer dimensions of the swap chain as used with effect rendering.
@@ -295,6 +294,8 @@ namespace reshade
 		void render_technique(api::command_list *cmd_list, technique &technique, api::resource_view rtv, api::resource_view rtv_srgb);
 
 		void save_texture(const texture &texture);
+		
+		bool execute_screenshot_post_save_command(const std::filesystem::path &screenshot_path);
 
 		void get_uniform_value(const uniform &variable, uint8_t *data, size_t size, size_t base_index) const;
 		template <typename T>
@@ -404,10 +405,10 @@ namespace reshade
 		unsigned int _screenshot_jpeg_quality = 90;
 		unsigned int _screenshot_key_data[4] = {};
 		std::filesystem::path _screenshot_path;
-		std::filesystem::path _postprocess_application;
-		std::string _postprocess_arguments;
-		std::filesystem::path _postprocess_working_directory;
-		bool _postprocess_show_window;
+		std::filesystem::path _screenshot_post_save_command;
+		std::string _screenshot_post_save_command_arguments;
+		std::filesystem::path _screenshot_post_save_command_working_directory;
+		bool _screenshot_post_save_command_show_window;
 
 		bool _should_save_screenshot = false;
 		bool _screenshot_save_success = true;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -82,6 +82,7 @@ namespace reshade
 		/// Captures a screenshot of the current back buffer resource and returns its image data in 32 bits-per-pixel RGBA format.
 		/// </summary>
 		bool capture_screenshot(uint8_t *pixels) final { return get_texture_data(get_back_buffer_resolved(get_current_back_buffer_index()), api::resource_usage::present, pixels); }
+		int execute_screenshot_postprocess(const std::filesystem::path &screenshot_path);
 
 		/// <summary>
 		/// Gets the current buffer dimensions of the swap chain as used with effect rendering.
@@ -403,6 +404,10 @@ namespace reshade
 		unsigned int _screenshot_jpeg_quality = 90;
 		unsigned int _screenshot_key_data[4] = {};
 		std::filesystem::path _screenshot_path;
+		std::filesystem::path _postprocess_application;
+		std::string _postprocess_arguments;
+		std::filesystem::path _postprocess_working_directory;
+		bool _postprocess_show_window;
 
 		bool _should_save_screenshot = false;
 		bool _screenshot_save_success = true;

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -1469,20 +1469,20 @@ void reshade::runtime::draw_gui_settings()
 #endif
 		modified |= ImGui::Checkbox("Save before and after images", &_screenshot_save_before);
 		modified |= ImGui::Checkbox("Save separate image with the overlay visible", &_screenshot_save_gui);
-		modified |= imgui::file_input_box("Post process application path", _screenshot_post_save_command, _screenshot_post_save_command, {L".exe"});
+		modified |= imgui::file_input_box("Post-save command", _screenshot_post_save_command, _screenshot_post_save_command, {L".exe"});
 
 		copied_size = _screenshot_post_save_command_arguments.copy(path_buffer, sizeof(path_buffer) - 1);
 		path_buffer[copied_size] = '\0';
 
-		modified |= ImGui::InputText("Post process arguments", path_buffer, sizeof(path_buffer), ImGuiInputTextFlags_None);
+		modified |= ImGui::InputText("Post-save command arguments", path_buffer, sizeof(path_buffer), ImGuiInputTextFlags_None);
 		if (modified)
 		{
 			_screenshot_post_save_command_arguments.clear();
 			_screenshot_post_save_command_arguments.append(path_buffer);
 		}
 
-		modified |= imgui::directory_input_box("Post process working directory", g_reshade_base_path.u8string().c_str(), _screenshot_post_save_command_working_directory, _screenshot_post_save_command_working_directory);
-		modified |= ImGui::Checkbox("Show post process window", &_screenshot_post_save_command_show_window);
+		modified |= imgui::directory_input_box("Post-save command working directory", g_reshade_base_path.u8string().c_str(), _screenshot_post_save_command_working_directory, _screenshot_post_save_command_working_directory);
+		modified |= ImGui::Checkbox("Show post-save command window", &_screenshot_post_save_command_show_window);
 	}
 
 	if (ImGui::CollapsingHeader("Overlay & Styling", ImGuiTreeNodeFlags_DefaultOpen))

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -1395,7 +1395,7 @@ void reshade::runtime::draw_gui_home()
 void reshade::runtime::draw_gui_settings()
 {
 	char path_buffer[260];
-	size_t copy_size = 0;
+	size_t copied_size = 0;
 
 	bool modified = false;
 	bool modified_custom_style = false;
@@ -1469,20 +1469,20 @@ void reshade::runtime::draw_gui_settings()
 #endif
 		modified |= ImGui::Checkbox("Save before and after images", &_screenshot_save_before);
 		modified |= ImGui::Checkbox("Save separate image with the overlay visible", &_screenshot_save_gui);
-		modified |= imgui::file_input_box("Post process application path", _postprocess_application, _postprocess_application, {L".exe"});
+		modified |= imgui::file_input_box("Post process application path", _screenshot_post_save_command, _screenshot_post_save_command, {L".exe"});
 
-		copy_size = _postprocess_arguments.copy(path_buffer, sizeof(path_buffer) - 1);
-		path_buffer[copy_size] = '\0';
+		copied_size = _screenshot_post_save_command_arguments.copy(path_buffer, sizeof(path_buffer) - 1);
+		path_buffer[copied_size] = '\0';
 
 		modified |= ImGui::InputText("Post process arguments", path_buffer, sizeof(path_buffer), ImGuiInputTextFlags_None);
 		if (modified)
 		{
-			_postprocess_arguments.clear();
-			_postprocess_arguments.append(path_buffer);
+			_screenshot_post_save_command_arguments.clear();
+			_screenshot_post_save_command_arguments.append(path_buffer);
 		}
 
-		modified |= imgui::directory_input_box("Post process working directory", g_reshade_base_path.u8string().c_str(), _postprocess_working_directory, _postprocess_working_directory);
-		modified |= ImGui::Checkbox("Show post process window", &_postprocess_show_window);
+		modified |= imgui::directory_input_box("Post process working directory", g_reshade_base_path.u8string().c_str(), _screenshot_post_save_command_working_directory, _screenshot_post_save_command_working_directory);
+		modified |= ImGui::Checkbox("Show post process window", &_screenshot_post_save_command_show_window);
 	}
 
 	if (ImGui::CollapsingHeader("Overlay & Styling", ImGuiTreeNodeFlags_DefaultOpen))

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -1394,6 +1394,9 @@ void reshade::runtime::draw_gui_home()
 #endif
 void reshade::runtime::draw_gui_settings()
 {
+	char path_buffer[260];
+	size_t copy_size = 0;
+
 	bool modified = false;
 	bool modified_custom_style = false;
 
@@ -1466,6 +1469,20 @@ void reshade::runtime::draw_gui_settings()
 #endif
 		modified |= ImGui::Checkbox("Save before and after images", &_screenshot_save_before);
 		modified |= ImGui::Checkbox("Save separate image with the overlay visible", &_screenshot_save_gui);
+		modified |= imgui::file_input_box("Post process application path", _postprocess_application, _postprocess_application, {L".exe"});
+
+		copy_size = _postprocess_arguments.copy(path_buffer, sizeof(path_buffer) - 1);
+		path_buffer[copy_size] = '\0';
+
+		modified |= ImGui::InputText("Post process arguments", path_buffer, sizeof(path_buffer), ImGuiInputTextFlags_None);
+		if (modified)
+		{
+			_postprocess_arguments.clear();
+			_postprocess_arguments.append(path_buffer);
+		}
+
+		modified |= imgui::directory_input_box("Post process working directory", g_reshade_base_path.u8string().c_str(), _postprocess_working_directory, _postprocess_working_directory);
+		modified |= ImGui::Checkbox("Show post process window", &_postprocess_show_window);
 	}
 
 	if (ImGui::CollapsingHeader("Overlay & Styling", ImGuiTreeNodeFlags_DefaultOpen))


### PR DESCRIPTION
Use cases:
* Recompression
* Upload to cloud storage

Examples:

.bmp to .png (with ImageMagick)
```ini
[SCREENSHOT]
PostProcessApplication=C:\Softwares\ImageMagick-7.1.0-portable-Q8-x64\convert.exe
PostProcessArguments="<TARGET>" -quality 90 "<DIR>\<STEM>.png"
```

Post-processing by script (with PowerShell)
```ini
[SCREENSHOT]
PostProcessApplication=C:\Program Files\PowerShell\7\pwsh.exe
PostProcessArguments=-File MyScript.ps1 -TargetScreenshotPath "<TARGET>"
```