### PR TITLE
Programatic overlay control and add-on event for overlay activation

### DIFF
--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -32,6 +32,18 @@ namespace reshade { namespace api
 	RESHADE_DEFINE_HANDLE(effect_uniform_variable);
 
 	/// <summary>
+	/// Input source for events triggered by user input.
+	/// </summary>
+	enum class input_source
+	{
+		none      = 0,
+		mouse     = 1,
+		keyboard  = 2,
+		gamepad   = 3,
+		clipboard = 4,
+	};
+
+	/// <summary>
 	/// A post-processing effect runtime, used to control effects.
 	/// <para>ReShade associates an independent post-processing effect runtime with most swap chains.</para>
 	/// </summary>
@@ -743,5 +755,15 @@ namespace reshade { namespace api
 		/// <param name="name">Name of the definition.</param>
 		/// <param name="value">Value of the definition.</param>
 		virtual void set_preprocessor_definition_for_effect(const char *effect_name, const char *name, const char *value) = 0;
+
+		/// <summary>
+		/// Activates ReShade's overlay programatically.
+		/// </summary>
+		/// <param name="activate">Activation state to request.</param>
+		/// <param name="source">Source of activation request.</param>
+		/// <remarks>
+		/// Returns <see langword="true"/> if the activation was accepted, otherwise returns <see langword="false"/>.
+		/// </remarks>
+		virtual bool activate_overlay(bool activate, reshade::api::input_source source) = 0;
 	};
 } }

--- a/include/reshade_events.hpp
+++ b/include/reshade_events.hpp
@@ -12,7 +12,7 @@ namespace reshade
 	enum class addon_event : uint32_t
 	{
 		/// <summary>
-		/// Called after successfull device creation, from:
+		/// Called after successful device creation, from:
 		/// <list type="bullet">
 		/// <item><description>IDirect3D9::CreateDevice</description></item>
 		/// <item><description>IDirect3D9Ex::CreateDeviceEx</description></item>
@@ -49,7 +49,7 @@ namespace reshade
 		destroy_device,
 
 		/// <summary>
-		/// Called after successfull command list creation, from:
+		/// Called after successful command list creation, from:
 		/// <list type="bullet">
 		/// <item><description>ID3D11Device::CreateDeferredContext</description></item>
 		/// <item><description>ID3D11Device1::CreateDeferredContext1</description></item>
@@ -78,7 +78,7 @@ namespace reshade
 		destroy_command_list,
 
 		/// <summary>
-		/// Called after successfull command queue creation, from:
+		/// Called after successful command queue creation, from:
 		/// <list type="bullet">
 		/// <item><description>ID3D12Device::CreateCommandQueue</description></item>
 		/// <item><description>vkCreateDevice (for every queue associated with the device)</description></item>
@@ -101,7 +101,7 @@ namespace reshade
 		destroy_command_queue,
 
 		/// <summary>
-		/// Called after successfull swap chain creation, from:
+		/// Called after successful swap chain creation, from:
 		/// <list type="bullet">
 		/// <item><description>IDirect3D9::CreateDevice (for the implicit swap chain)</description></item>
 		/// <item><description>IDirect3D9Ex::CreateDeviceEx (for the implicit swap chain)</description></item>
@@ -176,7 +176,7 @@ namespace reshade
 		destroy_effect_runtime,
 
 		/// <summary>
-		/// Called after successfull sampler creation from:
+		/// Called after successful sampler creation from:
 		/// <list type="bullet">
 		/// <item><description>ID3D10Device::CreateSamplerState</description></item>
 		/// <item><description>ID3D11Device::CreateSamplerState</description></item>
@@ -223,7 +223,7 @@ namespace reshade
 		destroy_sampler,
 
 		/// <summary>
-		/// Called after successfull resource creation from:
+		/// Called after successful resource creation from:
 		/// <list type="bullet">
 		/// <item><description>IDirect3DDevice9::CreateVertexBuffer</description></item>
 		/// <item><description>IDirect3DDevice9::CreateIndexBuffer</description></item>
@@ -369,7 +369,7 @@ namespace reshade
 		destroy_resource,
 
 		/// <summary>
-		/// Called after successfull resource view creation from:
+		/// Called after successful resource view creation from:
 		/// <list type="bullet">
 		/// <item><description>IDirect3DDevice9::CreateTexture</description></item>
 		/// <item><description>IDirect3DDevice9::CreateCubeTexture</description></item>
@@ -555,7 +555,7 @@ namespace reshade
 		update_texture_region,
 
 		/// <summary>
-		/// Called after successfull pipeline creation from:
+		/// Called after successful pipeline creation from:
 		/// <list type="bullet">
 		/// <item><description>IDirect3DDevice9::CreateVertexShader</description></item>
 		/// <item><description>IDirect3DDevice9::CreatePixelShader</description></item>
@@ -675,7 +675,7 @@ namespace reshade
 		destroy_pipeline,
 
 		/// <summary>
-		/// Called after successfull pipeline layout creation from:
+		/// Called after successful pipeline layout creation from:
 		/// <list type="bullet">
 		/// <item><description>ID3D12Device::CreateRootSignature</description></item>
 		/// <item><description>vkCreatePipelineLayout</description></item>
@@ -731,7 +731,7 @@ namespace reshade
 		update_descriptor_tables,
 
 		/// <summary>
-		/// Called after successfull query heap creation from:
+		/// Called after successful query heap creation from:
 		/// <list type="bullet">
 		/// <item><description>ID3D12Device::CreateQueryHeap</description></item>
 		/// <item><description>vkCreateQueryPool</description></item>
@@ -1564,6 +1564,15 @@ namespace reshade
 		/// </remarks>
 		reshade_reorder_techniques,
 
+		/// <summary>
+		/// Called when the ReShade overlay is about to be activated (shown) or deactivated (hidden).
+		/// <para>Callback function signature: <c>bool (api::effect_runtime *runtime, bool* activate, ImGuiInputSource source)</c></para>
+		/// </summary>
+		/// <remarks>
+		/// To prevent overlay activation, set the value of activate and return <see langword="true"/>, otherwise return <see langword="false"/>.
+		/// </remarks>
+		reshade_overlay_activation,
+
 #if RESHADE_ADDON
 		max // Last value used internally by ReShade to determine number of events in this enum
 #endif
@@ -1695,4 +1704,6 @@ namespace reshade
 
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_set_current_preset_path, void, api::effect_runtime *runtime, const char *path);
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_reorder_techniques, bool, api::effect_runtime *runtime, size_t count, api::effect_technique *techniques);
+
+	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_overlay_activation, bool, api::effect_runtime *runtime, bool* activate, api::input_source source);
 }

