### PR TITLE
Add API 'require_reload_effect' to set flag to reload effects

### DIFF
--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -804,6 +804,6 @@ namespace reshade { namespace api
 		/// TODO
 		/// </summary>
 		/// <param name="effect_name">TODO</param>
-		virtual void require_reload_effect(const char *effect_name) = 0;
+		virtual void reload_effect_next_frame(const char *effect_name) = 0;
 	};
 } }

--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -799,5 +799,11 @@ namespace reshade { namespace api
 		/// </summary>
 		/// <param name="variable">Opaque handle to the uniform variable.</param>
 		virtual void reset_uniform_value(effect_uniform_variable variable) = 0;
+
+		/// <summary>
+		/// TODO
+		/// </summary>
+		/// <param name="effect_name">TODO</param>
+		virtual void require_reload_effect(const char *effect_name) = 0;
 	};
 } }

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -3599,23 +3599,24 @@ void reshade::runtime::destroy_effects()
 	assert(_techniques.empty() && _technique_sorting.empty());
 
 	_textures_loaded = false;
-	_should_reload_effect = std::numeric_limits<size_t>::max();
+	_reload_required_effects.clear();
 }
 void reshade::runtime::require_reload_effect(const char *effect_name)
 {
 #if RESHADE_FX
 	if (effect_name == nullptr || *effect_name == '\0')
 	{
-		_should_reload_effect = _effects.size();
+		_reload_required_effects = { _effects.size() };
 		return;
 	}
 
 	if (auto it = std::find_if(_effects.cbegin(), _effects.cend(), [effect_name = std::string_view(effect_name)](const effect &effect) { return effect.source_file.filename().u8string() == effect_name; });
 		it != _effects.cend())
 	{
-		// TODO
-		// _should_reload_effect = (All of required effects)
-		_should_reload_effect = static_cast<size_t>(std::distance(_effects.cbegin(), it));
+		if (const size_t effect_index = static_cast<size_t>(std::distance(_effects.cbegin(), it));
+			std::find(_reload_required_effects.cbegin(), _reload_required_effects.cend(), _effects.size()) == _reload_required_effects.cend() &&
+			std::find(_reload_required_effects.cbegin(), _reload_required_effects.cend(), effect_index) == _reload_required_effects.cend())
+			_reload_required_effects.push_back(effect_index);
 	}
 #endif
 }
