### PR TITLE
Add the API to read all elements of value from ReShade configuration

### DIFF
--- a/include/reshade.hpp
+++ b/include/reshade.hpp
@@ -224,10 +224,10 @@ namespace reshade
 	inline void set_config_value(api::effect_runtime *runtime, const char *section, const char *key, const char *value, size_t buffer_count)
 	{
 #if defined(RESHADE_API_LIBRARY)
-		ReShadeSetConfigValue2(nullptr, runtime, section, key, value, buffer_count);
+		ReShadeSetConfigArray(nullptr, runtime, section, key, value, buffer_count);
 #else
 		static const auto func = reinterpret_cast<void(*)(HMODULE, api::effect_runtime *, const char *, const char *, const char *, size_t)>(
-			GetProcAddress(internal::get_reshade_module_handle(), "ReShadeSetConfigValue2"));
+			GetProcAddress(internal::get_reshade_module_handle(), "ReShadeSetConfigArray"));
 		func(internal::get_current_module_handle(), runtime, section, key, value, buffer_count);
 #endif
 	}

--- a/include/reshade.hpp
+++ b/include/reshade.hpp
@@ -11,7 +11,7 @@
 #include <Windows.h>
 
 // Current version of the ReShade API
-#define RESHADE_API_VERSION 11
+#define RESHADE_API_VERSION 12
 
 // Optionally import ReShade API functions when 'RESHADE_API_LIBRARY' is defined instead of using header-only mode
 #if defined(RESHADE_API_LIBRARY) || defined(RESHADE_API_LIBRARY_EXPORT)
@@ -28,7 +28,10 @@ RESHADE_API_LIBRARY_DECL void ReShadeLogMessage(HMODULE module, int level, const
 RESHADE_API_LIBRARY_DECL void ReShadeGetBasePath(char *path, size_t *path_size);
 
 RESHADE_API_LIBRARY_DECL bool ReShadeGetConfigValue(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, char *value, size_t *value_size);
+RESHADE_API_LIBRARY_DECL bool ReShadeGetConfigValue2(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, char *value, size_t *buffer_count);
+
 RESHADE_API_LIBRARY_DECL void ReShadeSetConfigValue(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, const char *value);
+RESHADE_API_LIBRARY_DECL void ReShadeSetConfigValue2(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, const char *value, size_t buffer_count);
 
 RESHADE_API_LIBRARY_DECL bool ReShadeRegisterAddon(HMODULE module, uint32_t api_version);
 RESHADE_API_LIBRARY_DECL void ReShadeUnregisterAddon(HMODULE module);
@@ -186,6 +189,16 @@ namespace reshade
 		return true;
 	}
 #endif
+	inline bool get_config_value2(api::effect_runtime *runtime, const char *section, const char *key, char *value, size_t *buffer_count)
+	{
+#if defined(RESHADE_API_LIBRARY)
+		return ReShadeGetConfigValue2(nullptr, runtime, section, key, value, buffer_count);
+#else
+		static const auto func = reinterpret_cast<bool(*)(HMODULE, api::effect_runtime *, const char *, const char *, char *, size_t *)>(
+			GetProcAddress(internal::get_reshade_module_handle(), "ReShadeGetConfigValue2"));
+		return func(internal::get_current_module_handle(), runtime, section, key, value, buffer_count);
+#endif
+	}
 
 	/// <summary>
 	/// Sets and saves a value in one of ReShade's config files.
@@ -219,6 +232,16 @@ namespace reshade
 		set_config_value<int>(runtime, section, key, value ? 1 : 0);
 	}
 #endif
+	inline void set_config_value2(api::effect_runtime *runtime, const char *section, const char *key, const char *value, size_t buffer_count)
+	{
+#if defined(RESHADE_API_LIBRARY)
+		ReShadeSetConfigValue2(nullptr, runtime, section, key, value, buffer_count);
+#else
+		static const auto func = reinterpret_cast<void(*)(HMODULE, api::effect_runtime *, const char *, const char *, const char *, size_t)>(
+			GetProcAddress(internal::get_reshade_module_handle(), "ReShadeSetConfigValue2"));
+		func(internal::get_current_module_handle(), runtime, section, key, value, buffer_count);
+#endif
+	}
 
 	/// <summary>
 	/// Registers this module as an add-on with ReShade.

