### PR TITLE
Create screenshot directory if it doesn't exist.

### DIFF
--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -3305,13 +3305,22 @@ void reshade::runtime::save_screenshot(const std::wstring &postfix)
 	filename += postfix;
 	filename += _screenshot_format == 0 ? L".bmp" : _screenshot_format == 1 ? L".png" : L".jpg";
 
-	std::filesystem::path screenshot_path = g_reshade_base_path / _screenshot_path / filename;
+	std::filesystem::path screenshot_dir = g_reshade_base_path / _screenshot_path;
+	std::filesystem::path screenshot_path = screenshot_dir / filename;
 
 	LOG(INFO) << "Saving screenshot to " << screenshot_path << " ...";
 
 	_screenshot_save_success = false; // Default to a save failure unless it is reported to succeed below
+	_failed_to_create_screenshot_dir = false;
 
-	if (std::vector<uint8_t> data(static_cast<size_t>(_width) * static_cast<size_t>(_height) * 4);
+	std::error_code _;
+	std::filesystem::create_directories(screenshot_dir, _);
+
+	if (!std::filesystem::exists(screenshot_dir, _))
+	{
+		_failed_to_create_screenshot_dir = true;
+	}
+	else if (std::vector<uint8_t> data(static_cast<size_t>(_width) * static_cast<size_t>(_height) * 4);
 		capture_screenshot(data.data()))
 	{
 		// Remove alpha channel

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -412,6 +412,7 @@ namespace reshade
 
 		bool _should_save_screenshot = false;
 		bool _screenshot_save_success = true;
+		bool _failed_to_create_screenshot_dir = false;
 		std::filesystem::path _last_screenshot_file;
 		std::chrono::high_resolution_clock::time_point _last_screenshot_time;
 		#pragma endregion

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -651,10 +651,12 @@ void reshade::runtime::draw_gui()
 		else if (show_screenshot_message)
 		{
 			if (!_screenshot_save_success)
-				if (std::error_code ec; std::filesystem::exists(_screenshot_path, ec))
-					ImGui::TextColored(COLOR_RED, "Unable to save screenshot because of an internal error (the format may not be supported).");
+			{
+				if (_failed_to_create_screenshot_dir)
+					ImGui::TextColored(COLOR_RED, "Unable to save screenshot because path \"%s\" could not be created.", _screenshot_path.u8string().c_str());
 				else
-					ImGui::TextColored(COLOR_RED, "Unable to save screenshot because path doesn't exist: %s.", _screenshot_path.u8string().c_str());
+					ImGui::TextColored(COLOR_RED, "Unable to save screenshot because of an internal error (the format may not be supported).");
+			}
 			else
 				ImGui::Text("Screenshot successfully saved to %s", _last_screenshot_file.u8string().c_str());
 		}


### PR DESCRIPTION
This PR makes ReShade create the directory where screenshots are to be saved instead of just erroring out.

It is done by trying to create the directory (through `std::filesystem::create_directories()`) and then checking if it exists afterwards with `std::filesystem::exists()`. If it doesn't, it sets `_failed_to_create_screenshot_dir` to `true` and the error message will specify that it could not have been created.

PS: I've tried using the `std::error_code` returned by `create_directories()` but it would seem to not raise an error even when trying to save to a protected directory (like `C:\Program Files\<subdir>`), this seemed like a more reliable solution.