### PR TITLE
Add protection against key repeats triggering keybinds

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -271,7 +271,7 @@ bool reshade::input::is_key_down(unsigned int keycode) const
 bool reshade::input::is_key_pressed(unsigned int keycode) const
 {
 	assert(keycode < ARRAYSIZE(_keys));
-	return keycode > 0 && keycode < ARRAYSIZE(_keys) && (_keys[keycode] & 0x88) == 0x88;
+	return keycode > 0 && keycode < ARRAYSIZE(_keys) && (_keys[keycode] & 0x88) == 0x88 && !is_key_repeated(keycode);
 }
 bool reshade::input::is_key_pressed(unsigned int keycode, bool ctrl, bool shift, bool alt, bool force_modifiers) const
 {
@@ -288,6 +288,11 @@ bool reshade::input::is_key_released(unsigned int keycode) const
 {
 	assert(keycode < ARRAYSIZE(_keys));
 	return keycode > 0 && keycode < ARRAYSIZE(_keys) && (_keys[keycode] & 0x88) == 0x08;
+}
+bool reshade::input::is_key_repeated(unsigned int keycode) const
+{
+	assert(keycode < ARRAYSIZE(_keys));
+	return keycode < ARRAYSIZE(_keys) && (_last_keys[keycode] & 0x80) == 0x80 && (_keys[keycode] & 0x80) == 0x80;
 }
 
 bool reshade::input::is_any_key_down() const
@@ -371,6 +376,9 @@ void reshade::input::max_mouse_position(unsigned int position[2]) const
 void reshade::input::next_frame()
 {
 	_frame_count++;
+
+	// Backup key states from the last processed frame so that state transitions can be identified
+	std::copy_n(_keys, 256, _last_keys);
 
 	for (uint8_t &state : _keys)
 		state &= ~0x08;

--- a/source/input.hpp
+++ b/source/input.hpp
@@ -53,6 +53,7 @@ namespace reshade
 		bool is_key_pressed(unsigned int keycode, bool ctrl, bool shift, bool alt, bool force_modifiers = false) const;
 		bool is_key_pressed(const unsigned int key[4], bool force_modifiers = false) const { return is_key_pressed(key[0], key[1] != 0, key[2] != 0, key[3] != 0, force_modifiers); }
 		bool is_key_released(unsigned int keycode) const;
+		bool is_key_repeated(unsigned int keycode) const;
 		bool is_any_key_down() const;
 		bool is_any_key_pressed() const;
 		bool is_any_key_released() const;
@@ -123,6 +124,7 @@ namespace reshade
 		bool _block_mouse = false;
 		bool _block_keyboard = false;
 		uint8_t _keys[256] = {};
+		uint8_t _last_keys[256] = {};
 		unsigned int _keys_time[256] = {};
 		short _mouse_wheel_delta = 0;
 		unsigned int _mouse_position[2] = {};


### PR DESCRIPTION
For games that run their message loop on a different thread than presents the SwapChain, key repeats are currently altering the state of the `_keys[]` array after `reshade::input::next_frame (...)` runs.

<h2>This nullifies the logic that twiddles the bits here:</h2>

```cpp
	for (uint8_t &state : _keys)
		state &= ~0x08;
```

Thus, when the UI goes to sample `reshade::input::is_key_pressed (...)`, it sees **0x88** caused by key repeats and all keybinds in ReShade will randomly fire off multiple times causing the UI to toggle rapidly, thousands of screenshots to be taken, multiple copies of code saved when <kbd>S</kbd> is pressed, etc.

<h3>Simply holding down the <kbd>Home</kbd> key in the Microsoft Store version of Persona 5 currently results in this:</h3>

https://github.com/crosire/reshade/assets/13346629/8c70490a-47f1-42b8-b820-0a36dccc6b53

<hr>

I am fairly certain that `is_key_pressed (...)` should be excluding key repeats (that's what all this bit-twiddling is for, after all), so I have added logic to protect against this:

Each time `next_frame (...)` runs, the array of key states (as ***viewed*** during the last frame) is backed-up, and a new function (`is_key_repeated (...)`) checks whether the key is down between two successive frames. If it is, key repeats will be ignored and there is zero chance of triggering keybinds for key presses already processed on the last frame.

This changes keyboard input to behave more like gamepad input currently does, comparing a snapshot of the state from the last frame against the current state when checking for keys newly pressed.

<h3>Fixed Behavior (<kbd>Home</kbd> pressed once and held):</h3>

https://github.com/crosire/reshade/assets/13346629/d21dea9e-bad3-4ddf-bf3e-0efed107facb