--- a/include/reshade.hpp
+++ b/include/reshade.hpp
@@ -28,10 +28,9 @@ RESHADE_API_LIBRARY_DECL void ReShadeLogMessage(HMODULE module, int level, const
 RESHADE_API_LIBRARY_DECL void ReShadeGetBasePath(char *path, size_t *path_size);
 
 RESHADE_API_LIBRARY_DECL bool ReShadeGetConfigValue(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, char *value, size_t *value_size);
-RESHADE_API_LIBRARY_DECL bool ReShadeGetConfigValue2(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, char *value, size_t *buffer_count);
 
 RESHADE_API_LIBRARY_DECL void ReShadeSetConfigValue(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, const char *value);
-RESHADE_API_LIBRARY_DECL void ReShadeSetConfigValue2(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, const char *value, size_t buffer_count);
+RESHADE_API_LIBRARY_DECL void ReShadeSetConfigArray(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, const char *value, size_t buffer_count);
 
 RESHADE_API_LIBRARY_DECL bool ReShadeRegisterAddon(HMODULE module, uint32_t api_version);
 RESHADE_API_LIBRARY_DECL void ReShadeUnregisterAddon(HMODULE module);
@@ -189,16 +188,6 @@ namespace reshade
 		return true;
 	}
 #endif
-	inline bool get_config_value2(api::effect_runtime *runtime, const char *section, const char *key, char *value, size_t *buffer_count)
-	{
-#if defined(RESHADE_API_LIBRARY)
-		return ReShadeGetConfigValue2(nullptr, runtime, section, key, value, buffer_count);
-#else
-		static const auto func = reinterpret_cast<bool(*)(HMODULE, api::effect_runtime *, const char *, const char *, char *, size_t *)>(
-			GetProcAddress(internal::get_reshade_module_handle(), "ReShadeGetConfigValue2"));
-		return func(internal::get_current_module_handle(), runtime, section, key, value, buffer_count);
-#endif
-	}
 
 	/// <summary>
 	/// Sets and saves a value in one of ReShade's config files.
@@ -232,7 +221,7 @@ namespace reshade
 		set_config_value<int>(runtime, section, key, value ? 1 : 0);
 	}
 #endif
