### PR TITLE
Ternary operator tries upper-casting here

### DIFF
--- a/source/hook_manager.cpp
+++ b/source/hook_manager.cpp
@@ -317,7 +317,9 @@ static reshade::hook find_internal(reshade::hook::address target, reshade::hook:
 				(target == nullptr || hook.target == target);
 		});
 
-	return it != s_hooks.cend() ? *it : reshade::hook {};
+	if (it != s_hooks.cend())
+		return *it;
+	return reshade::hook{};
 }
 
 template <typename T>


### PR DESCRIPTION
VS emits below error message.

```
Error C2446 ':': no conversion from 'reshade::hook' to 'const named_hook'
```