### PR TITLE
Preserve socket error state

### DIFF
--- a/source/windows/ws2_32.cpp
+++ b/source/windows/ws2_32.cpp
@@ -12,6 +12,22 @@
 // Do not count network traffic for local sockets (localhost), so to avoid blocking occuring in games running local servers in single player too
 static bool is_local_socket(SOCKET s)
 {
+	struct network_state_guard
+	{
+		int error;
+		int wsa_error;
+
+		network_state_guard() : error(errno), wsa_error(WSAGetLastError())
+		{
+		}
+
+		~network_state_guard()
+		{
+			errno = error;
+			WSASetLastError(wsa_error);
+		}
+	} error_guard;
+
 	// Get the target address information of the socket
 	int address_size = sizeof(SOCKADDR_STORAGE);
 	SOCKADDR_STORAGE peer_address = {};


### PR DESCRIPTION
I noticed that the socket error state wasn't preserved. When addon is enabled, some operations might clobber `errno` and calling `is_local_socket` might change the `WSAGetLastError` value.

As stated on the [Windows documentation](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsagetlasterror):
> The WSAGetLastError function returns the last error that occurred for the calling thread. When a particular Windows Sockets function indicates an error has occurred, this function should be called immediately to retrieve the extended error code for the failing function call.

For instance, creating a string might clobber the error value as mentioned here: https://dolp.in/pr3143

This PR aims to limit hooking side-effects and preserves the socket error state.