### PR TITLE
Fix various Vulkan tools (namely the SDK) complaining about the layer manifest being invalid

### DIFF
--- a/setup/ReShade32.json
+++ b/setup/ReShade32.json
@@ -1,7 +1,7 @@
 {
 	"file_format_version": "1.0.0",
 	"layer": {
-		"name": "VK_LAYER_reshade",
+		"name": "VK_LAYER_CROSIRE_reshade",
 		"type": "GLOBAL",
 		"library_path": ".\\ReShade32.dll",
 		"api_version": "1.3.268",

--- a/setup/ReShade64.json
+++ b/setup/ReShade64.json
@@ -1,7 +1,7 @@
 {
 	"file_format_version": "1.0.0",
 	"layer": {
-		"name": "VK_LAYER_reshade",
+		"name": "VK_LAYER_CROSIRE_reshade",
 		"type": "GLOBAL",
 		"library_path": ".\\ReShade64.dll",
 		"api_version": "1.3.268",


### PR DESCRIPTION
gets rid off this message when opening vkconfig from the Vulkan SDK:

![vkconfig_2024-01-16_21-01-07](https://github.com/crosire/reshade/assets/19245343/fb5fc746-1243-4737-a78a-c4dd6b2c7429)

so now debugging via the SDK possible!

if the naming is unwanted you can change it obviously :)

hopefully this is not intentional 🤞