-	inline void set_config_value2(api::effect_runtime *runtime, const char *section, const char *key, const char *value, size_t buffer_count)
+	inline void set_config_value(api::effect_runtime *runtime, const char *section, const char *key, const char *value, size_t buffer_count)
 	{
 #if defined(RESHADE_API_LIBRARY)
 		ReShadeSetConfigValue2(nullptr, runtime, section, key, value, buffer_count);

--- a/source/addon.cpp
+++ b/source/addon.cpp
@@ -53,35 +53,6 @@ bool ReShadeGetConfigValue(HMODULE, reshade::api::effect_runtime *runtime, const
 
 	const std::string section_string = section != nullptr ? section : std::string();
 	const std::string key_string = key != nullptr ? key : std::string();
-	std::string value_string;
-
-	if (!config.get(section_string, key_string, value_string))
-	{
-		*size = 0;
-		return false;
-	}
-
-	if (value == nullptr)
-	{
-		*size = value_string.size() + 1;
-	}
-	else if (*size != 0)
-	{
-		*size = value_string.copy(value, *size - 1);
-		value[*size] = '\0';
-	}
-
-	return true;
-}
-bool ReShadeGetConfigValue2(HMODULE, reshade::api::effect_runtime *runtime, const char *section, const char *key, char *value, size_t *size)
-{
-	if (size == nullptr)
-		return false;
-
-	ini_file &config = (runtime != nullptr) ? ini_file::load_cache(static_cast<reshade::runtime *>(runtime)->get_config_path()) : reshade::global_config();
-
-	const std::string section_string = section != nullptr ? section : std::string();
-	const std::string key_string = key != nullptr ? key : std::string();
 	std::vector<std::string> elements;
 	std::string value_string;
 
@@ -110,17 +81,11 @@ bool ReShadeGetConfigValue2(HMODULE, reshade::api::effect_runtime *runtime, cons
 	return true;
 }
 
-void ReShadeSetConfigValue(HMODULE, reshade::api::effect_runtime *runtime, const char *section, const char *key, const char *value)
+void ReShadeSetConfigValue(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, const char *value)
 {
-	ini_file &config = (runtime != nullptr) ? ini_file::load_cache(static_cast<reshade::runtime *>(runtime)->get_config_path()) : reshade::global_config();
-
-	const std::string section_string = section != nullptr ? section : std::string();
-	const std::string key_string = key != nullptr ? key : std::string();
-	const std::string value_string = value != nullptr ? value : std::string();
-
-	config.set(section_string, key_string, value_string);
+	return ReShadeSetConfigArray(module, runtime, section, key, value, value != nullptr ? strlen(value) : 0);
 }
-void ReShadeSetConfigValue2(HMODULE, reshade::api::effect_runtime *runtime, const char *section, const char *key, const char *value, size_t value_buffer_count)
+void ReShadeSetConfigArray(HMODULE, reshade::api::effect_runtime *runtime, const char *section, const char *key, const char *value, size_t value_buffer_count)
 {
 	ini_file &config = (runtime != nullptr) ? ini_file::load_cache(static_cast<reshade::runtime *>(runtime)->get_config_path()) : reshade::global_config();
 

--- a/source/addon.cpp
+++ b/source/addon.cpp
@@ -46,39 +46,42 @@ void ReShadeGetBasePath(char *path, size_t *size)
 
 bool ReShadeGetConfigValue(HMODULE, reshade::api::effect_runtime *runtime, const char *section, const char *key, char *value, size_t *size)
 {
-	if (size == nullptr)
-		return false;
-
 	ini_file &config = (runtime != nullptr) ? ini_file::load_cache(static_cast<reshade::runtime *>(runtime)->get_config_path()) : reshade::global_config();
 
 	const std::string section_string = section != nullptr ? section : std::string();
 	const std::string key_string = key != nullptr ? key : std::string();
+
 	std::vector<std::string> elements;
-	std::string value_string;
+	config.get(section_string, key_string, elements);
 
-	if (!config.get(section_string, key_string, elements))
+	if (size != nullptr || value != nullptr)
 	{
-		*size = 0;
-		return false;
+		std::string value_string;
+		for (const std::string &element : elements)
+		{
+			value_string += element;
+			value_string += '\0';
+		}
+
+		if (size != nullptr)
+		{
+			if (elements.empty())
+			{
+				*size = 0;
+			}
+			else if (value == nullptr)
+			{
+				*size = value_string.size() + 1;
+			}
+			else if (*size != 0)
+			{
+				*size = value_string.copy(value, *size - 1);
+				value[*size] = '\0';
+			}
+		}
 	}
 
-	for (const std::string &element : elements)
-	{
-		value_string += element;
-		value_string += '\0';
-	}
-
-	if (value == nullptr)
-	{
-		*size = value_string.size() + 1;
-	}
-	else if (*size != 0)
-	{
-		*size = value_string.copy(value, *size - 1);
-		value[*size] = '\0';
-	}
-
-	return true;
+	return !elements.empty();
 }
 
 void ReShadeSetConfigValue(HMODULE module, reshade::api::effect_runtime *runtime, const char *section, const char *key, const char *value)
@@ -91,22 +94,26 @@ void ReShadeSetConfigArray(HMODULE, reshade::api::effect_runtime *runtime, const
 
 	const std::string section_string = section != nullptr ? section : std::string();
 	const std::string key_string = key != nullptr ? key : std::string();
+
+	if (value_buffer_count == 0)
+	{
+		config.remove_key(section_string, key_string);
+		return;
+	}
+
 	const std::string_view value_string = value != nullptr ? std::string_view(value, value_buffer_count) : std::string_view();
 
 	std::vector<std::string> elements;
-	if (value_buffer_count != 0)
+	std::string *element = &elements.emplace_back();
+	for (size_t i = 0; i < value_buffer_count; i++)
 	{
-		std::string *element = &elements.emplace_back();
-		for (size_t i = 0; i < value_buffer_count; i++)
-		{
-			if (const char c = value_string[i]; c != '\0')
-				*element += c;
-			else
-				element = &elements.emplace_back();
-		}
-		if (value_string.back() == '\0')
-			elements.pop_back();
+		if (const char c = value_string[i]; c != '\0')
+			*element += c;
+		else
+			element = &elements.emplace_back();
 	}
+	if (value_string.back() == '\0')
+		elements.pop_back();
 
 	config.set(section_string, key_string, elements);
 }

--- a/source/ini_file.cpp
+++ b/source/ini_file.cpp
@@ -11,7 +11,7 @@
 #include <shared_mutex>
 
 static std::shared_mutex s_ini_cache_mutex;
-static std::unordered_map<std::wstring, std::unique_ptr<ini_file>> s_ini_cache;
+static std::unordered_map<std::wstring, std::shared_ptr<ini_file>> s_ini_cache;
 
 ini_file &reshade::global_config()
 {
@@ -232,7 +232,13 @@ bool ini_file::flush_cache(const std::filesystem::path &path)
 {
 	const std::shared_lock<std::shared_mutex> lock(s_ini_cache_mutex);
 
-	const auto it = s_ini_cache.find(path);
+	auto it = s_ini_cache.find(path);
+	if (it == s_ini_cache.end())
+	{
+		std::error_code ec;
+		if (const std::filesystem::path canonical_path = std::filesystem::canonical(path, ec); !ec)
+			it = s_ini_cache.find(canonical_path);
+	}
 	return it != s_ini_cache.end() && it->second->save();
 }
 
@@ -254,15 +260,28 @@ ini_file &ini_file::load_cache(const std::filesystem::path &path)
 	assert(!path.empty());
 
 	const std::unique_lock<std::shared_mutex> lock(s_ini_cache_mutex);
+	
+	auto it = s_ini_cache.find(path);
+	if (it == s_ini_cache.end())
+	{
+		std::error_code ec;
+		const std::filesystem::path canonical_path = std::filesystem::canonical(path, ec);
+		if (!ec)
+			it = s_ini_cache.find(canonical_path);
 
-	const auto insert = s_ini_cache.try_emplace(path);
-	const auto it = insert.first;
+		// Only construct when actually adding a new entry to the cache, since the 'ini_file' constructor performs a costly load of the file
+		if (it == s_ini_cache.end())
+		{
+			std::shared_ptr<ini_file> ptr = std::make_shared<ini_file>(path);
+			if (s_ini_cache.try_emplace(path, ptr); !ec)
+				s_ini_cache.try_emplace(canonical_path, ptr);
 
-	// Only construct when actually adding a new entry to the cache, since the 'ini_file' constructor performs a costly load of the file
-	if (insert.second)
-		it->second = std::make_unique<ini_file>(path);
+			return *ptr;
+		}
+	}
+
 	// Don't reload file when it was just loaded or there are still modifications pending
-	else if (!it->second->_modified)
+	if (!it->second->_modified)
 		it->second->load();
 
 	return *it->second;

--- a/source/ini_file.hpp
+++ b/source/ini_file.hpp
@@ -265,20 +265,20 @@ public:
 	/// Saves all changes to INI files that were loaded through <see cref="load_cache"/> to disk.
 	/// </summary>
 	static bool flush_cache();
-	static bool flush_cache(const std::filesystem::path &path);
+	static bool flush_cache(std::filesystem::path path);
 
 	/// <summary>
 	/// Removes all INI files from cache, without saving changes.
 	/// </summary>
 	static void clear_cache();
-	static void clear_cache(const std::filesystem::path &path);
+	static void clear_cache(std::filesystem::path path);
 
 	/// <summary>
 	/// Gets the specified INI file from cache or opens it when it was not cached yet.
 	/// </summary>
 	/// <param name="path">Path to the INI file to access.</param>
 	/// <returns>Reference to the cached data.</returns>
-	static ini_file &load_cache(const std::filesystem::path &path);
+	static ini_file &load_cache(std::filesystem::path path);
 
 private:
 	template <typename T>

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -178,7 +178,7 @@ void reshade::runtime::get_uniform_variable_name([[maybe_unused]] api::effect_un
 		else if (*size != 0)
 		{
 			*size = variable->name.copy(value, *size - 1);
-			value[*size++] = '\0';
+			value[*size] = '\0';
 		}
 	}
 	else
@@ -202,7 +202,7 @@ void reshade::runtime::get_uniform_variable_effect_name([[maybe_unused]] api::ef
 		else if (*size != 0)
 		{
 			*size = effect_name.copy(value, *size - 1);
-			value[*size++] = '\0';
+			value[*size] = '\0';
 		}
 	}
 	else
@@ -321,7 +321,7 @@ bool reshade::runtime::get_annotation_string_from_uniform_variable([[maybe_unuse
 				else if (*size != 0)
 				{
 					*size = annotation.copy(value, *size - 1);
-					value[*size++] = '\0';
+					value[*size] = '\0';
 				}
 			}
 
@@ -545,7 +545,7 @@ void reshade::runtime::get_texture_variable_name([[maybe_unused]] api::effect_te
 		else if (*size != 0)
 		{
 			*size = variable->name.copy(value, *size - 1);
-			value[*size++] = '\0';
+			value[*size] = '\0';
 		}
 	}
 	else
@@ -569,7 +569,7 @@ void reshade::runtime::get_texture_variable_effect_name([[maybe_unused]] api::ef
 		else if (*size != 0)
 		{
 			*size = effect_name.copy(value, *size - 1);
-			value[*size++] = '\0';
+			value[*size] = '\0';
 		}
 	}
 	else
@@ -688,7 +688,7 @@ bool reshade::runtime::get_annotation_string_from_texture_variable([[maybe_unuse
 				else if (*size != 0)
 				{
 					*size = annotation.copy(value, *size - 1);
-					value[*size++] = '\0';
+					value[*size] = '\0';
 				}
 			}
 
@@ -862,7 +862,7 @@ void reshade::runtime::get_technique_name([[maybe_unused]] api::effect_technique
 		else if (*size != 0)
 		{
 			*size = tech->name.copy(value, *size - 1);
-			value[*size++] = '\0';
+			value[*size] = '\0';
 		}
 	}
 	else
@@ -886,7 +886,7 @@ void reshade::runtime::get_technique_effect_name([[maybe_unused]] api::effect_te
 		else if (*size != 0)
 		{
 			*size = effect_name.copy(value, *size - 1);
-			value[*size++] = '\0';
+			value[*size] = '\0';
 		}
 	}
 	else
@@ -1005,7 +1005,7 @@ bool reshade::runtime::get_annotation_string_from_technique([[maybe_unused]] api
 				else if (*size != 0)
 				{
 					*size = annotation.copy(value, *size - 1);
-					value[*size++] = '\0';
+					value[*size] = '\0';
 				}
 			}
 
@@ -1286,7 +1286,7 @@ bool reshade::runtime::get_preprocessor_definition_for_effect([[maybe_unused]] c
 			else if (*size != 0)
 			{
 				*size = definitions_string.copy(value, *size - 1);
-				value[*size++] = '\0';
+				value[*size] = '\0';
 			}
 		}
 
@@ -1308,7 +1308,7 @@ bool reshade::runtime::get_preprocessor_definition_for_effect([[maybe_unused]] c
 				else if (*size != 0)
 				{
 					*size = definition_it->second.copy(value, *size - 1);
-					value[*size++] = '\0';
+					value[*size] = '\0';
 				}
 			}
 
@@ -1457,7 +1457,7 @@ void reshade::runtime::get_current_preset_path([[maybe_unused]] char *path, size
 	else if (*size != 0)
 	{
 		*size = path_string.copy(path, *size - 1);
-		path[*size++] = '\0';
+		path[*size] = '\0';
 	}
 #else
 	*size = 0;


### PR DESCRIPTION
This PR also includes the following changes:
[Fixed an issue where the file may be cached by different paths separately](https://github.com/crosire/reshade/commit/b94b1ee604871ddea30260a855c51e5c3c781d78) 
