### PR TITLE
Removed preset saving from uniform variable setters, added save_current_preset to public API

### DIFF
--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -660,5 +660,12 @@ namespace reshade::api
 			size_t length = SIZE;
 			get_technique_effect_name(technique, effect_name, &length);
 		}
+
+		/// <summary>
+		/// Enables or disables the flag whether the current preset file is saved after a uniform variable was changed through the api using one of the set_uniform_variable_* methods. 
+		/// </summary>
+		/// <param name="save_preset">Set to <see langword="true"/> to enable preset file saving after a uniform variable has been changed through the api or <see langword="false"/> to disable it.</param>
+		///	<remarks>By default the flag is set to true. It's recommended to set this flag to <see langword="false"/> if you set uniform variables in a loop, or multiple times in a handler to the reshade_present event</remarks>
+		virtual void set_save_preset_on_api_uniform_change_state(bool save_preset) = 0;
 	};
 }

--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -250,6 +250,8 @@ namespace reshade::api
 		/// <param name="values">Pointer to an array of booleans that are used to update this uniform variable.</param>
 		/// <param name="count">Number of values to write.</param>
 		/// <param name="array_index">Array offset to start writing values to when this uniform variable is an array variable.</param>
+		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
+		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
 		virtual void set_uniform_value_bool(effect_uniform_variable variable, const bool *values, size_t count, size_t array_index = 0) = 0;
 		/// <summary>
 		/// Sets the value of the specified uniform <paramref name="variable"/> as a vector of boolean values.
@@ -259,6 +261,8 @@ namespace reshade::api
 		/// <param name="y">Optional value of the second component in the vector that is used to update this uniform variable.</param>
 		/// <param name="z">Optional value of the third component in the vector that is used to update this uniform variable.</param>
 		/// <param name="w">Optional value of the fourth component in the vector that is used to update this uniform variable.</param>
