### PR TITLE
Fix technique shortcuts are not loaded

### DIFF
--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1298,6 +1298,7 @@ void reshade::runtime::load_current_preset()
 			enable_technique(tech);
 		else
 			disable_technique(tech);
+
 		preset.get({}, "Key" + unique_name, tech.toggle_key_data);
 		preset.get({}, "Key" + tech.name, tech.toggle_key_data);
 	}

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -1298,6 +1298,8 @@ void reshade::runtime::load_current_preset()
 			enable_technique(tech);
 		else
 			disable_technique(tech);
+		preset.get({}, "Key" + unique_name, tech.toggle_key_data);
+		preset.get({}, "Key" + tech.name, tech.toggle_key_data);
 	}
 
 	// Reverse queue so that effects are enabled in the order they are defined in the preset (since the queue is worked from back to front)


### PR DESCRIPTION
This issue was introduced in 035903aad0818a6db70a6208b6f41ebd407d4d27 months ago. The two `preset.get()` were accidentally removed when removing the toggle annotation, and the key shortcuts could not be loaded into ReShade.