### PR TITLE
Fix missing XML tags in API docs

### DIFF
--- a/include/reshade_api_resource.hpp
+++ b/include/reshade_api_resource.hpp
@@ -311,7 +311,7 @@ namespace reshade { namespace api
 
 	/// <summary>
 	/// An opaque handle to a resource object (buffer, texture, ...).
-	/// <para>Resources created by the application are only guaranteed to be valid during event callbacks.
+	/// <para>Resources created by the application are only guaranteed to be valid during event callbacks.</para>
 	/// <para>Depending on the render API this can be a pointer to a 'IDirect3DResource9', 'ID3D10Resource', 'ID3D11Resource' or 'ID3D12Resource' object or a 'VkImage' handle.</para>
 	/// </summary>
 	RESHADE_DEFINE_HANDLE(resource);
@@ -404,7 +404,7 @@ namespace reshade { namespace api
 
 	/// <summary>
 	/// An opaque handle to a resource view object (depth-stencil, render target, shader resource view, ...).
-	/// <para>Resource views created by the application are only guaranteed to be valid during event callbacks.
+	/// <para>Resource views created by the application are only guaranteed to be valid during event callbacks.</para>
 	/// <para>Depending on the render API this can be a pointer to a 'IDirect3DResource9', 'ID3D10View' or 'ID3D11View' object, or a 'D3D12_CPU_DESCRIPTOR_HANDLE' (to a view descriptor) or 'VkImageView' handle.</para>
 	/// </summary>
 	RESHADE_DEFINE_HANDLE(resource_view);


### PR DESCRIPTION
As the title says, since intellisense was unhappy. Thanks for the excellent documentation.


P.S.
The [addon event create_pipeline_layout](https://github.com/crosire/reshade/blob/79011b27cba8880923e838ee086a5615fc64a414/include/reshade_events.hpp#L693) appears to be 100% unused and the docs imply otherwise. It's not referenced in the source code as far as I can tell. Wasn't sure where to bring this up.