### PR TITLE
Add effect scope for preprocessor definitions

### DIFF
--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -553,11 +553,18 @@ namespace reshade::api
 			return get_preprocessor_definition(name, value, &length);
 		}
 		/// <summary>
-		/// Defines a global preprocessor definition to the specified <paramref name="value"/>.
+		/// Defines a preprocessor definition to the specified <paramref name="value"/>.
 		/// </summary>
 		/// <param name="name">Name of the definition.</param>
 		/// <param name="value">Value of the definition.</param>
 		virtual void set_preprocessor_definition(const char *name, const char *value) = 0;
+		/// <summary>
+		/// *TODO*
+		/// </summary>
+		/// <param name="effect_name">*TODO*</param>
+		/// <param name="name">Name of the definition.</param>
+		/// <param name="value">Value of the definition.</param>
+		virtual void set_preprocessor_definition(const char *effect_name, const char *name, const char *value) = 0;
 
 		/// <summary>
 		/// Applies a <paramref name="technique"/> to the specified render targets (regardless of the state of this technique).
@@ -660,5 +667,11 @@ namespace reshade::api
 			size_t length = SIZE;
 			get_technique_effect_name(technique, effect_name, &length);
 		}
+
+		/// <summary>
+		/// *TODO*
+		/// </summary>
+		/// <returns>*TODO*</returns>
+		virtual bool has_effects_loaded() const = 0;
 	};
 }

--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -689,11 +689,5 @@ namespace reshade::api
 		/// <param name="name">Name of the definition.</param>
 		/// <param name="value">Value of the definition.</param>
 		virtual void set_preprocessor_definition(const char *effect_name, const char *name, const char *value) = 0;
-
-		/// <summary>
-		/// *TODO*
-		/// </summary>
-		/// <returns>*TODO*</returns>
-		virtual bool has_effects_loaded() const = 0;
 	};
 }

--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -558,13 +558,6 @@ namespace reshade::api
 		/// <param name="name">Name of the definition.</param>
 		/// <param name="value">Value of the definition.</param>
 		virtual void set_preprocessor_definition(const char *name, const char *value) = 0;
-		/// <summary>
-		/// *TODO*
-		/// </summary>
-		/// <param name="effect_name">*TODO*</param>
-		/// <param name="name">Name of the definition.</param>
-		/// <param name="value">Value of the definition.</param>
-		virtual void set_preprocessor_definition(const char *effect_name, const char *name, const char *value) = 0;
 
 		/// <summary>
 		/// Applies a <paramref name="technique"/> to the specified render targets (regardless of the state of this technique).
@@ -667,6 +660,14 @@ namespace reshade::api
 			size_t length = SIZE;
 			get_technique_effect_name(technique, effect_name, &length);
 		}
+
+		/// <summary>
+		/// *TODO*
+		/// </summary>
+		/// <param name="effect_name">*TODO*</param>
+		/// <param name="name">Name of the definition.</param>
+		/// <param name="value">Value of the definition.</param>
+		virtual void set_preprocessor_definition(const char *effect_name, const char *name, const char *value) = 0;
 
 		/// <summary>
 		/// *TODO*

--- a/source/ini_file.hpp
+++ b/source/ini_file.hpp
@@ -54,6 +54,26 @@ public:
 		return true;
 	}
 
+	bool get(std::vector<std::string> &sections) const
+	{
+		sections.clear();
+		sections.reserve(_sections.size());
+		for (const auto &section : _sections)
+			sections.push_back(section.first);
+		return true;
+	}
+	bool get(const std::string &section, std::vector<std::string> &keys) const
+	{
+		const auto it1 = _sections.find(section);
+		if (it1 == _sections.end())
+			return false;
+		keys.clear();
+		keys.reserve(it1->second.size());
+		for (const auto &it2 : it1->second)
+			keys.push_back(it2.first);
+		return true;
+	}
+
 	/// <summary>
 	/// Gets the value of the specified <paramref name="section"/> and <paramref name="key"/> from the INI.
 	/// </summary>

--- a/source/ini_file.hpp
+++ b/source/ini_file.hpp
@@ -54,23 +54,17 @@ public:
 		return true;
 	}
 
