### PR TITLE
Fix exception when interacting with key_input_box

### DIFF
--- a/source/imgui_widgets.cpp
+++ b/source/imgui_widgets.cpp
@@ -216,7 +216,10 @@ bool reshade::imgui::key_input_box(const char *name, unsigned int key[4], const 
 	if (key[0] || key[1] || key[2] || key[3])
 		buf[input::key_name(key).copy(buf, sizeof(buf) - 1)] = '\0';
 
-	ImGui::BeginDisabled(ImGui::GetCurrentContext()->NavInputSource == ImGuiInputSource_Gamepad);
+	const bool is_gamepad = ImGui::GetCurrentContext()->NavInputSource == ImGuiInputSource_Gamepad;
+
+	if (is_gamepad)
+		ImGui::BeginDisabled();
 
 	ImGui::InputTextWithHint(name, "Click to set keyboard shortcut", buf, sizeof(buf), ImGuiInputTextFlags_ReadOnly | ImGuiInputTextFlags_NoUndoRedo | ImGuiInputTextFlags_NoHorizontalScroll);
 
@@ -248,7 +251,8 @@ bool reshade::imgui::key_input_box(const char *name, unsigned int key[4], const 
 		ImGui::SetTooltip("Click in the field and press any key to change the shortcut to that key.");
 	}
 
-	ImGui::EndDisabled();
+	if (is_gamepad)
+		ImGui::EndDisabled();
 
 	return false;
 }


### PR DESCRIPTION
ImGui's BeginDisabled/EndDisabled are very sensitive to variable state changes and unfortunately were throwing an exception on first-key input here.

Also see:
https://github.com/ocornut/imgui/issues/5011#issuecomment-1037556295