### PR TITLE
Added a remark to the reshade_reloaded_effects event to signal how many times it gets called

### DIFF
--- a/include/reshade_events.hpp
+++ b/include/reshade_events.hpp
@@ -1479,6 +1479,7 @@ namespace reshade
 		/// Called right after all ReShade effects were reloaded.
 		/// This occurs during effect runtime initialization or because the user pressed the "Reload" button in the overlay.
 		/// <para>Callback function signature: <c>void (api::effect_runtime *runtime)</c></para>
+		///	<remarks>This is called after every preset has been reloaded. This means that if the user has e.g. 3 presets loaded into ReShade, this event is called three times. </remarks>
 		/// </summary>
 		reshade_reloaded_effects,
 

--- a/include/reshade_events.hpp
+++ b/include/reshade_events.hpp
@@ -1479,7 +1479,8 @@ namespace reshade
 		/// Called right after all ReShade effects were reloaded.
 		/// This occurs during effect runtime initialization or because the user pressed the "Reload" button in the overlay.
 		/// <para>Callback function signature: <c>void (api::effect_runtime *runtime)</c></para>
-		///	<remarks>This is called after every preset has been reloaded. This means that if the user has e.g. 3 presets loaded into ReShade, this event is called three times. </remarks>
+		///	<remarks>The callback is called twice: first right after all effects have been destroyed, and second right after the effects have been reloaded and all techniques enabled in the active
+		///	preset have been enabled.</remarks>
 		/// </summary>
 		reshade_reloaded_effects,
 


### PR DESCRIPTION
I ran into this and as it's not clear what's going on, I documented it. 

~~E.g. I had 2 presets in my test setup and when clicking 'Reload' this event was called twice, once for each preset. This is logical of course but I understood from the documentation on the method it would be called once.~~

Updated, see posts below.