### PR TITLE
Add features to texture addons

### DIFF
--- a/examples/04-texture_dump/dump_options.hpp
+++ b/examples/04-texture_dump/dump_options.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+/// CONSTANTS
+// You shouldn't need to modify these if you're just editing options
+#define DUMP_HASH_FULL 0
+#define DUMP_HASH_TEXMOD 1
+
+#define DUMP_FMT_BMP 0
+#define DUMP_FMT_PNG 1
+
+
+/// OPTIONS
+
+// Which hash method to use
+// Only supports FULL and TEXMOD
+#define DUMP_HASH DUMP_HASH_TEXMOD
+
+// The subdirectory to place textures in
+// This directory should exist in the same directory as Reshade and the game's executable
+#define DUMP_DIR "texdump"
+
+// Which texture format to output
+// Only supports PNG and BMP
+#define DUMP_FMT DUMP_FMT_PNG
+
+// This allows the addon to skip any textures it already dumped this session
+// This may reduce lag, but will increase memory usage
+// Comment out the line below to disable
+#define DUMP_ENABLE_HASH_SET
+

--- a/examples/04-texture_dump/texturemod_dump.vcxproj
+++ b/examples/04-texture_dump/texturemod_dump.vcxproj
@@ -127,6 +127,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="crc32_hash.hpp" />
+    <ClInclude Include="dump_options.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/examples/05-texture_replace/replace_options.hpp
+++ b/examples/05-texture_replace/replace_options.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+/// CONSTANTS
+// You shouldn't need to modify these if you're just editing options
+#define REPLACE_HASH_FULL 0
+#define REPLACE_HASH_TEXMOD 1
+
+#define REPLACE_FMT_BMP 0
+#define REPLACE_FMT_PNG 1
+
+
+/// OPTIONS
+
+// Which hash method to use
+// Only supports FULL and TEXMOD
+#define REPLACE_HASH REPLACE_HASH_TEXMOD
+
+// The subdirectory to load textures from
+// This directory should exist in the same directory as Reshade and the game's executable
+#define REPLACE_DIR "texreplace"
+
+// Which texture format to read
+// Only supports PNG and BMP
+#define REPLACE_FMT REPLACE_FMT_PNG
+

--- a/examples/05-texture_replace/texturemod_replace.vcxproj
+++ b/examples/05-texture_replace/texturemod_replace.vcxproj
@@ -126,6 +126,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="crc32_hash.hpp" />
+    <ClInclude Include="replace_options.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION
# Texture Dump
- Added options header to configure addon behavior
- Added option to switch between full hashing and TexMod hashing
- Added support for saving textures to a subdirectory
- Added support for saving PNG files
- Added saving texture hashes to a set for optimization purposes.
  If a texture has already been dumped in the current session, then the dump function will not write it to disk again.
  This could be further improved by reading the filenames from the texture subdirectory and loading the hashes into the set, preventing the addon from dumping textures that were dumped in a previous gameplay session.

Default behavior is to save PNG textures to `<reshade-dir>/texdump/<texture-hash>.png`
Optimization is enabled by default

![image](https://user-images.githubusercontent.com/4993144/154824325-19fffceb-dc4d-4866-bf11-21da0ba9656c.png)

# Texture Replace
- Added options header to configure addon behavior
- Added option to switch between full hashing and TexMod hashing
- Added support for loading textures from a subdirectory
- Added support for loading PNG files

Default behavior is to load PNG textures from `<reshade-dir>/texreplace/<texture-hash>.png`

_(By "reshade-dir", I mean the directory that has the game executable, "ReShade.ini", "reshade-shaders/", etc)_