### PR TITLE
Prevent effect reloads in case the bit depth of the back buffer changes odd number of times within a frame

### DIFF
--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -302,6 +302,9 @@ namespace reshade
 		std::vector<std::pair<std::string, std::string>> _global_preprocessor_definitions;
 		std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>> _preset_preprocessor_definitions;
 		size_t _should_reload_effect = std::numeric_limits<size_t>::max();
+#if RESHADE_ADDON
+		bool _should_block_effect_reload = false;
+#endif
 
 		std::filesystem::path _effect_cache_path;
 		std::vector<std::filesystem::path> _effect_search_paths;


### PR DESCRIPTION
The current mechanism causes the effect reload blocking mechanism to reset in case the bit depth changes an odd number of times. This change prevents the reload block from being reset within a frame.