### PR TITLE
Fix DX11 *SSetConstantBuffers() calls setting the same buffer data to multiple cbuffers slots

### DIFF
--- a/source/d3d10/d3d10_impl_device.hpp
+++ b/source/d3d10/d3d10_impl_device.hpp
@@ -158,7 +158,7 @@ namespace reshade::d3d10
 		void insert_debug_marker(const char *, const float[4]) final {}
 
 	private:
-		com_ptr<ID3D10Buffer> _push_constants;
-		std::vector<uint32_t> _push_constants_data;
+		com_ptr<ID3D10Buffer> _push_constants[D3D10_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
+		std::vector<uint32_t> _push_constants_data[D3D10_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
 	};
 }

--- a/source/d3d11/d3d11_impl_command_list.cpp
+++ b/source/d3d11/d3d11_impl_command_list.cpp
@@ -465,12 +465,27 @@ void reshade::d3d11::device_context_impl::push_constants(api::shader_stage stage
 {
 	if (count == 0)
 		return;
+		
+	uint32_t push_constants_slot = 0;
+	if (layout != 0)
+	{
+		const api::descriptor_range &range = reinterpret_cast<pipeline_layout_impl *>(layout.handle)->ranges[layout_param];
+
+		push_constants_slot = range.dx_register_index;
+		stages &= range.visibility;
+	}
+
+	if (push_constants_slot >= D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT)
+	{
+		log::message(log::level::error, "Unsupported constant buffer slot");
+		return;
+	}
 
 	count += first;
 
-	if (count > _push_constants_data.size())
+	if (count > _push_constants_data[push_constants_slot].size())
 	{
-		_push_constants_data.resize(count);
+		_push_constants_data[push_constants_slot].resize(count);
 
 		// Enlarge push constant buffer to fit new requirement
 		D3D11_BUFFER_DESC desc = {};
@@ -479,38 +494,32 @@ void reshade::d3d11::device_context_impl::push_constants(api::shader_stage stage
 		desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
 		desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 
-		_push_constants.reset();
+		_push_constants[push_constants_slot].reset();
 
-		if (FAILED(_device_impl->_orig->CreateBuffer(&desc, nullptr, &_push_constants)))
+		if (FAILED(_device_impl->_orig->CreateBuffer(&desc, nullptr, &_push_constants[push_constants_slot])))
 		{
-			_push_constants_data.clear();
+			_push_constants_data[push_constants_slot].clear();
 
 			log::message(log::level::error, "Failed to create push constant buffer!");
 			return;
 		}
 
-		_device_impl->set_resource_name({ reinterpret_cast<uintptr_t>(_push_constants.get()) }, "Push constants");
+		_device_impl->set_resource_name({ reinterpret_cast<uintptr_t>(_push_constants[push_constants_slot].get()) }, "Push constants");
 	}
 
-	std::memcpy(_push_constants_data.data() + first, values, (count - first) * sizeof(uint32_t));
+	std::memcpy(_push_constants_data[push_constants_slot].data() + first, values, (count - first) * sizeof(uint32_t));
 
-	ID3D11Buffer *const push_constants = _push_constants.get();
+	// The "ID3D11Buffer" data isn't always immediately sent to the GPU when calling the set cbuffers functions below,
+	// instead, the calls are "cached" and executed at some point later, so we need to make sure we have one buffer per slot,
+	// to avoid the same buffer cross polluting multiple slots.
+	ID3D11Buffer *const push_constants = _push_constants[push_constants_slot].get();
 
 	// Discard the buffer so driver can return a new memory region to avoid stalls
 	if (D3D11_MAPPED_SUBRESOURCE mapped;
 		SUCCEEDED(_orig->Map(push_constants, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped)))
 	{
-		std::memcpy(mapped.pData, _push_constants_data.data(), _push_constants_data.size() * sizeof(uint32_t));
+		std::memcpy(mapped.pData, _push_constants_data[push_constants_slot].data(), _push_constants_data[push_constants_slot].size() * sizeof(uint32_t));
 		_orig->Unmap(push_constants, 0);
-	}
-
-	uint32_t push_constants_slot = 0;
-	if (layout != 0)
-	{
-		const api::descriptor_range &range = reinterpret_cast<pipeline_layout_impl *>(layout.handle)->ranges[layout_param];
-
-		push_constants_slot = range.dx_register_index;
-		stages &= range.visibility;
 	}
 
 	if ((stages & api::shader_stage::vertex) == api::shader_stage::vertex)

--- a/source/d3d11/d3d11_impl_command_list.cpp
+++ b/source/d3d11/d3d11_impl_command_list.cpp
@@ -465,7 +465,7 @@ void reshade::d3d11::device_context_impl::push_constants(api::shader_stage stage
 {
 	if (count == 0)
 		return;
-		
+
 	uint32_t push_constants_slot = 0;
 	if (layout != 0)
 	{
@@ -476,10 +476,7 @@ void reshade::d3d11::device_context_impl::push_constants(api::shader_stage stage
 	}
 
 	if (push_constants_slot >= D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT)
-	{
-		log::message(log::level::error, "Unsupported constant buffer slot");
 		return;
-	}
 
 	count += first;
 
@@ -509,9 +506,7 @@ void reshade::d3d11::device_context_impl::push_constants(api::shader_stage stage
 
 	std::memcpy(_push_constants_data[push_constants_slot].data() + first, values, (count - first) * sizeof(uint32_t));
 
-	// The "ID3D11Buffer" data isn't always immediately sent to the GPU when calling the set cbuffers functions below,
-	// instead, the calls are "cached" and executed at some point later, so we need to make sure we have one buffer per slot,
-	// to avoid the same buffer cross polluting multiple slots.
+	// Manage separate constant buffer per slot, so that it is possible to use multiple push constants ranges with different slots simultaneously
 	ID3D11Buffer *const push_constants = _push_constants[push_constants_slot].get();
 
 	// Discard the buffer so driver can return a new memory region to avoid stalls

--- a/source/d3d11/d3d11_impl_device_context.hpp
+++ b/source/d3d11/d3d11_impl_device_context.hpp
@@ -151,7 +151,7 @@ namespace reshade::d3d11
 		device_impl *const _device_impl;
 		com_ptr<ID3DUserDefinedAnnotation> _annotations;
 
-		com_ptr<ID3D11Buffer> _push_constants;
-		std::vector<uint32_t> _push_constants_data;
+		com_ptr<ID3D11Buffer> _push_constants[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
+		std::vector<uint32_t> _push_constants_data[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
 	};
 }


### PR DESCRIPTION
… if multiple "device_context_impl::push_constants()" calls were made between two draw calls.

While working on a RenoDX mod, I tried to push two separate cbuffers (with different reshade pipeline layouts and different cbuffers slots) within the same draw call (e.g. `addon_event::draw`) and noticed that the cbuffers values were cross polluting each other, the values of the second `push_constants()` call would end up set to the first cbuffer too.
So I checked the code and made a guess that the `ID3D11Buffer` might not be copied to the GPU immediately when calling (e.g.) `PSSetConstantBuffers()`, but later. Making separate copies of the buffer per cbuffer slot fixed the issue.
The command list from the game I was modding is not "deferred" afaik, but still I'm guessing some stuff is delayed, it's a command list after all.

I suppose the same issue would be present in DX10 and DX12, possibly in Vulkan too etc etc, but I haven't tried these nor have the means to do so, so it's better if they are fixed separately later.