--- a/include/reshade_events.hpp
+++ b/include/reshade_events.hpp
@@ -1566,7 +1566,7 @@ namespace reshade
 
 		/// <summary>
 		/// Called when the ReShade overlay is about to be activated (shown) or deactivated (hidden).
-		/// <para>Callback function signature: <c>bool (api::effect_runtime *runtime, bool* activate, ImGuiInputSource source)</c></para>
+		/// <para>Callback function signature: <c>bool (api::effect_runtime *runtime, bool* activate, api::input_source source)</c></para>
 		/// </summary>
 		/// <remarks>
 		/// To prevent overlay activation, set the value of activate and return <see langword="true"/>, otherwise return <see langword="false"/>.

--- a/source/addon_manager.cpp
+++ b/source/addon_manager.cpp
@@ -7,6 +7,7 @@
 
 #include "reshade.hpp"
 #include "addon_manager.hpp"
+#include "runtime.hpp"
 #include "dll_log.hpp"
 #include "ini_file.hpp"
 
@@ -550,6 +551,14 @@ void ReShadeUnregisterOverlay(const char *title, void(*callback)(reshade::api::e
 		[title, callback](const reshade::addon_info::overlay_callback &item) {
 			return item.title == title && item.callback == callback;
 		}), info->overlay_callbacks.end());
+}
+
+bool ReShadeActivateOverlay(reshade::api::effect_runtime *runtime, bool activate, reshade::api::input_source source)
+{
+	if (runtime == nullptr)
+		return false;
+
+	return runtime->activate_overlay (activate, source);
 }
 
 #endif

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -168,6 +168,7 @@ namespace reshade
 		void set_current_preset_path(const char *path) final;
 
 		void reorder_techniques(size_t count, const api::effect_technique *techniques) final;
+		bool activate_overlay(bool activate, reshade::api::input_source source) final;
 
 	protected:
 		runtime(api::device *device, api::command_queue *graphics_queue);


### PR DESCRIPTION
This introduces a new `addon_event::reshade_overlay_activation` that add-ons can subscribe to in order to watch for overlay activation and prevent activation state changes if necessary.

It also re-works the internal `_show_overlay` toggle in `reshade::runtime::draw_gui (...)` to use a new `reshade::runtime::activate_overlay (...)` function that is accessible to add-ons through `ReShadeActivateOverlay (...)`.

The new event differs from the existing overlay events in the add-on API in that it has nothing to do with extending ReShade's overlay, but instead allows add-ons to react to overlay activation or bring up ReShade's overlay on-demand.

<hr>

_Special K uses this in order to hide its own overlay and cease input manipulation while users are interacting with the ReShade UI, and to restore its overlay and input processing behavior once ReShade's UI is closed. This is the expected use-case._