### PR TITLE
Halved the size of the spinner (back to the size it originally was)

### DIFF
--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -1141,7 +1141,7 @@ void reshade::runtime::draw_gui()
 #if RESHADE_FX
 		if (show_spinner)
 		{
-			imgui::spinner((_effects.size() - _reload_remaining_effects) / float(_effects.size()), 8.0f * _font_size / 13, 10.0f * _font_size / 13);
+			imgui::spinner((_effects.size() - _reload_remaining_effects) / float(_effects.size()), 8.0f * _font_size / 13, 5.0f * _font_size / 13);
 		}
 		else
 #endif
@@ -1904,7 +1904,7 @@ void reshade::runtime::draw_gui_home()
 	if (_reload_remaining_effects != std::numeric_limits<size_t>::max())
 	{
 		ImGui::SetCursorPos(ImGui::GetWindowSize() * 0.5f - ImVec2(21, 21));
-		imgui::spinner((_effects.size() - _reload_remaining_effects) / float(_effects.size()), 8.0f * _font_size / 13, 10.0f * _font_size / 13);
+		imgui::spinner((_effects.size() - _reload_remaining_effects) / float(_effects.size()), 8.0f * _font_size / 13, 5.0f * _font_size / 13);
 		return; // Cannot show techniques and variables while effects are loading, since they are being modified in other threads during that time
 	}
 

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -1141,7 +1141,7 @@ void reshade::runtime::draw_gui()
 #if RESHADE_FX
 		if (show_spinner)
 		{
-			imgui::spinner((_effects.size() - _reload_remaining_effects) / float(_effects.size()), 16.0f * _font_size / 13, 10.0f * _font_size / 13);
+			imgui::spinner((_effects.size() - _reload_remaining_effects) / float(_effects.size()), 8.0f * _font_size / 13, 10.0f * _font_size / 13);
 		}
 		else
 #endif
@@ -1904,7 +1904,7 @@ void reshade::runtime::draw_gui_home()
 	if (_reload_remaining_effects != std::numeric_limits<size_t>::max())
 	{
 		ImGui::SetCursorPos(ImGui::GetWindowSize() * 0.5f - ImVec2(21, 21));
-		imgui::spinner((_effects.size() - _reload_remaining_effects) / float(_effects.size()), 16.0f * _font_size / 13, 10.0f * _font_size / 13);
+		imgui::spinner((_effects.size() - _reload_remaining_effects) / float(_effects.size()), 8.0f * _font_size / 13, 10.0f * _font_size / 13);
 		return; // Cannot show techniques and variables while effects are loading, since they are being modified in other threads during that time
 	}
 


### PR DESCRIPTION
Halved the size of the spinner (back to the size it originally was)

It's now about the same size (42 x 42px) as a taskbar icon in Windows 10 (48x48px) which I feel is about the perfect size.

If I knew how I would also add a 1 or 2 second wait before it shows up, because if the compile time is THAT short, why even bother people with a message since it's near instantaneous anyways.

Maybe we should also add it to the initial message - since it is the logo after all. 