+		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
+		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
 		inline  void set_uniform_value_bool(effect_uniform_variable variable, bool x, bool y = bool(0), bool z = bool(0), bool w = bool(0)) {
 			const bool values[4] = { x, y, z, w };
 			set_uniform_value_bool(variable, values, 4);
@@ -270,6 +274,8 @@ namespace reshade::api
 		/// <param name="values">Pointer to an array of floating-points that are used to update this uniform variable.</param>
 		/// <param name="count">Number of values to write.</param>
 		/// <param name="array_index">Array offset to start writing values to when this uniform variable is an array variable.</param>
+		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
+		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
 		virtual void set_uniform_value_float(effect_uniform_variable variable, const float *values, size_t count, size_t array_index = 0) = 0;
 		/// <summary>
 		/// Sets the value of the specified uniform <paramref name="variable"/> as a vector of floating-point values.
@@ -279,6 +285,8 @@ namespace reshade::api
 		/// <param name="y">Optional value of the second component in the vector that is used to update this uniform variable.</param>
 		/// <param name="z">Optional value of the third component in the vector that is used to update this uniform variable.</param>
 		/// <param name="w">Optional value of the fourth component in the vector that is used to update this uniform variable.</param>
+		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
+		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
 		inline  void set_uniform_value_float(effect_uniform_variable variable, float x, float y = float(0), float z = float(0), float w = float(0)) {
 			const float values[4] = { x, y, z, w };
 			set_uniform_value_float(variable, values, 4);
@@ -290,6 +298,8 @@ namespace reshade::api
 		/// <param name="values">Pointer to an array of signed integers that are used to update this uniform variable.</param>
 		/// <param name="count">Number of values to write.</param>
 		/// <param name="array_index">Array offset to start writing values to when this uniform variable is an array variable.</param>
+		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
+		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
 		virtual void set_uniform_value_int(effect_uniform_variable variable, const int32_t *values, size_t count, size_t array_index = 0) = 0;
 		/// <summary>
 		/// Sets the value of the specified uniform <paramref name="variable"/> as a vector of signed integer values.
@@ -299,6 +309,8 @@ namespace reshade::api
 		/// <param name="y">Optional value of the second component in the vector that is used to update this uniform variable.</param>
 		/// <param name="z">Optional value of the third component in the vector that is used to update this uniform variable.</param>
 		/// <param name="w">Optional value of the fourth component in the vector that is used to update this uniform variable.</param>
+		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
+		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
 		inline  void set_uniform_value_int(effect_uniform_variable variable, int32_t x, int32_t y = int32_t(0), int32_t z = int32_t(0), int32_t w = int32_t(0)) {
 			const int32_t values[4] = { x, y, z, w };
 			set_uniform_value_int(variable, values, 4);
@@ -310,6 +322,8 @@ namespace reshade::api
 		/// <param name="values">Pointer to an array of unsigned integers that are used to update this uniform variable.</param>
 		/// <param name="count">Number of values to write.</param>
 		/// <param name="array_index">Array offset to start writing values to when this uniform variable is an array variable.</param>
+		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
+		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
 		virtual void set_uniform_value_uint(effect_uniform_variable variable, const uint32_t *values, size_t count, size_t array_index = 0) = 0;
 		/// <summary>
 		/// Sets the value of the specified uniform <paramref name="variable"/> as a vector of unsigned integer values.
@@ -319,6 +333,8 @@ namespace reshade::api
 		/// <param name="y">Optional value of the second component in the vector that is used to update this uniform variable.</param>
 		/// <param name="z">Optional value of the third component in the vector that is used to update this uniform variable.</param>
 		/// <param name="w">Optional value of the fourth component in the vector that is used to update this uniform variable.</param>
+		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
+		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
 		inline  void set_uniform_value_uint(effect_uniform_variable variable, uint32_t x, uint32_t y = uint32_t(0), uint32_t z = uint32_t(0), uint32_t w = uint32_t(0)) {
 			const uint32_t values[4] = { x, y, z, w };
 			set_uniform_value_uint(variable, values, 4);
@@ -662,10 +678,8 @@ namespace reshade::api
 		}
 
 		/// <summary>
-		/// Enables or disables the flag whether the current preset file is saved after a uniform variable was changed through the api using one of the set_uniform_variable_* methods. 
+		/// Saves the current preset with the current state of the loaded techniques and uniform variables.
 		/// </summary>
-		/// <param name="save_preset">Set to <see langword="true"/> to enable preset file saving after a uniform variable has been changed through the api or <see langword="false"/> to disable it.</param>
-		///	<remarks>By default the flag is set to true. It's recommended to set this flag to <see langword="false"/> if you set uniform variables in a loop, or multiple times in a handler to the reshade_present event</remarks>
-		virtual void set_save_preset_on_api_uniform_change_state(bool save_preset) = 0;
+		virtual void save_current_preset() const = 0;
 	};
 }

--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -251,7 +251,7 @@ namespace reshade::api
 		/// <param name="count">Number of values to write.</param>
 		/// <param name="array_index">Array offset to start writing values to when this uniform variable is an array variable.</param>
 		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
-		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
+		///	is saved to disk, call <see cref="save_current_preset"/></remarks>
 		virtual void set_uniform_value_bool(effect_uniform_variable variable, const bool *values, size_t count, size_t array_index = 0) = 0;
 		/// <summary>
 		/// Sets the value of the specified uniform <paramref name="variable"/> as a vector of boolean values.
@@ -262,7 +262,7 @@ namespace reshade::api
 		/// <param name="z">Optional value of the third component in the vector that is used to update this uniform variable.</param>
 		/// <param name="w">Optional value of the fourth component in the vector that is used to update this uniform variable.</param>
 		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
-		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
+		///	is saved to disk, call <see cref="save_current_preset"/></remarks>
 		inline  void set_uniform_value_bool(effect_uniform_variable variable, bool x, bool y = bool(0), bool z = bool(0), bool w = bool(0)) {
 			const bool values[4] = { x, y, z, w };
 			set_uniform_value_bool(variable, values, 4);
@@ -275,7 +275,7 @@ namespace reshade::api
 		/// <param name="count">Number of values to write.</param>
 		/// <param name="array_index">Array offset to start writing values to when this uniform variable is an array variable.</param>
 		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
-		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
+		///	is saved to disk, call <see cref="save_current_preset"/></remarks>
 		virtual void set_uniform_value_float(effect_uniform_variable variable, const float *values, size_t count, size_t array_index = 0) = 0;
 		/// <summary>
 		/// Sets the value of the specified uniform <paramref name="variable"/> as a vector of floating-point values.
@@ -286,7 +286,7 @@ namespace reshade::api
 		/// <param name="z">Optional value of the third component in the vector that is used to update this uniform variable.</param>
 		/// <param name="w">Optional value of the fourth component in the vector that is used to update this uniform variable.</param>
 		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
-		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
+		///	is saved to disk, call <see cref="save_current_preset"/></remarks>
 		inline  void set_uniform_value_float(effect_uniform_variable variable, float x, float y = float(0), float z = float(0), float w = float(0)) {
 			const float values[4] = { x, y, z, w };
 			set_uniform_value_float(variable, values, 4);
@@ -299,7 +299,7 @@ namespace reshade::api
 		/// <param name="count">Number of values to write.</param>
 		/// <param name="array_index">Array offset to start writing values to when this uniform variable is an array variable.</param>
 		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
-		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
+		///	is saved to disk, call <see cref="save_current_preset"/></remarks>
 		virtual void set_uniform_value_int(effect_uniform_variable variable, const int32_t *values, size_t count, size_t array_index = 0) = 0;
 		/// <summary>
 		/// Sets the value of the specified uniform <paramref name="variable"/> as a vector of signed integer values.
@@ -310,7 +310,7 @@ namespace reshade::api
 		/// <param name="z">Optional value of the third component in the vector that is used to update this uniform variable.</param>
 		/// <param name="w">Optional value of the fourth component in the vector that is used to update this uniform variable.</param>
 		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
-		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
+		///	is saved to disk, call <see cref="save_current_preset"/></remarks>
 		inline  void set_uniform_value_int(effect_uniform_variable variable, int32_t x, int32_t y = int32_t(0), int32_t z = int32_t(0), int32_t w = int32_t(0)) {
 			const int32_t values[4] = { x, y, z, w };
 			set_uniform_value_int(variable, values, 4);
@@ -323,7 +323,7 @@ namespace reshade::api
 		/// <param name="count">Number of values to write.</param>
 		/// <param name="array_index">Array offset to start writing values to when this uniform variable is an array variable.</param>
 		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
-		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
+		///	is saved to disk, call <see cref="save_current_preset"/></remarks>
 		virtual void set_uniform_value_uint(effect_uniform_variable variable, const uint32_t *values, size_t count, size_t array_index = 0) = 0;
 		/// <summary>
 		/// Sets the value of the specified uniform <paramref name="variable"/> as a vector of unsigned integer values.
@@ -334,7 +334,7 @@ namespace reshade::api
 		/// <param name="z">Optional value of the third component in the vector that is used to update this uniform variable.</param>
 		/// <param name="w">Optional value of the fourth component in the vector that is used to update this uniform variable.</param>
 		///	<remarks>Setting the uniform value won't result in a save of the current preset. To make sure the current preset with the changed value
-		///	is saved to disk, call <see ref="save_current_preset"/></remarks>
+		///	is saved to disk, call <see cref="save_current_preset"/></remarks>
 		inline  void set_uniform_value_uint(effect_uniform_variable variable, uint32_t x, uint32_t y = uint32_t(0), uint32_t z = uint32_t(0), uint32_t w = uint32_t(0)) {
 			const uint32_t values[4] = { x, y, z, w };
 			set_uniform_value_uint(variable, values, 4);

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -169,7 +169,9 @@ namespace reshade
 		void get_texture_variable_effect_name(api::effect_texture_variable variable, char *effect_name, size_t *length) const final;
 		void get_technique_effect_name(api::effect_technique technique, char *effect_name, size_t *length) const final;
 
-		void set_save_preset_on_api_uniform_change_state(bool save_preset) final;
+#if RESHADE_FX
+		void save_current_preset() const override;
+#endif
 
 	protected:
 		runtime(api::device *device, api::command_queue *graphics_queue);
@@ -204,7 +206,6 @@ namespace reshade
 
 #if RESHADE_FX
 		void load_current_preset();
-		void save_current_preset() const;
 
 		bool switch_to_next_preset(std::filesystem::path filter_path, bool reversed = false);
 
@@ -540,10 +541,6 @@ namespace reshade
 #  endif
 		uint32_t _editor_palette[imgui::code_editor::color_palette_max];
 		#pragma endregion
-#endif
-
-#if RESHADE_FX
-		bool _save_preset_on_api_uniform_change = true;
 #endif
 	};
 

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -169,6 +169,8 @@ namespace reshade
 		void get_texture_variable_effect_name(api::effect_texture_variable variable, char *effect_name, size_t *length) const final;
 		void get_technique_effect_name(api::effect_technique technique, char *effect_name, size_t *length) const final;
 
+		void set_save_preset_on_api_uniform_change_state(bool save_preset) final;
+
 	protected:
 		runtime(api::device *device, api::command_queue *graphics_queue);
 		~runtime();
@@ -538,6 +540,10 @@ namespace reshade
 #  endif
 		uint32_t _editor_palette[imgui::code_editor::color_palette_max];
 		#pragma endregion
+#endif
+
+#if RESHADE_ADDON
+		bool _save_preset_on_api_uniform_change = true;
 #endif
 	};
 

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -170,7 +170,7 @@ namespace reshade
 		void get_technique_effect_name(api::effect_technique technique, char *effect_name, size_t *length) const final;
 
 #if RESHADE_FX
-		void save_current_preset() const override;
+		void save_current_preset() const final;
 #endif
 
 	protected:

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -542,7 +542,7 @@ namespace reshade
 		#pragma endregion
 #endif
 
-#if RESHADE_ADDON
+#if RESHADE_FX
 		bool _save_preset_on_api_uniform_change = true;
 #endif
 	};

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -345,7 +345,7 @@ void reshade::runtime::set_uniform_value_bool([[maybe_unused]] api::effect_unifo
 
 	set_uniform_value(*variable, values, count, array_index);
 
-	if (variable->special == special_uniform::none)
+	if (variable->special == special_uniform::none && _save_preset_on_api_uniform_change)
 		save_current_preset();
 
 #if RESHADE_ADDON
@@ -367,7 +367,7 @@ void reshade::runtime::set_uniform_value_float([[maybe_unused]] api::effect_unif
 
 	set_uniform_value(*variable, values, count, array_index);
 
-	if (variable->special == special_uniform::none)
+	if (variable->special == special_uniform::none && _save_preset_on_api_uniform_change)
 		save_current_preset();
 
 #if RESHADE_ADDON
@@ -389,7 +389,7 @@ void reshade::runtime::set_uniform_value_int([[maybe_unused]] api::effect_unifor
 
 	set_uniform_value(*variable, values, count, array_index);
 
-	if (variable->special == special_uniform::none)
+	if (variable->special == special_uniform::none && _save_preset_on_api_uniform_change)
 		save_current_preset();
 
 #if RESHADE_ADDON
@@ -411,7 +411,7 @@ void reshade::runtime::set_uniform_value_uint([[maybe_unused]] api::effect_unifo
 
 	set_uniform_value(*variable, values, count, array_index);
 
-	if (variable->special == special_uniform::none)
+	if (variable->special == special_uniform::none && _save_preset_on_api_uniform_change)
 		save_current_preset();
 
 #if RESHADE_ADDON
@@ -419,6 +419,7 @@ void reshade::runtime::set_uniform_value_uint([[maybe_unused]] api::effect_unifo
 #endif
 #endif
 }
+
 
 void reshade::runtime::enumerate_texture_variables([[maybe_unused]] const char *effect_name, [[maybe_unused]] void(*callback)(effect_runtime *runtime, api::effect_texture_variable variable, void *user_data), [[maybe_unused]] void *user_data)
 {
@@ -891,6 +892,7 @@ void reshade::runtime::set_technique_state([[maybe_unused]] api::effect_techniqu
 #endif
 }
 
+
 void reshade::runtime::set_preprocessor_definition([[maybe_unused]] const char *name, [[maybe_unused]] const char *value)
 {
 #if RESHADE_FX
@@ -1170,4 +1172,14 @@ void reshade::runtime::get_technique_effect_name([[maybe_unused]] api::effect_te
 	else
 #endif
 		*length = 0;
+}
+
+
+void reshade::runtime::set_save_preset_on_api_uniform_change_state([[maybe_unused]] bool save_preset)
+{
+#if RESHADE_FX
+#if RESHADE_ADDON
+	_save_preset_on_api_uniform_change = save_preset;
+#endif
+#endif
 }

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -1178,8 +1178,6 @@ void reshade::runtime::get_technique_effect_name([[maybe_unused]] api::effect_te
 void reshade::runtime::set_save_preset_on_api_uniform_change_state([[maybe_unused]] bool save_preset)
 {
 #if RESHADE_FX
-#if RESHADE_ADDON
 	_save_preset_on_api_uniform_change = save_preset;
-#endif
 #endif
 }

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -345,9 +345,6 @@ void reshade::runtime::set_uniform_value_bool([[maybe_unused]] api::effect_unifo
 
 	set_uniform_value(*variable, values, count, array_index);
 
-	if (variable->special == special_uniform::none && _save_preset_on_api_uniform_change)
-		save_current_preset();
-
 #if RESHADE_ADDON
 	_is_in_api_call = was_is_in_api_call;
 #endif
@@ -366,9 +363,6 @@ void reshade::runtime::set_uniform_value_float([[maybe_unused]] api::effect_unif
 #endif
 
 	set_uniform_value(*variable, values, count, array_index);
-
-	if (variable->special == special_uniform::none && _save_preset_on_api_uniform_change)
-		save_current_preset();
 
 #if RESHADE_ADDON
 	_is_in_api_call = was_is_in_api_call;
@@ -389,9 +383,6 @@ void reshade::runtime::set_uniform_value_int([[maybe_unused]] api::effect_unifor
 
 	set_uniform_value(*variable, values, count, array_index);
 
-	if (variable->special == special_uniform::none && _save_preset_on_api_uniform_change)
-		save_current_preset();
-
 #if RESHADE_ADDON
 	_is_in_api_call = was_is_in_api_call;
 #endif
@@ -410,9 +401,6 @@ void reshade::runtime::set_uniform_value_uint([[maybe_unused]] api::effect_unifo
 #endif
 
 	set_uniform_value(*variable, values, count, array_index);
-
-	if (variable->special == special_uniform::none && _save_preset_on_api_uniform_change)
-		save_current_preset();
 
 #if RESHADE_ADDON
 	_is_in_api_call = was_is_in_api_call;
@@ -1172,12 +1160,4 @@ void reshade::runtime::get_technique_effect_name([[maybe_unused]] api::effect_te
 	else
 #endif
 		*length = 0;
-}
-
-
-void reshade::runtime::set_save_preset_on_api_uniform_change_state([[maybe_unused]] bool save_preset)
-{
-#if RESHADE_FX
-	_save_preset_on_api_uniform_change = save_preset;
-#endif
 }


### PR DESCRIPTION
~~This commit adds `set_save_preset_on_api_uniform_change_state` which sets the new runtime flag `_save_preset_on_api_uniform_change` to the specified value. By default `_save_preset_on_api_uniform_change` is set to true to keep the API functionality the same with previous API versions. The flag `_save_preset_on_api_uniform_change` is used in the `set_uniform_variable_*` methods to allow for a way to switch preset saving off when uniform variables are changed.~~

~~API methods have been added at the bottom to keep API interfaces binary compatible. The `_save_preset_on_api_uniform_change` member variable is also added at the bottom of the runtime type for this reason.~~

~~I've not added a get_... variant as by default the flag is true and the general use case is that it's switched off only temporarily in a tight loop or single event handler.~~

As per discussion in Discord, I've reworked this PR to lift `save_current_preset` to the public API and remove the calls to `save_current_preset` in the `set_uniform_value_*` methods. 
I haven't lifted `load_current_preset` to the public API because it looks like it requires extra code around it in most current use cases which would require a wrapper method with almost the same name; additionally, it's also already covered for most use cases with `set_current_preset_path`.

I've added remarks to the `set_uniform_value_*` methods that the preset isn't saved after setting the uniform, and to do so the developer should call `save_current_preset`. 

I didn't increase the API version number as v7 hasn't been released yet. 