### PR TITLE
Added API 'reset_uniform_value' to allow add-ons can reset variables

### DIFF
--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -793,5 +793,11 @@ namespace reshade { namespace api
 		/// Overrides the color space used for presentation.
 		/// </summary>
 		virtual void set_color_space(color_space color_space) = 0;
+
+		/// <summary>
+		/// Resets the value of the specified uniform <paramref name="variable"/>.
+		/// </summary>
+		/// <param name="variable">Opaque handle to the uniform variable.</param>
+		virtual void reset_uniform_value(effect_uniform_variable variable) = 0;
 	};
 } }

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -208,6 +208,7 @@ namespace reshade
 		void save_texture(const texture &texture);
 		void update_texture(texture &texture, uint32_t width, uint32_t height, uint32_t depth, const void *pixels);
 
+		void reset_uniform_value(api::effect_uniform_variable variable);
 		void reset_uniform_value(uniform &variable);
 
 		void get_uniform_value_data(const uniform &variable, uint8_t *data, size_t size, size_t base_index) const;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -103,6 +103,8 @@ namespace reshade
 		bool get_annotation_uint_from_uniform_variable(api::effect_uniform_variable variable, const char *name, uint32_t *values, size_t count, size_t array_index = 0) const final;
 		bool get_annotation_string_from_uniform_variable(api::effect_uniform_variable variable, const char *name, char *value, size_t *value_size) const final;
 
+		void reset_uniform_value(api::effect_uniform_variable variable);
+
 		void get_uniform_value_bool(api::effect_uniform_variable variable, bool *values, size_t count, size_t array_index) const final;
 		void get_uniform_value_float(api::effect_uniform_variable variable, float *values, size_t count, size_t array_index) const final;
 		void get_uniform_value_int(api::effect_uniform_variable variable, int32_t *values, size_t count, size_t array_index) const final;
@@ -208,7 +210,6 @@ namespace reshade
 		void save_texture(const texture &texture);
 		void update_texture(texture &texture, uint32_t width, uint32_t height, uint32_t depth, const void *pixels);
 
-		void reset_uniform_value(api::effect_uniform_variable variable);
 		void reset_uniform_value(uniform &variable);
 
 		void get_uniform_value_data(const uniform &variable, uint8_t *data, size_t size, size_t base_index) const;

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -1417,3 +1417,9 @@ bool reshade::runtime::open_overlay(bool /*open*/, api::input_source /*source*/)
 	return false;
 }
 #endif
+
+void reshade::runtime::reset_uniform_value([[maybe_unused]] api::effect_uniform_variable handle)
+{
+	if (auto variable = reinterpret_cast<uniform *>(handle.handle))
+		reset_uniform_value(*variable);
+}

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -1420,6 +1420,8 @@ bool reshade::runtime::open_overlay(bool /*open*/, api::input_source /*source*/)
 
 void reshade::runtime::reset_uniform_value([[maybe_unused]] api::effect_uniform_variable handle)
 {
+#if RESHADE_FX
 	if (auto variable = reinterpret_cast<uniform *>(handle.handle))
 		reset_uniform_value(*variable);
+#endif
 }


### PR DESCRIPTION
See my add-on side https://github.com/cot6/reshade-addons/commit/c398194608edfc621dbdf0478f990c2e37abcbad?diff=unified&w=1