@@ -3737,9 +3738,10 @@ bool reshade::runtime::update_effect_color_and_stencil_tex(uint32_t width, uint3
 #if RESHADE_ADDON
 	if (force_reload)
 	{
-		if (_effects.size() != _should_reload_effect && !_block_effect_reload_this_frame)
+		if (std::find(_reload_required_effects.cbegin(), _reload_required_effects.cend(), _effects.size()) == _reload_required_effects.cend() &&
+			!_block_effect_reload_this_frame)
 		{
-			_should_reload_effect = _effects.size();
+			_reload_required_effects = { _effects.size() };
 		}
 		else
 		{
@@ -3748,7 +3750,7 @@ bool reshade::runtime::update_effect_color_and_stencil_tex(uint32_t width, uint3
 #endif
 
 			// Avoid reloading effects when effect color resource changes every frame
-			_should_reload_effect = std::numeric_limits<size_t>::max();
+			_reload_required_effects.clear();
 			_block_effect_reload_this_frame = true;
 		}
 	}
@@ -3782,16 +3784,18 @@ void reshade::runtime::update_effects()
 	if (_frame_count == 0 && !_no_reload_on_init)
 		reload_effects();
 
-	if (_should_reload_effect != std::numeric_limits<size_t>::max() && !is_loading())
+	if (!_reload_required_effects.empty() && !is_loading())
 	{
 		save_current_preset(); // Save preset preprocessor definitions
 
-		if (_should_reload_effect < _effects.size())
-			reload_effect(_should_reload_effect);
+		assert(_reload_required_effects.back() <= _effects.size());
+
+		if (_reload_required_effects.back() < _effects.size())
+			reload_effect(_reload_required_effects.back());
 		else
 			reload_effects();
 
-		_should_reload_effect = std::numeric_limits<size_t>::max();
+		_reload_required_effects.pop_back();
 	}
 
 	if (_reload_remaining_effects == 0)

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -3601,6 +3601,24 @@ void reshade::runtime::destroy_effects()
 	_textures_loaded = false;
 	_should_reload_effect = std::numeric_limits<size_t>::max();
 }
+void reshade::runtime::require_reload_effect(const char *effect_name)
+{
+#if RESHADE_FX
+	if (effect_name == nullptr || *effect_name == '\0')
+	{
+		_should_reload_effect = _effects.size();
+		return;
+	}
+
+	if (auto it = std::find_if(_effects.cbegin(), _effects.cend(), [effect_name = std::string_view(effect_name)](const effect &effect) { return effect.source_file.filename().u8string() == effect_name; });
+		it != _effects.cend())
+	{
+		// TODO
+		// _should_reload_effect = (All of required effects)
+		_should_reload_effect = static_cast<size_t>(std::distance(_effects.cbegin(), it));
+	}
+#endif
+}
 
 bool reshade::runtime::load_effect_cache(const std::string &id, const std::string &type, std::string &data) const
 {

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -3601,7 +3601,7 @@ void reshade::runtime::destroy_effects()
 	_textures_loaded = false;
 	_reload_required_effects.clear();
 }
-void reshade::runtime::require_reload_effect(const char *effect_name)
+void reshade::runtime::reload_effect_next_frame(const char *effect_name)
 {
 #if RESHADE_FX
 	if (effect_name == nullptr || *effect_name == '\0')

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -198,7 +198,7 @@ namespace reshade
 		bool reload_effect(size_t effect_index);
 		void reload_effects(bool force_load_all = false);
 		void destroy_effects();
-		void require_reload_effect(const char *effect_name);
+		void reload_effect_next_frame(const char *effect_name);
 
 		bool load_effect_cache(const std::string &id, const std::string &type, std::string &data) const;
 		bool save_effect_cache(const std::string &id, const std::string &type, const std::string &data) const;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -293,7 +293,7 @@ namespace reshade
 
 		std::vector<std::pair<std::string, std::string>> _global_preprocessor_definitions;
 		std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>> _preset_preprocessor_definitions;
-		size_t _should_reload_effect = std::numeric_limits<size_t>::max();
+		std::vector<size_t> _reload_required_effects;
 		bool _block_effect_reload_this_frame = false;
 
 		std::filesystem::path _effect_cache_path;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -198,6 +198,7 @@ namespace reshade
 		bool reload_effect(size_t effect_index);
 		void reload_effects(bool force_load_all = false);
 		void destroy_effects();
+		void require_reload_effect(const char *effect_name);
 
 		bool load_effect_cache(const std::string &id, const std::string &type, std::string &data) const;
 		bool save_effect_cache(const std::string &id, const std::string &type, const std::string &data) const;

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -1211,15 +1211,16 @@ void reshade::runtime::set_preprocessor_definition_for_effect([[maybe_unused]] c
 
 		if ((scope_mask_updated & (GLOBAL_SCOPE_FLAG | PRESET_SCOPE_FLAG)) != 0)
 		{
-			_should_reload_effect = _effects.size();
+			_reload_required_effects = { _effects.size() };
 		}
 		else
 		{
 			const size_t effect_index = std::distance(_effects.cbegin(), std::find_if(_effects.cbegin(), _effects.cend(),
 				[effect_name = std::filesystem::u8path(effect_name_string)](const effect &effect) { return effect_name == effect.source_file.filename(); }));
 
-			if (effect_index != _should_reload_effect || _should_reload_effect == std::numeric_limits<size_t>::max())
-				_should_reload_effect = effect_index;
+			if (std::find(_reload_required_effects.cbegin(), _reload_required_effects.cend(), _effects.size()) == _reload_required_effects.cend() &&
+				std::find(_reload_required_effects.cbegin(), _reload_required_effects.cend(), effect_index) == _reload_required_effects.cend())
+				_reload_required_effects.push_back(effect_index);
 		}
 	}
 #endif


### PR DESCRIPTION
See my add-on side https://github.com/cot6/reshade-addons/pull/6 

TODO

- [x] Supports to reload multiple effects
- [x] Abort if effect is broken (solved by add-on side)
- [x] Other error patterns (solved by add-on side)