+	/// <summary>
+	/// *TODO*
+	/// </summary>
+	/// <param name="sections">*TODO*</param>
+	/// <returns>*TODO*</returns>
 	bool get(std::vector<std::string> &sections) const
 	{
 		sections.clear();
 		sections.reserve(_sections.size());
 		for (const auto &section : _sections)
 			sections.push_back(section.first);
-		return true;
-	}
-	bool get(const std::string &section, std::vector<std::string> &keys) const
-	{
-		const auto it1 = _sections.find(section);
-		if (it1 == _sections.end())
-			return false;
-		keys.clear();
-		keys.reserve(it1->second.size());
-		for (const auto &it2 : it1->second)
-			keys.push_back(it2.first);
 		return true;
 	}
 

--- a/source/ini_file.hpp
+++ b/source/ini_file.hpp
@@ -55,20 +55,6 @@ public:
 	}
 
 	/// <summary>
-	/// *TODO*
-	/// </summary>
-	/// <param name="sections">*TODO*</param>
-	/// <returns>*TODO*</returns>
-	bool get(std::vector<std::string> &sections) const
-	{
-		sections.clear();
-		sections.reserve(_sections.size());
-		for (const auto &section : _sections)
-			sections.push_back(section.first);
-		return true;
-	}
-
-	/// <summary>
 	/// Gets the value of the specified <paramref name="section"/> and <paramref name="key"/> from the INI.
 	/// </summary>
 	/// <param name="value">Reference filled with the data of this INI entry.</param>

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1483,7 +1483,6 @@ bool reshade::runtime::load_effect(const std::filesystem::path &source_file, con
 		pp.add_macro_definition("BUFFER_COLOR_BIT_DEPTH", std::to_string(format_color_bit_depth(_effect_color_format)));
 
 		for (const definition &definition : preprocessor_definitions)
-			if (!definition.first.empty())
 				pp.add_macro_definition(definition.first, definition.second.empty() ? "1" : definition.second);
 
 		for (const std::filesystem::path &include_path : include_paths)
@@ -3481,6 +3480,23 @@ void reshade::runtime::update_effects()
 	// Delay first load to the first render call to avoid loading while the application is still initializing
 	if (_frame_count == 0 && !_no_reload_on_init && !(_no_reload_for_non_vr && !_is_vr))
 		reload_effects();
+
+#if RESHADE_ADDON
+	if (_reload_remaining_effects == std::numeric_limits<size_t>::max())
+	{
+		if (const size_t effect_index = _should_save_preprocessor_definitions;
+			effect_index != std::numeric_limits<size_t>::max())
+		{
+			save_current_preset();
+			_should_save_preprocessor_definitions = std::numeric_limits<size_t>::max();
+
+			if (effect_index < _effects.size())
+				reload_effect(effect_index);
+			else
+				reload_effects();
+		}
+	}
+#endif
 
 	if (_reload_remaining_effects == 0)
 	{

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1014,13 +1014,11 @@ void reshade::runtime::load_current_preset()
 		for (std::pair<std::string, std::string> &value : preset_preprocessor_definitions)
 			preprocessor_definitions.push_back(definition{ definition::scope_preset, "", std::move(value.first), std::move(value.second) });
 
-	if (std::vector<std::string> effect_names; preset.get(effect_names))
-		for (std::string &effect_name : effect_names)
-			if (effect_name.rfind(".fx") != std::string::npos)
-				if (std::vector<std::pair<std::string, std::string >> effect_preprocessor_definitions;
-					preset.get(effect_name, "PreprocessorDefinitions", effect_preprocessor_definitions))
-					for (std::pair<std::string, std::string> &value : effect_preprocessor_definitions)
-						preprocessor_definitions.push_back(definition{ definition::scope_effect, effect_name, std::move(value.first), std::move(value.second) });
+	for (const reshade::effect &effect : _effects)
+		if (std::vector<std::pair<std::string, std::string >> effect_preprocessor_definitions;
+			preset.get(effect.source_file.filename().u8string(), "PreprocessorDefinitions", effect_preprocessor_definitions))
+			for (std::pair<std::string, std::string> &value : effect_preprocessor_definitions)
+				preprocessor_definitions.push_back(definition{ definition::scope_effect, effect.source_file.filename().u8string(), std::move(value.first), std::move(value.second) });
 
 	std::stable_sort(preprocessor_definitions.begin(), preprocessor_definitions.end(), [](const definition &a, const definition &b) { return a.first < b.first; });
 	std::stable_sort(preprocessor_definitions.begin(), preprocessor_definitions.end(), [](const definition &a, const definition &b) { return a.name < b.name; });

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1020,9 +1020,8 @@ void reshade::runtime::load_current_preset()
 			for (std::pair<std::string, std::string> &value : effect_preprocessor_definitions)
 				preprocessor_definitions.push_back(definition{ definition::scope_effect, effect.source_file.filename().u8string(), std::move(value.first), std::move(value.second) });
 
-	std::stable_sort(preprocessor_definitions.begin(), preprocessor_definitions.end(), [](const definition &a, const definition &b) { return a.first < b.first; });
-	std::stable_sort(preprocessor_definitions.begin(), preprocessor_definitions.end(), [](const definition &a, const definition &b) { return a.name < b.name; });
-	std::stable_sort(preprocessor_definitions.rbegin(), preprocessor_definitions.rend(), [](const definition &a, const definition &b) { return a.scope < b.scope; });
+	std::stable_sort(preprocessor_definitions.begin(), preprocessor_definitions.end(),
+		[](const definition &a, const definition &b) { return a.scope == b.scope ? a.name == b.name ? a.first < b.first : a.name < b.name : a.scope > b.scope; });
 
 	// Recompile effects if preprocessor definitions have changed or running in performance mode (in which case all preset values are compile-time constants)
 	if (_reload_remaining_effects != 0) // ... unless this is the 'load_current_preset' call in 'update_effects'
@@ -3245,9 +3244,8 @@ void reshade::runtime::load_effects()
 			for (std::pair<std::string, std::string> &value : effect_preprocessor_definitions)
 				_preprocessor_definitions.push_back(definition{ definition::scope_effect, effect_file.filename().u8string(), std::move(value.first), std::move(value.second) });
 
-	std::stable_sort(_preprocessor_definitions.begin(), _preprocessor_definitions.end(), [](const definition &a, const definition &b) { return a.first < b.first; });
-	std::stable_sort(_preprocessor_definitions.begin(), _preprocessor_definitions.end(), [](const definition &a, const definition &b) { return a.name < b.name; });
-	std::stable_sort(_preprocessor_definitions.rbegin(), _preprocessor_definitions.rend(), [](const definition &a, const definition &b) { return a.scope < b.scope; });
+	std::stable_sort(_preprocessor_definitions.begin(), _preprocessor_definitions.end(),
+		[](const definition &a, const definition &b) { return a.scope == b.scope ? a.name == b.name ? a.first < b.first : a.name < b.name : a.scope > b.scope; });
 
 	if (effect_files.empty())
 		return; // No effect files found, so nothing more to do

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1366,7 +1366,7 @@ bool reshade::runtime::switch_to_next_preset(std::filesystem::path filter_path, 
 	return true;
 }
 
-bool reshade::runtime::load_effect(std::filesystem::path source_file, const ini_file &preset, size_t effect_index, bool preprocess_required)
+bool reshade::runtime::load_effect(const std::filesystem::path &source_file, const ini_file &preset, size_t effect_index, bool preprocess_required)
 {
 	const std::chrono::high_resolution_clock::time_point time_load_started = std::chrono::high_resolution_clock::now();
 

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1027,8 +1027,7 @@ void reshade::runtime::load_current_preset()
 	// Recompile effects if preprocessor definitions have changed or running in performance mode (in which case all preset values are compile-time constants)
 	if (_reload_remaining_effects != 0) // ... unless this is the 'load_current_preset' call in 'update_effects'
 	{
-		if (_performance_mode || !std::equal(preprocessor_definitions.cbegin(), preprocessor_definitions.cend(), _preprocessor_definitions.cbegin(), _preprocessor_definitions.cend(),
-			[](const definition &a, const definition &b) { return a.scope == b.scope && a.name == b.name && a.first == b.first && a.second == b.second; }))
+		if (_performance_mode || preprocessor_definitions != _preprocessor_definitions)
 		{
 			_preprocessor_definitions = std::move(preprocessor_definitions);
 			reload_effects();

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -210,7 +210,7 @@ namespace reshade
 
 		bool switch_to_next_preset(std::filesystem::path filter_path, bool reversed = false);
 
-		bool load_effect(std::filesystem::path source_file, const ini_file &preset, size_t effect_index, bool preprocess_required = false);
+		bool load_effect(const std::filesystem::path &source_file, const ini_file &preset, size_t effect_index, bool preprocess_required = false);
 		bool create_effect(size_t effect_index);
 		bool create_effect_sampler_state(const api::sampler_desc &desc, api::sampler &sampler);
 		void destroy_effect(size_t effect_index);

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -175,8 +175,6 @@ namespace reshade
 		void save_current_preset() const final;
 #endif
 
-		bool has_effects_loaded() const final;
-
 	protected:
 		runtime(api::device *device, api::command_queue *graphics_queue);
 		~runtime();
@@ -304,6 +302,9 @@ namespace reshade
 		unsigned int _reload_key_data[4] = {};
 		unsigned int _performance_mode_key_data[4] = {};
 		std::vector<definition> _preprocessor_definitions;
+#if RESHADE_ADDON
+		size_t _should_save_preprocessor_definitions = std::numeric_limits<size_t>::max();
+#endif
 		std::filesystem::path _effect_cache_path;
 		std::vector<std::filesystem::path> _effect_search_paths;
 		std::vector<std::filesystem::path> _texture_search_paths;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -23,6 +23,7 @@ class ini_file;
 namespace reshade
 {
 	// Forward declarations to avoid excessive #include
+	struct definition;
 	struct effect;
 	struct uniform;
 	struct texture;
@@ -151,6 +152,7 @@ namespace reshade
 
 		bool get_preprocessor_definition(const char *name, char *value, size_t *length) const final;
 		void set_preprocessor_definition(const char *name, const char *value) final;
+		void set_preprocessor_definition(const char *effect_name, const char *name, const char *value) final;
 
 		bool get_effects_state() const final;
 		void set_effects_state(bool enabled) final;
@@ -168,6 +170,8 @@ namespace reshade
 		void get_uniform_variable_effect_name(api::effect_uniform_variable variable, char *effect_name, size_t *length) const final;
 		void get_texture_variable_effect_name(api::effect_texture_variable variable, char *effect_name, size_t *length) const final;
 		void get_technique_effect_name(api::effect_technique technique, char *effect_name, size_t *length) const final;
+
+		bool has_effects_loaded() const final;
 
 	protected:
 		runtime(api::device *device, api::command_queue *graphics_queue);
@@ -206,7 +210,7 @@ namespace reshade
 
 		bool switch_to_next_preset(std::filesystem::path filter_path, bool reversed = false);
 
-		bool load_effect(const std::filesystem::path &source_file, const ini_file &preset, size_t effect_index, bool preprocess_required = false);
+		bool load_effect(std::filesystem::path source_file, const ini_file &preset, size_t effect_index, bool preprocess_required = false);
 		bool create_effect(size_t effect_index);
 		bool create_effect_sampler_state(const api::sampler_desc &desc, api::sampler &sampler);
 		void destroy_effect(size_t effect_index);
@@ -296,8 +300,7 @@ namespace reshade
 		bool _load_option_disable_skipping = false;
 		unsigned int _reload_key_data[4] = {};
 		unsigned int _performance_mode_key_data[4] = {};
-		std::vector<std::pair<std::string, std::string>> _global_preprocessor_definitions;
-		std::vector<std::pair<std::string, std::string>> _preset_preprocessor_definitions;
+		std::vector<definition> _preprocessor_definitions;
 		std::filesystem::path _effect_cache_path;
 		std::vector<std::filesystem::path> _effect_search_paths;
 		std::vector<std::filesystem::path> _texture_search_paths;

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -915,7 +915,7 @@ void reshade::runtime::set_preprocessor_definition([[maybe_unused]] const char *
 	}
 	else
 	{
-		if (const unsigned int scope = effect_name == nullptr ? definition::scope_preset : definition::scope_effect;
+		if (const auto scope = effect_name == nullptr ? definition::scope_preset : definition::scope_effect;
 			exist != _preprocessor_definitions.end() && exist->scope == scope)
 		{
 			assert(exist->name == effect_name);
@@ -924,7 +924,7 @@ void reshade::runtime::set_preprocessor_definition([[maybe_unused]] const char *
 		else
 		{
 			definition &definition = _preprocessor_definitions.emplace_back();
-			definition.scope = scope;
+			definition.scope = static_cast<decltype(definition::scope)>(scope);
 			if (effect_name != nullptr)
 				definition.name = effect_name;
 			definition.first = name;

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -932,9 +932,8 @@ void reshade::runtime::set_preprocessor_definition([[maybe_unused]] const char *
 		}
 	}
 
-	std::stable_sort(_preprocessor_definitions.begin(), _preprocessor_definitions.end(), [](const definition &a, const definition &b) { return a.first < b.first; });
-	std::stable_sort(_preprocessor_definitions.begin(), _preprocessor_definitions.end(), [](const definition &a, const definition &b) { return a.name < b.name; });
-	std::stable_sort(_preprocessor_definitions.rbegin(), _preprocessor_definitions.rend(), [](const definition &a, const definition &b) { return a.scope < b.scope; });
+	std::stable_sort(_preprocessor_definitions.begin(), _preprocessor_definitions.end(),
+		[](const definition &a, const definition &b) { return a.scope == b.scope ? a.name == b.name ? a.first < b.first : a.name < b.name : a.scope > b.scope; });
 
 	// Save preset first, as preprocessor definitions are reset to those in the current preset during reloading
 	save_current_preset();

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -256,7 +256,7 @@ bool reshade::runtime::get_annotation_string_from_uniform_variable([[maybe_unuse
 {
 #if RESHADE_FX
 	const auto variable = reinterpret_cast<const uniform *>(handle.handle);
-	if (variable != nullptr && length != nullptr)
+	if (variable != nullptr)
 	{
 		if (const auto it = std::find_if(variable->annotations.cbegin(), variable->annotations.cend(),
 				[name](const reshadefx::annotation &annotation) { return annotation.name == name; });
@@ -264,10 +264,11 @@ bool reshade::runtime::get_annotation_string_from_uniform_variable([[maybe_unuse
 		{
 			const std::string_view annotation = variable->annotation_as_string(name);
 
-			if (value != nullptr && *length != 0)
+			if (value != nullptr && length != nullptr && *length != 0)
 				value[annotation.copy(value, *length - 1)] = '\0';
+			if (length != nullptr)
+				*length = annotation.size();
 
-			*length = annotation.size();
 			return true;
 		}
 	}
@@ -934,7 +935,7 @@ void reshade::runtime::set_preprocessor_definition([[maybe_unused]] const char *
 }
 bool reshade::runtime::get_preprocessor_definition(const char *name, [[maybe_unused]] char *value, size_t *length) const
 {
-	if (name == nullptr || length == nullptr)
+	if (name == nullptr)
 		return false;
 
 #if RESHADE_FX
@@ -942,15 +943,17 @@ bool reshade::runtime::get_preprocessor_definition(const char *name, [[maybe_unu
 		[name](const definition &definition) { return definition.first == name; });
 		it != _preprocessor_definitions.cend())
 	{
-		if (value != nullptr && *length != 0)
+		if (value != nullptr && length != nullptr && *length != 0)
 			value[it->second.copy(value, *length - 1)] = '\0';
+		if (length != nullptr)
+			*length = it->second.size();
 
-		*length = it->second.size();
 		return true;
 	}
 #endif
 
-	*length = 0;
+	if (length != nullptr)
+		*length = 0;
 	return false;
 }
 

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -2788,7 +2788,7 @@ void reshade::runtime::draw_variable_editor()
 			struct
 			{
 				const char *name;
-				unsigned int scope;
+				decltype(definition::scope) scope;
 				bool &modified;
 			} definition_types[] = {
 				{ "Global", definition::scope_global, global_modified },
@@ -2842,7 +2842,7 @@ void reshade::runtime::draw_variable_editor()
 					ImGui::Dummy(ImVec2());
 					ImGui::SameLine(0, content_region_width - button_size);
 					if (ImGui::Button(ICON_FK_PLUS, ImVec2(button_size, 0)))
-						_preprocessor_definitions.push_back(definition{ type.scope });
+						_preprocessor_definitions.push_back(definition{ static_cast<decltype(definition::scope)>(type.scope) });
 
 					ImGui::EndTabItem();
 				}

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -2770,8 +2770,10 @@ void reshade::runtime::draw_variable_editor()
 	{
 		ImGui::SetWindowPos(popup_pos);
 
+		const size_t count_global = std::count_if(_preprocessor_definitions.cbegin(), _preprocessor_definitions.cend(), [](const definition &definition) { return definition.scope == definition::scope_global; });
+		const size_t count_preset = std::count_if(_preprocessor_definitions.cbegin(), _preprocessor_definitions.cend(), [](const definition &definition) { return definition.scope == definition::scope_preset; });
 		bool global_modified = false, preset_modified = false;
-		float popup_height = (std::max(_global_preprocessor_definitions.size(), _preset_preprocessor_definitions.size()) + 2) * ImGui::GetFrameHeightWithSpacing();
+		float popup_height = (std::max(count_global, count_preset) + 2) * ImGui::GetFrameHeightWithSpacing();
 		popup_height = std::min(popup_height, ImGui::GetWindowViewport()->Size.y - popup_pos.y - 20.0f);
 		popup_height = std::max(popup_height, 42.0f); // Ensure window always has a minimum height
 		const float button_size = ImGui::GetFrameHeight();
@@ -2786,24 +2788,29 @@ void reshade::runtime::draw_variable_editor()
 			struct
 			{
 				const char *name;
-				std::vector<std::pair<std::string, std::string>> &preprocessor_definitions;
+				unsigned int scope;
 				bool &modified;
 			} definition_types[] = {
-				{ "Global", _global_preprocessor_definitions, global_modified },
-				{ "Current Present", _preset_preprocessor_definitions, preset_modified },
+				{ "Global", definition::scope_global, global_modified },
+				{ "Current Present", definition::scope_preset, preset_modified },
 			};
 
 			for (const auto &type : definition_types)
 			{
 				if (ImGui::BeginTabItem(type.name))
 				{
-					for (size_t i = 0; i < type.preprocessor_definitions.size(); ++i)
+					for (size_t i = 0; i < _preprocessor_definitions.size(); ++i)
 					{
-						char name[128] = "";
-						char value[128] = "";
+						definition &definition = _preprocessor_definitions[i];
 
-						type.preprocessor_definitions[i].first.copy(name, sizeof(name) - 1);
-						type.preprocessor_definitions[i].second.copy(value, sizeof(value) - 1);
+						if (definition.scope != type.scope)
+							continue;
+
+						char name[128];
+						char value[256];
+
+						name[definition.first.copy(name, sizeof(name) - 1)] = '\0';
+						value[definition.second.copy(value, sizeof(value) - 1)] = '\0';
 
 						ImGui::PushID(static_cast<int>(i));
 
@@ -2821,11 +2828,12 @@ void reshade::runtime::draw_variable_editor()
 						if (imgui::confirm_button(ICON_FK_MINUS, button_size, "Do you really want to remove the preprocessor definition '%s'?", name))
 						{
 							type.modified = true;
-							type.preprocessor_definitions.erase(type.preprocessor_definitions.begin() + i--);
+							_preprocessor_definitions.erase(_preprocessor_definitions.begin() + i--);
 						}
 						else if (type.modified)
 						{
-							type.preprocessor_definitions[i] = { name, value };
+							definition.first = name;
+							definition.second = value;
 						}
 
 						ImGui::PopID();
@@ -2834,7 +2842,7 @@ void reshade::runtime::draw_variable_editor()
 					ImGui::Dummy(ImVec2());
 					ImGui::SameLine(0, content_region_width - button_size);
 					if (ImGui::Button(ICON_FK_PLUS, ImVec2(button_size, 0)))
-						type.preprocessor_definitions.emplace_back();
+						_preprocessor_definitions.push_back(definition{ type.scope });
 
 					ImGui::EndTabItem();
 				}
@@ -2859,23 +2867,6 @@ void reshade::runtime::draw_variable_editor()
 		reload_effects();
 		_was_preprocessor_popup_edited = false;
 	}
-
-	const auto find_definition_value = [](std::vector<std::pair<std::string, std::string>> &list, const std::string &name, char value[128] = nullptr) {
-		for (auto it = list.begin(); it != list.end(); ++it)
-		{
-			char current_name[128] = "";
-			it->first.copy(current_name, sizeof(current_name) - 1);
-
-			if (name == current_name)
-			{
-				if (value != nullptr)
-					value[it->second.copy(value, 128 - 1)] = '\0';
-				return it;
-			}
-		}
-
-		return list.end();
-	};
 
 	ImGui::BeginChild("##variables", ImVec2(0, 0), false, ImGuiWindowFlags_NavFlattened);
 	if (_variable_editor_tabs)
@@ -2931,11 +2922,10 @@ void reshade::runtime::draw_variable_editor()
 					reset_uniform_value(variable_it);
 
 			// Reset all preprocessor definitions
-			for (const std::pair<std::string, std::string> &definition : effect.definitions)
-				if (const auto preset_it = find_definition_value(_preset_preprocessor_definitions, definition.first);
-					preset_it != _preset_preprocessor_definitions.end())
-					force_reload_effect = true, // Need to reload after changing preprocessor defines so to get accurate defaults again
-					_preset_preprocessor_definitions.erase(preset_it);
+			for (std::pair<std::string, std::string> &value : effect.definitions)
+				if (auto it = std::remove_if(_preprocessor_definitions.begin(), _preprocessor_definitions.end(), [&value](definition &definition) { return definition.first == value.first; });
+					it != _preprocessor_definitions.end())
+					_preprocessor_definitions.erase(it), force_reload_effect = true; // Need to reload after changing preprocessor defines so to get accurate defaults again
 
 			if (_auto_save_preset)
 				save_current_preset();
@@ -2946,7 +2936,7 @@ void reshade::runtime::draw_variable_editor()
 
 		bool category_closed = false;
 		std::string current_category;
-		auto modified_definition = _preset_preprocessor_definitions.end();
+		definition modified_definition = {};
 
 		size_t active_variable = 0;
 		size_t active_variable_index = std::numeric_limits<size_t>::max();
@@ -3188,40 +3178,39 @@ void reshade::runtime::draw_variable_editor()
 
 			if (ImGui::TreeNodeEx(category_label.c_str(), ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_DefaultOpen))
 			{
-				for (const std::pair<std::string, std::string> &definition : effect.definitions)
+				for (const std::pair<std::string, std::string> &value : effect.definitions)
 				{
-					char value[128] = "";
-					const auto global_it = find_definition_value(_global_preprocessor_definitions, definition.first, value);
-					const auto preset_it = find_definition_value(_preset_preprocessor_definitions, definition.first, value);
+					auto exist = _preprocessor_definitions.end();
+					for (auto it = _preprocessor_definitions.begin(); it != _preprocessor_definitions.end(); it++)
+						if (it->first == value.first && (exist == _preprocessor_definitions.end() || it->scope > exist->scope))
+							exist = it;
 
-					if (global_it == _global_preprocessor_definitions.end() &&
-						preset_it == _preset_preprocessor_definitions.end())
-						definition.second.copy(value, sizeof(value) - 1); // Fill with default value
-
-					if (ImGui::InputText(definition.first.c_str(), value, sizeof(value),
-							global_it != _global_preprocessor_definitions.end() ? ImGuiInputTextFlags_ReadOnly : ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_EnterReturnsTrue))
+					char text[256] = "";
+					if (exist != _preprocessor_definitions.end())
+						text[exist->second.copy(text, sizeof(text) - 1)] = '\0';
+					if (ImGui::InputTextWithHint(value.first.c_str(), value.second.c_str(), text, sizeof(text), (exist != _preprocessor_definitions.end() && exist->scope == definition::scope_global) ? ImGuiInputTextFlags_ReadOnly : ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_EnterReturnsTrue))
 					{
-						if (value[0] == '\0') // An empty value removes the definition
+						if (text[0] == '\0') // An empty value removes the definition
 						{
-							if (preset_it != _preset_preprocessor_definitions.end())
+							if (exist != _preprocessor_definitions.end())
 							{
 								force_reload_effect = true;
-								_preset_preprocessor_definitions.erase(preset_it);
+								_preprocessor_definitions.erase(exist);
 							}
 						}
 						else
 						{
 							force_reload_effect = true;
 
-							if (preset_it != _preset_preprocessor_definitions.end())
+							if (exist != _preprocessor_definitions.end())
 							{
-								*preset_it = { definition.first, value };
-								modified_definition = preset_it;
+								assert(exist->first == value.first);
+								exist->second = text;
+								modified_definition = *exist;
 							}
 							else
 							{
-								_preset_preprocessor_definitions.emplace_back(definition.first, value);
-								modified_definition = _preset_preprocessor_definitions.end() - 1;
+								modified_definition = _preprocessor_definitions.emplace_back(definition{ definition::scope_preset, "", value.first, text });
 							}
 						}
 					}
@@ -3231,10 +3220,10 @@ void reshade::runtime::draw_variable_editor()
 					{
 						if (ImGui::Button(ICON_FK_UNDO " Reset to default", ImVec2(230.0f, 0)))
 						{
-							if (preset_it != _preset_preprocessor_definitions.end())
+							if (exist != _preprocessor_definitions.end())
 							{
 								force_reload_effect = true;
-								_preset_preprocessor_definitions.erase(preset_it);
+								_preprocessor_definitions.erase(exist);
 							}
 
 							ImGui::CloseCurrentPopup();
@@ -3263,11 +3252,14 @@ void reshade::runtime::draw_variable_editor()
 			const bool reload_successful_before = _last_reload_successfull;
 
 			// Reload current effect file
-			if (!reload_effect(effect_index) &&
-				modified_definition != _preset_preprocessor_definitions.end())
+			if (!reload_effect(effect_index) && !modified_definition.first.empty())
 			{
+				assert(modified_definition.scope == definition::scope_preset || modified_definition.scope == definition::scope_effect);
+
 				// The preprocessor definition that was just modified caused the effect to not compile, so reset to default and try again
-				_preset_preprocessor_definitions.erase(modified_definition);
+				_preprocessor_definitions.erase(std::remove_if(_preprocessor_definitions.begin(), _preprocessor_definitions.end(),
+					[&modified_definition](definition &definition) { return definition.scope == modified_definition.scope && definition.name == modified_definition.name && definition.first == modified_definition.first; }),
+					_preprocessor_definitions.end());
 
 				if (reload_effect(effect_index))
 				{
@@ -3276,7 +3268,15 @@ void reshade::runtime::draw_variable_editor()
 
 					// Update preset again now, so that the removed preprocessor definition does not reappear on a reload
 					// The preset is actually loaded again next frame to update the technique status (see 'update_and_render_effects'), so cannot use 'save_current_preset' here
-					ini_file::load_cache(_current_preset_path).set({}, "PreprocessorDefinitions", _preset_preprocessor_definitions);
+					ini_file &preset = ini_file::load_cache(_current_preset_path);
+
+					if (std::vector<std::pair<std::string, std::string>> preprocessor_definitions;
+						preset.get(modified_definition.name, "PreprocessorDefinitions", preprocessor_definitions))
+					{
+						preprocessor_definitions.erase(std::remove_if(preprocessor_definitions.begin(), preprocessor_definitions.end(),
+							[&modified_definition](std::pair<std::string, std::string> &value) { return value.first == modified_definition.first; }), preprocessor_definitions.end());
+						preset.set(modified_definition.name, "PreprocessorDefinitions", preprocessor_definitions);
+					}
 				}
 			}
 

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -3210,7 +3210,7 @@ void reshade::runtime::draw_variable_editor()
 							}
 							else
 							{
-								modified_definition = _preprocessor_definitions.emplace_back(definition{ definition::scope_preset, "", value.first, text });
+								modified_definition = _preprocessor_definitions.emplace_back(definition{ definition::scope_effect, "", value.first, text });
 							}
 						}
 					}

--- a/source/runtime_objects.hpp
+++ b/source/runtime_objects.hpp
@@ -282,5 +282,17 @@ namespace reshade
 		};
 		std::vector<binding_data> texture_semantic_to_binding;
 	};
+
+	struct definition
+	{
+		unsigned int scope = 0;
+		std::string name;
+		std::string first;
+		std::string second;
+
+		static constexpr unsigned int scope_global = 0;
+		static constexpr unsigned int scope_preset = 1;
+		static constexpr unsigned int scope_effect = 2;
+	};
 #endif
 }

--- a/source/runtime_objects.hpp
+++ b/source/runtime_objects.hpp
@@ -293,6 +293,8 @@ namespace reshade
 		static constexpr unsigned int scope_global = 0;
 		static constexpr unsigned int scope_preset = 1;
 		static constexpr unsigned int scope_effect = 2;
+
+		constexpr bool operator==(const definition &obj) const { return obj.scope == scope && obj.name == name && obj.first == first && obj.second == second; }
 	};
 #endif
 }

--- a/source/runtime_objects.hpp
+++ b/source/runtime_objects.hpp
@@ -285,14 +285,16 @@ namespace reshade
 
 	struct definition
 	{
-		unsigned int scope = 0;
+		enum
+		{
+			scope_global,
+			scope_preset,
+			scope_effect
+		} scope;
+
 		std::string name;
 		std::string first;
 		std::string second;
-
-		static constexpr unsigned int scope_global = 0;
-		static constexpr unsigned int scope_preset = 1;
-		static constexpr unsigned int scope_effect = 2;
 
 		constexpr bool operator==(const definition &obj) const { return obj.scope == scope && obj.name == name && obj.first == first && obj.second == second; }
 	};

--- a/source/runtime_objects.hpp
+++ b/source/runtime_objects.hpp
@@ -292,11 +292,11 @@ namespace reshade
 			scope_effect
 		} scope;
 
+		std::string effect_name;
 		std::string name;
-		std::string first;
-		std::string second;
+		std::string value;
 
-		constexpr bool operator==(const definition &obj) const { return obj.scope == scope && obj.name == name && obj.first == first && obj.second == second; }
+		constexpr bool operator==(const definition &obj) const { return obj.scope == scope && obj.effect_name == effect_name && obj.name == name && obj.value == value; }
 	};
 #endif
 }


### PR DESCRIPTION
This PR contains these changes

* Add `effect` scope (See [My add-on side](https://github.com/seri14/reshade-addons/compare/main...addon-uibind))
* ~Add API `bool has_effects_loaded()` to avoid touch _effects/_techniques/_textures/_uniforms while loading effects~
  Cancelled. See https://github.com/crosire/reshade/pull/250#issuecomment-1478615159
* Increase text buffer size from 128 to 256 (for to_string(float4x4) requires at least 144 bytes)
* Display definition default value as hint instead of input text

