### PR TITLE
Add GetRawInputBuffer hook to handle games that do not use WM_INPUT

### DIFF
--- a/res/exports.def
+++ b/res/exports.def
@@ -486,5 +486,5 @@ EXPORTS
 	DirectInputCreateEx PRIVATE
 
 	; dinput8.dll
-	DirectInput8Create PRIVATE
+	DirectInput8Create = HookDirectInput8Create PRIVATE
 	GetdfDIJoystick PRIVATE

--- a/res/exports.def
+++ b/res/exports.def
@@ -462,6 +462,10 @@ EXPORTS
 	ClipCursor = HookClipCursor PRIVATE
 	GetCursorPos = HookGetCursorPosition PRIVATE
 	SetCursorPos = HookSetCursorPosition PRIVATE
+	GetAsyncKeyState = HookGetAsyncKeyState PRIVATE
+	GetKeyState = HookGetKeyState PRIVATE
+	GetKeyboardState = HookGetKeyboardState PRIVATE
+    GetRawInputBuffer = HookGetRawInputBuffer PRIVATE
 
 	; ws2_32.dll (Uses ordinals in ws2_32.lib for most exports)
 	send = HookSend PRIVATE

--- a/res/exports.def
+++ b/res/exports.def
@@ -465,7 +465,10 @@ EXPORTS
 	GetAsyncKeyState = HookGetAsyncKeyState PRIVATE
 	GetKeyState = HookGetKeyState PRIVATE
 	GetKeyboardState = HookGetKeyboardState PRIVATE
-    GetRawInputBuffer = HookGetRawInputBuffer PRIVATE
+	GetRawInputBuffer = HookGetRawInputBuffer PRIVATE
+	SetWindowsHookExA = HookSetWindowsHookExA PRIVATE
+	SetWindowsHookExW = HookSetWindowsHookExW PRIVATE
+	UnhookWindowsHookEx = HookUnhookWindowsHookEx PRIVATE
 
 	; ws2_32.dll (Uses ordinals in ws2_32.lib for most exports)
 	send = HookSend PRIVATE

--- a/source/dll_main.cpp
+++ b/source/dll_main.cpp
@@ -282,11 +282,9 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
 
 					reshade::hooks::register_module(L"user32.dll");
 
-					// Always register DirectInput 1-7 module (to overwrite cooperative level)
+					// Always register DirectInput 1-8 module (to overwrite cooperative level)
 					reshade::hooks::register_module(get_system_path() / L"dinput.dll");
-					// Register DirectInput 8 module in case it was used to load ReShade (but ignore otherwise)
-					if (_wcsicmp(module_name.c_str(), L"dinput8") == 0)
-						reshade::hooks::register_module(get_system_path() / L"dinput8.dll");
+					reshade::hooks::register_module(get_system_path() / L"dinput8.dll");
 				}
 
 #if RESHADE_ADDON == 1

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -494,6 +494,8 @@ void reshade::input::immobilize_cursor(bool enable)
 			s_last_cursor_position.y = cursor_pos.y;
 		}
 	}
+
+	_immobilize_cursor = enable;
 }
 
 void reshade::input::block_mouse_input(bool enable)
@@ -512,11 +514,15 @@ void reshade::input::block_mouse_input(bool enable)
 		// Restore previous clipping rectangle when not blocking mouse input
 		ClipCursor(&s_last_clip_cursor);
 	}
+
+	_block_mouse = enable;
 }
 void reshade::input::block_keyboard_input(bool enable)
 {
 	if (enable)
 		_block_keyboard_time = std::chrono::high_resolution_clock::now();
+
+	_block_keyboard = enable;
 }
 
 bool is_immobilizing_cursor(reshade::input::window_handle target = reshade::input::any_window)

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -776,10 +776,6 @@ extern "C" BOOL WINAPI HookClipCursor(const RECT *lpRect)
 	// Some applications clip the mouse cursor, so disable that while we want full control over mouse input
 	if (is_blocking_mouse_input() || is_immobilizing_cursor())
 	{
-		// A non-zero clipping rect would move the cursor, and may be a component of a game's mouselook.
-		if (lpRect != nullptr)
-			s_last_cursor_warp = std::chrono::high_resolution_clock::now();
-
 		lpRect = nullptr;
 	}
 

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -485,7 +485,6 @@ void reshade::input::immobilize_cursor(bool enable)
 	bool originally_immobilized = is_immobilizing_cursor();
 	if (enable)
 	{
-		_immobilize_cursor_time = std::chrono::high_resolution_clock::now();
 		// Update the initial cursor position as soon as blocking starts
 		static const auto trampoline = reshade::hooks::call(HookGetCursorPosition);
 		POINT cursor_pos;
@@ -503,7 +502,6 @@ void reshade::input::block_mouse_input(bool enable)
 	// Some games setup ClipCursor with a tiny area which could make the cursor stay in that area instead of the whole window
 	if (enable)
 	{
-		_block_mouse_time = std::chrono::high_resolution_clock::now();
 		// This will call into 'HookClipCursor' below, so back up and restore rectangle
 		const RECT last_clip_cursor = s_last_clip_cursor;
 		ClipCursor(nullptr);

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -1037,7 +1037,7 @@ namespace reshade::hooks::win32 {
 	HHOOK real_mouse_hook = nullptr;
 
 	// Per-thread hooks
-	concurrency::concurrent_unordered_map<DWORD, HOOKPROC> real_keyboard_procs;
+	concurrency::concurrent_unordered_map<HHOOK, HOOKPROC> real_keyboard_procs;
 	concurrency::concurrent_unordered_map<DWORD, HHOOK> real_keyboard_hooks;
 	concurrency::concurrent_unordered_map<DWORD, HOOKPROC> real_mouse_procs;
 	concurrency::concurrent_unordered_map<DWORD, HHOOK> real_mouse_hooks;
@@ -1060,7 +1060,9 @@ extern "C" LRESULT CALLBACK proxy_mouse_proc (int nCode, WPARAM wParam, LPARAM l
 		{
 			DWORD thread_id = GetCurrentThreadId();
 			HOOKPROC hook_fn = reshade::hooks::win32::real_mouse_procs.count(thread_id) && reshade::hooks::win32::real_mouse_procs.at(thread_id) != nullptr ? reshade::hooks::win32::real_mouse_procs.at(thread_id) : reshade::hooks::win32::real_mouse_proc;
-			return hook_fn(nCode, wParam, lParam);
+
+			if (hook_fn != nullptr)
+				return hook_fn(nCode, wParam, lParam);
 		}
 	}
 
@@ -1084,7 +1086,9 @@ extern "C" LRESULT CALLBACK proxy_low_level_mouse_proc (int nCode, WPARAM wParam
 		{
 			DWORD thread_id = GetCurrentThreadId();
 			HOOKPROC hook_fn = reshade::hooks::win32::real_mouse_procs.count(thread_id) && reshade::hooks::win32::real_mouse_procs.at(thread_id) != nullptr ? reshade::hooks::win32::real_mouse_procs.at(thread_id) : reshade::hooks::win32::real_mouse_proc;
-			return hook_fn(nCode, wParam, lParam);
+
+			if (hook_fn != nullptr)
+				return hook_fn(nCode, wParam, lParam);
 		}
 	}
 
@@ -1109,7 +1113,9 @@ extern "C" LRESULT CALLBACK proxy_keyboard_proc (int nCode, WPARAM wParam, LPARA
 		{
 			DWORD thread_id = GetCurrentThreadId();
 			HOOKPROC hook_fn = (reshade::hooks::win32::real_keyboard_procs.count(thread_id) && reshade::hooks::win32::real_keyboard_procs.at(thread_id) != nullptr) ? reshade::hooks::win32::real_keyboard_procs.at(thread_id) : reshade::hooks::win32::real_keyboard_proc;
-			return hook_fn(nCode, wParam, lParam);
+
+			if (hook_fn != nullptr)
+				return hook_fn(nCode, wParam, lParam);
 		}
 	}
 
@@ -1135,7 +1141,9 @@ extern "C" LRESULT CALLBACK proxy_low_level_keyboard_proc (int nCode, WPARAM wPa
 		{
 			DWORD thread_id = GetCurrentThreadId();
 			HOOKPROC hook_fn = (reshade::hooks::win32::real_keyboard_procs.count(thread_id) && reshade::hooks::win32::real_keyboard_procs.at(thread_id) != nullptr) ? reshade::hooks::win32::real_keyboard_procs.at(thread_id) : reshade::hooks::win32::real_keyboard_proc;
-			return hook_fn(nCode, wParam, lParam);
+
+			if (hook_fn != nullptr)
+				return hook_fn(nCode, wParam, lParam);
 		}
 	}
 	

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -1208,7 +1208,7 @@ extern "C" HHOOK WINAPI HookSetWindowsHookExW(int idHook, HOOKPROC lpfn, HINSTAN
 	static const auto trampoline = reshade::hooks::call(HookSetWindowsHookExW);
 	HHOOK* real_hook = nullptr;
 
-	reshade::log::message(reshade::log::level::info, "Redirecting HookSetWindowsHookExW(idHook = %d, lpfn = %p, hmod = %p, dwThreadId = %d) ...", idHook, lpfn, hmod, dwThreadId);
+	reshade::log::message(reshade::log::level::info, "Redirecting SetWindowsHookExW(idHook = %d, lpfn = %p, hmod = %p, dwThreadId = %d) ...", idHook, lpfn, hmod, dwThreadId);
 
 	switch (idHook)
 	{
@@ -1296,7 +1296,7 @@ extern "C" HHOOK WINAPI HookSetWindowsHookExA(int idHook, HOOKPROC lpfn, HINSTAN
 	static const auto trampoline = reshade::hooks::call(HookSetWindowsHookExA);
 	HHOOK* real_hook = nullptr;
 
-	reshade::log::message(reshade::log::level::info, "Redirecting HookSetWindowsHookExA(idHook = %d, lpfn = %p, hmod = %p, dwThreadId = %d) ...", idHook, lpfn, hmod, dwThreadId);
+	reshade::log::message(reshade::log::level::info, "Redirecting SetWindowsHookExA(idHook = %d, lpfn = %p, hmod = %p, dwThreadId = %d) ...", idHook, lpfn, hmod, dwThreadId);
 
 	switch (idHook)
 	{

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -1037,7 +1037,7 @@ namespace reshade::hooks::win32 {
 	HHOOK real_mouse_hook = nullptr;
 
 	// Per-thread hooks
-	concurrency::concurrent_unordered_map<HHOOK, HOOKPROC> real_keyboard_procs;
+	concurrency::concurrent_unordered_map<DWORD, HOOKPROC> real_keyboard_procs;
 	concurrency::concurrent_unordered_map<DWORD, HHOOK> real_keyboard_hooks;
 	concurrency::concurrent_unordered_map<DWORD, HOOKPROC> real_mouse_procs;
 	concurrency::concurrent_unordered_map<DWORD, HHOOK> real_mouse_hooks;

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -817,7 +817,7 @@ extern "C" BOOL WINAPI HookGetCursorPosition(LPPOINT lpPoint)
 	// Allow the game to see the real cursor position if it's not busy using the wrong API for mouselook...
 	// (i.e. no calls to SetCursorPos in a certain period of time)
 	const auto now = std::chrono::high_resolution_clock::now();
-	const bool recently_warped = (is_immobilizing_cursor() && std::chrono::duration_cast<std::chrono::milliseconds>(s_last_cursor_warp - now).count() < 125);
+	const bool recently_warped = (is_immobilizing_cursor() && std::chrono::duration_cast<std::chrono::milliseconds>(now - s_last_cursor_warp).count() < 125);
 	if (is_blocking_mouse_input() || recently_warped)
 	{
 		assert(lpPoint != nullptr);

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -776,6 +776,10 @@ extern "C" BOOL WINAPI HookClipCursor(const RECT *lpRect)
 	// Some applications clip the mouse cursor, so disable that while we want full control over mouse input
 	if (is_blocking_mouse_input() || is_immobilizing_cursor())
 	{
+		// A non-zero clipping rect would move the cursor, and may be a component of a game's mouselook.
+		if (lpRect != nullptr)
+			s_last_cursor_warp = std::chrono::high_resolution_clock::now();
+
 		lpRect = nullptr;
 	}
 

--- a/source/input.hpp
+++ b/source/input.hpp
@@ -28,6 +28,9 @@ namespace reshade
 		/// </summary>
 		using window_handle = void *;
 
+		static constexpr window_handle AnyWindow   = 0;
+		static constexpr window_handle GlobalQueue = reinterpret_cast <window_handle> (~0);
+
 		explicit input(window_handle window);
 
 		/// <summary>
@@ -84,8 +87,8 @@ namespace reshade
 		/// Set to <see langword="true"/> to prevent mouse GetCursorPos from returning the real pos; use last value of SetCursorPos.
 		/// This is separate from mouse blocking, it is intended to prevent games that use Set/GetCursorPos from warping the cursor.
 		/// </summary>
-		void immobilize_mouse(bool enable);
-		bool is_immobilizing_mouse() const { return _immobile_mouse; }
+		void immobilize_cursor(bool enable);
+		bool is_immobilizing_cursor() const { return _immobilize_cursor; }
 		/// <summary>
 		/// Set to <see langword="true"/> to prevent keyboard input window messages from reaching the application.
 		/// </summary>
@@ -125,9 +128,9 @@ namespace reshade
 	private:
 		std::recursive_mutex _mutex;
 		window_handle _window;
-		bool _immobile_mouse = false;
 		bool _block_mouse = false;
 		bool _block_keyboard = false;
+		bool _immobilize_cursor = false;
 		uint8_t _keys[256] = {};
 		uint8_t _last_keys[256] = {};
 		unsigned int _keys_time[256] = {};

--- a/source/input.hpp
+++ b/source/input.hpp
@@ -82,13 +82,13 @@ namespace reshade
 		/// Set to <see langword="true"/> to prevent mouse input window messages from reaching the application.
 		/// </summary>
 		void block_mouse_input(bool enable);
-		bool is_blocking_mouse_input() const { return _block_mouse || std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _block_mouse_time).count() < input_grace_period_ms; }
+		bool is_blocking_mouse_input() const { return _block_mouse; }
 		/// <summary>
 		/// Set to <see langword="true"/> to prevent mouse GetCursorPos from returning the real pos; use last value of SetCursorPos.
 		/// This is separate from mouse blocking, it is intended to prevent games that use Set/GetCursorPos from warping the cursor.
 		/// </summary>
 		void immobilize_cursor(bool enable);
-		bool is_immobilizing_cursor() const { return _immobilize_cursor || std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _immobilize_cursor_time).count() < input_grace_period_ms; }
+		bool is_immobilizing_cursor() const { return _immobilize_cursor; }
 		/// <summary>
 		/// Set to <see langword="true"/> to prevent keyboard input window messages from reaching the application.
 		/// </summary>
@@ -131,9 +131,7 @@ namespace reshade
 		bool _block_mouse;
 		bool _block_keyboard;
 		bool _immobilize_cursor;
-		std::chrono::high_resolution_clock::time_point _block_mouse_time; // timestamp when mouse input was last blocked
-		std::chrono::high_resolution_clock::time_point _block_keyboard_time; // timestamp when keyboard input was last blocked
-		std::chrono::high_resolution_clock::time_point _immobilize_cursor_time; // timestamp when cursor movement was last blocked
+		std::chrono::high_resolution_clock::time_point _block_keyboard_time; // timestamp when keyboard input was last blocked (prevent games from processing the keyboard combo to toggle ReShade's UI off)
 		uint8_t _keys[256] = {};
 		uint8_t _last_keys[256] = {};
 		unsigned int _keys_time[256] = {};

--- a/source/input.hpp
+++ b/source/input.hpp
@@ -28,9 +28,8 @@ namespace reshade
 		/// </summary>
 		using window_handle = void *;
 
-		static constexpr window_handle AnyWindow   = 0;
-		static constexpr window_handle GlobalQueue = reinterpret_cast <window_handle> (~0);
-		static constexpr int InputGracePeriodMs = 125;
+		static constexpr window_handle any_window = 0;
+		static constexpr int input_grace_period_ms = 125;
 
 		explicit input(window_handle window);
 
@@ -83,18 +82,18 @@ namespace reshade
 		/// Set to <see langword="true"/> to prevent mouse input window messages from reaching the application.
 		/// </summary>
 		void block_mouse_input(bool enable);
-		bool is_blocking_mouse_input() const { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _block_mouse_time).count() < InputGracePeriodMs; }
+		bool is_blocking_mouse_input() const { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _block_mouse_time).count() < input_grace_period_ms; }
 		/// <summary>
 		/// Set to <see langword="true"/> to prevent mouse GetCursorPos from returning the real pos; use last value of SetCursorPos.
 		/// This is separate from mouse blocking, it is intended to prevent games that use Set/GetCursorPos from warping the cursor.
 		/// </summary>
 		void immobilize_cursor(bool enable);
-		bool is_immobilizing_cursor() const { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _immobilize_cursor_time).count() < InputGracePeriodMs; }
+		bool is_immobilizing_cursor() const { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _immobilize_cursor_time).count() < input_grace_period_ms; }
 		/// <summary>
 		/// Set to <see langword="true"/> to prevent keyboard input window messages from reaching the application.
 		/// </summary>
 		void block_keyboard_input(bool enable);
-		bool is_blocking_keyboard_input() const { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _block_keyboard_time).count() < InputGracePeriodMs; }
+		bool is_blocking_keyboard_input() const { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _block_keyboard_time).count() < input_grace_period_ms; }
 
 		/// <summary>
 		/// Locks access to the input data so it cannot be modified in another thread.

--- a/source/input.hpp
+++ b/source/input.hpp
@@ -82,18 +82,18 @@ namespace reshade
 		/// Set to <see langword="true"/> to prevent mouse input window messages from reaching the application.
 		/// </summary>
 		void block_mouse_input(bool enable);
-		bool is_blocking_mouse_input() const { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _block_mouse_time).count() < input_grace_period_ms; }
+		bool is_blocking_mouse_input() const { return _block_mouse || std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _block_mouse_time).count() < input_grace_period_ms; }
 		/// <summary>
 		/// Set to <see langword="true"/> to prevent mouse GetCursorPos from returning the real pos; use last value of SetCursorPos.
 		/// This is separate from mouse blocking, it is intended to prevent games that use Set/GetCursorPos from warping the cursor.
 		/// </summary>
 		void immobilize_cursor(bool enable);
-		bool is_immobilizing_cursor() const { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _immobilize_cursor_time).count() < input_grace_period_ms; }
+		bool is_immobilizing_cursor() const { return _immobilize_cursor || std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _immobilize_cursor_time).count() < input_grace_period_ms; }
 		/// <summary>
 		/// Set to <see langword="true"/> to prevent keyboard input window messages from reaching the application.
 		/// </summary>
 		void block_keyboard_input(bool enable);
-		bool is_blocking_keyboard_input() const { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _block_keyboard_time).count() < input_grace_period_ms; }
+		bool is_blocking_keyboard_input() const { return _block_keyboard || std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _block_keyboard_time).count() < input_grace_period_ms; }
 
 		/// <summary>
 		/// Locks access to the input data so it cannot be modified in another thread.
@@ -128,6 +128,9 @@ namespace reshade
 	private:
 		std::recursive_mutex _mutex;
 		window_handle _window;
+		bool _block_mouse;
+		bool _block_keyboard;
+		bool _immobilize_cursor;
 		std::chrono::high_resolution_clock::time_point _block_mouse_time; // timestamp when mouse input was last blocked
 		std::chrono::high_resolution_clock::time_point _block_keyboard_time; // timestamp when keyboard input was last blocked
 		std::chrono::high_resolution_clock::time_point _immobilize_cursor_time; // timestamp when cursor movement was last blocked

--- a/source/input.hpp
+++ b/source/input.hpp
@@ -81,6 +81,12 @@ namespace reshade
 		void block_mouse_input(bool enable);
 		bool is_blocking_mouse_input() const { return _block_mouse; }
 		/// <summary>
+		/// Set to <see langword="true"/> to prevent mouse GetCursorPos from returning the real pos; use last value of SetCursorPos.
+		/// This is separate from mouse blocking, it is intended to prevent games that use Set/GetCursorPos from warping the cursor.
+		/// </summary>
+		void immobilize_mouse(bool enable);
+		bool is_immobilizing_mouse() const { return _immobile_mouse; }
+		/// <summary>
 		/// Set to <see langword="true"/> to prevent keyboard input window messages from reaching the application.
 		/// </summary>
 		void block_keyboard_input(bool enable);
@@ -119,6 +125,7 @@ namespace reshade
 	private:
 		std::recursive_mutex _mutex;
 		window_handle _window;
+		bool _immobile_mouse = false;
 		bool _block_mouse = false;
 		bool _block_keyboard = false;
 		uint8_t _keys[256] = {};

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -918,7 +918,7 @@ void reshade::runtime::draw_gui()
 		{
 			_input->block_mouse_input(false);
 			_input->block_keyboard_input(false);
-			_input->immobilize_mouse(false);
+			_input->immobilize_cursor(false);
 		}
 		return; // Early-out to avoid costly ImGui calls when no GUI elements are on the screen
 	}
@@ -1592,7 +1592,7 @@ void reshade::runtime::draw_gui()
 
 		_input->block_mouse_input(block_input && (imgui_io.WantCaptureMouse || _input_processing_mode == 2));
 		_input->block_keyboard_input(block_input && (imgui_io.WantCaptureKeyboard || _input_processing_mode == 2));
-		_input->immobilize_mouse(_show_overlay || _block_input_next_frame ||block_input && (imgui_io.WantCaptureMouse || _input_processing_mode == 2));
+		_input->immobilize_cursor(_show_overlay || _block_input_next_frame || (block_input && (imgui_io.WantCaptureMouse || _input_processing_mode == 2)));
 	}
 
 	if (ImDrawData *const draw_data = ImGui::GetDrawData();

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -918,6 +918,7 @@ void reshade::runtime::draw_gui()
 		{
 			_input->block_mouse_input(false);
 			_input->block_keyboard_input(false);
+			_input->immobilize_mouse(false);
 		}
 		return; // Early-out to avoid costly ImGui calls when no GUI elements are on the screen
 	}
@@ -1591,6 +1592,7 @@ void reshade::runtime::draw_gui()
 
 		_input->block_mouse_input(block_input && (imgui_io.WantCaptureMouse || _input_processing_mode == 2));
 		_input->block_keyboard_input(block_input && (imgui_io.WantCaptureKeyboard || _input_processing_mode == 2));
+		_input->immobilize_mouse(_show_overlay || _block_input_next_frame ||block_input && (imgui_io.WantCaptureMouse || _input_processing_mode == 2));
 	}
 
 	if (ImDrawData *const draw_data = ImGui::GetDrawData();

--- a/source/windows/dinput.cpp
+++ b/source/windows/dinput.cpp
@@ -13,8 +13,8 @@
 #include "input.hpp"
 
 // It is technically possible to associate these hooks back to a device (cooperative level), but it may not be the same window as ReShade renders on
-extern bool is_blocking_mouse_input(reshade::input::window_handle window = reshade::input::AnyWindow);
-extern bool is_blocking_keyboard_input(reshade::input::window_handle window = reshade::input::AnyWindow);
+extern bool is_blocking_mouse_input(reshade::input::window_handle window = reshade::input::any_window);
+extern bool is_blocking_keyboard_input(reshade::input::window_handle window = reshade::input::any_window);
 
 #define IDirectInputDevice_SetCooperativeLevel_Impl(vtable_index, device_interface_version, encoding) \
 	HRESULT STDMETHODCALLTYPE IDirectInputDevice##device_interface_version##encoding##_SetCooperativeLevel(IDirectInputDevice##device_interface_version##encoding *pDevice, HWND hwnd, DWORD dwFlags) \

--- a/source/windows/dinput.cpp
+++ b/source/windows/dinput.cpp
@@ -10,7 +10,7 @@
 #include <dinput.h>
 #include "dll_log.hpp" // Include late to get 'hr_to_string' helper function
 #include "hook_manager.hpp"
-#include <input.hpp>
+#include "input.hpp"
 
 // It is technically possible to associate these hooks back to a device (cooperative level), but it may not be the same window as ReShade renders on
 extern bool is_blocking_mouse_input(reshade::input::window_handle window = reshade::input::AnyWindow);

--- a/source/windows/dinput.cpp
+++ b/source/windows/dinput.cpp
@@ -10,9 +10,11 @@
 #include <dinput.h>
 #include "dll_log.hpp" // Include late to get 'hr_to_string' helper function
 #include "hook_manager.hpp"
+#include <input.hpp>
 
-extern bool is_blocking_mouse_input();
-extern bool is_blocking_keyboard_input();
+// It is technically possible to associate these hooks back to a device (cooperative level), but it may not be the same window as ReShade renders on
+extern bool is_blocking_mouse_input(reshade::input::window_handle window = reshade::input::AnyWindow);
+extern bool is_blocking_keyboard_input(reshade::input::window_handle window = reshade::input::AnyWindow);
 
 #define IDirectInputDevice_SetCooperativeLevel_Impl(vtable_index, device_interface_version, encoding) \
 	HRESULT STDMETHODCALLTYPE IDirectInputDevice##device_interface_version##encoding##_SetCooperativeLevel(IDirectInputDevice##device_interface_version##encoding *pDevice, HWND hwnd, DWORD dwFlags) \

--- a/source/windows/dinput8.cpp
+++ b/source/windows/dinput8.cpp
@@ -9,16 +9,149 @@
 #include <dinput.h>
 #include "dll_log.hpp" // Include late to get 'hr_to_string' helper function
 #include "hook_manager.hpp"
+#include "input.hpp"
 
-extern "C" HRESULT WINAPI DirectInput8Create(HINSTANCE hinst, DWORD dwVersion, REFIID riidltf, LPVOID *ppvOut, LPUNKNOWN pUnkOuter)
+// It is technically possible to associate these hooks back to a device (cooperative level), but it may not be the same window as ReShade renders on
+extern bool is_blocking_mouse_input(reshade::input::window_handle window = reshade::input::AnyWindow);
+extern bool is_blocking_keyboard_input(reshade::input::window_handle window = reshade::input::AnyWindow);
+
+#define IDirectInputDevice8_SetCooperativeLevel_Impl(vtable_index, encoding) \
+	HRESULT STDMETHODCALLTYPE IDirectInputDevice8##encoding##_SetCooperativeLevel(IDirectInputDevice8##encoding *pDevice, HWND hwnd, DWORD dwFlags) \
+	{ \
+		reshade::log::message(reshade::log::level::info, "Redirecting IDirectInputDevice8::SetCooperativeLevel(this = %p, hwnd = %p, dwFlags = %#x) ...", pDevice, hwnd, dwFlags); \
+		\
+		if (dwFlags & DISCL_EXCLUSIVE) \
+		{ \
+			DIDEVICEINSTANCE##encoding info = { sizeof(info) }; \
+			pDevice->GetDeviceInfo(&info); \
+			if (LOBYTE(info.dwDevType) == DI8DEVTYPE_MOUSE || \
+				LOBYTE(info.dwDevType) == DI8DEVTYPE_KEYBOARD) \
+			{ \
+				/* Need to remove exclusive flag, otherwise DirectInput will block input window messages and input.cpp will not receive input anymore */ \
+				dwFlags = (dwFlags & ~DISCL_EXCLUSIVE) | DISCL_NONEXCLUSIVE; \
+				\
+				reshade::log::message(reshade::log::level::info, "> Replacing flags with %#x.", dwFlags); \
+			} \
+		} \
+		\
+		return reshade::hooks::call(IDirectInputDevice8##encoding##_SetCooperativeLevel, reshade::hooks::vtable_from_instance(pDevice) + vtable_index)(pDevice, hwnd, dwFlags); \
+	}
+
+IDirectInputDevice8_SetCooperativeLevel_Impl(13,A)
+IDirectInputDevice8_SetCooperativeLevel_Impl(13,W)
+
+#define IDirectInputDevice8_GetDeviceState_Impl(vtable_index, encoding) \
+	HRESULT STDMETHODCALLTYPE IDirectInputDevice8##encoding##_GetDeviceState(IDirectInputDevice8##encoding *pDevice, DWORD cbData, LPVOID lpvData) \
+	{ \
+		DIDEVICEINSTANCE##encoding info = { sizeof(info) }; \
+		pDevice->GetDeviceInfo(&info); \
+		switch (LOBYTE(info.dwDevType)) \
+		{ \
+		case DI8DEVTYPE_MOUSE: \
+			if (is_blocking_mouse_input()) \
+			{ \
+				std::memset(lpvData, 0, cbData); \
+				return DI_OK; \
+			} \
+			break; \
+		case DI8DEVTYPE_KEYBOARD: \
+			if (is_blocking_keyboard_input()) \
+			{ \
+				std::memset(lpvData, 0, cbData); \
+				return DI_OK; \
+			} \
+			break; \
+		} \
+		\
+		return reshade::hooks::call(IDirectInputDevice8##encoding##_GetDeviceState, reshade::hooks::vtable_from_instance(pDevice) + vtable_index)(pDevice, cbData, lpvData); \
+	}
+
+IDirectInputDevice8_GetDeviceState_Impl(9,A)
+IDirectInputDevice8_GetDeviceState_Impl(9,W)
+
+#define IDirectInputDevice8_GetDeviceData_Impl(vtable_index, encoding) \
+	HRESULT STDMETHODCALLTYPE IDirectInputDevice8##encoding##_GetDeviceData(IDirectInputDevice8##encoding *pDevice, DWORD cbObjectData, LPDIDEVICEOBJECTDATA rgdod, LPDWORD pdwInOut, DWORD dwFlags) \
+	{ \
+		if ((dwFlags & DIGDD_PEEK) == 0) \
+		{ \
+			DIDEVICEINSTANCE##encoding info = { sizeof(info) }; \
+			pDevice->GetDeviceInfo(&info); \
+			switch (LOBYTE(info.dwDevType)) \
+			{ \
+			case DI8DEVTYPE_MOUSE: \
+				if (is_blocking_mouse_input()) \
+				{ \
+					*pdwInOut = 0; \
+					return DI_OK; \
+				} \
+				break; \
+			case DI8DEVTYPE_KEYBOARD: \
+				if (is_blocking_keyboard_input()) \
+				{ \
+					*pdwInOut = 0; \
+					return DI_OK; \
+				} \
+				break; \
+			} \
+		} \
+		\
+		return reshade::hooks::call(IDirectInputDevice8##encoding##_GetDeviceData, reshade::hooks::vtable_from_instance(pDevice) + vtable_index)(pDevice, cbObjectData, rgdod, pdwInOut, dwFlags); \
+	}
+
+IDirectInputDevice8_GetDeviceData_Impl(10,A)
+IDirectInputDevice8_GetDeviceData_Impl(10,W)
+
+#define IDirectInput8_CreateDevice_Impl(vtable_index, encoding) \
+	HRESULT STDMETHODCALLTYPE IDirectInput8##encoding##_CreateDevice(IDirectInput8##encoding *pDI, REFGUID rguid, LPDIRECTINPUTDEVICE8##encoding *lplpDirectInputDevice, LPUNKNOWN pUnkOuter) \
+	{ \
+		reshade::log::message( \
+			reshade::log::level::info, \
+			"Redirecting IDirectInput8" #encoding "::CreateDevice(this = %p, rguid = %s, lplpDirectInputDevice = %p, pUnkOuter = %p) ...", \
+			pDI, reshade::log::iid_to_string(rguid).c_str(), lplpDirectInputDevice, pUnkOuter); \
+		\
+		const HRESULT hr = reshade::hooks::call(IDirectInput8##encoding##_CreateDevice, reshade::hooks::vtable_from_instance(pDI) + vtable_index)(pDI, rguid, lplpDirectInputDevice, pUnkOuter); \
+		if (SUCCEEDED(hr)) \
+		{ \
+			reshade::hooks::install("IDirectInputDevice8" #encoding "::GetDeviceState", reshade::hooks::vtable_from_instance(*lplpDirectInputDevice), 9, reinterpret_cast<reshade::hook::address>(&IDirectInputDevice8##encoding##_GetDeviceState)); \
+			reshade::hooks::install("IDirectInputDevice8" #encoding "::GetDeviceData", reshade::hooks::vtable_from_instance(*lplpDirectInputDevice), 10, reinterpret_cast<reshade::hook::address>(&IDirectInputDevice8##encoding##_GetDeviceData)); \
+			reshade::hooks::install("IDirectInputDevice8" #encoding "::SetCooperativeLevel", reshade::hooks::vtable_from_instance(*lplpDirectInputDevice), 13, reinterpret_cast<reshade::hook::address>(&IDirectInputDevice8##encoding##_SetCooperativeLevel)); \
+		} \
+		else \
+		{ \
+			reshade::log::message(reshade::log::level::warning, "IDirectInput8" #encoding "::CreateDevice failed with error code %s.", reshade::log::hr_to_string(hr).c_str()); \
+		} \
+		return hr; \
+	}
+
+IDirectInput8_CreateDevice_Impl(3,A)
+IDirectInput8_CreateDevice_Impl(3,W)
+
+extern "C" HRESULT WINAPI HookDirectInput8Create(HINSTANCE hinst, DWORD dwVersion, REFIID riidltf, LPVOID *ppvOut, LPUNKNOWN pUnkOuter)
 {
 	reshade::log::message(
 		reshade::log::level::info,
 		"Redirecting DirectInput8Create(hinst = %p, dwVersion = %x, riidltf = %s, ppvOut = %p, pUnkOuter = %p) ...",
 		hinst, dwVersion, reshade::log::iid_to_string(riidltf).c_str(), ppvOut, pUnkOuter);
 
+	const HRESULT hr = reshade::hooks::call(HookDirectInput8Create)(hinst, dwVersion, riidltf, ppvOut, pUnkOuter);
+	if (SUCCEEDED(hr))
+	{
+		IUnknown *const factory = static_cast<IUnknown *>(*ppvOut);
+
+		if (riidltf == IID_IDirectInput8W)
+			reshade::hooks::install("IDirectInput8W::CreateDevice", reshade::hooks::vtable_from_instance(static_cast <IDirectInput8W *>(factory)), 3, reinterpret_cast<reshade::hook::address>(&IDirectInput8W_CreateDevice));
+		if (riidltf == IID_IDirectInput8A)
+			reshade::hooks::install("IDirectInput8A::CreateDevice", reshade::hooks::vtable_from_instance(static_cast <IDirectInput8A *>(factory)), 3, reinterpret_cast<reshade::hook::address>(&IDirectInput8A_CreateDevice));
+	}
+	else
+	{
+		reshade::log::message(reshade::log::level::warning, "DirectInput8Create failed with error code %s.", reshade::log::hr_to_string(hr).c_str());
+	}
+
+	return hr;
+
 	// Pass through without doing anything, this export only exists to allow wrapper installation as dinput8.dll
-	return reshade::hooks::call(DirectInput8Create)(hinst, dwVersion, riidltf, ppvOut, pUnkOuter);
+	return reshade::hooks::call(HookDirectInput8Create)(hinst, dwVersion, riidltf, ppvOut, pUnkOuter);
 }
 
 extern "C" LPCDIDATAFORMAT WINAPI GetdfDIJoystick()

--- a/source/windows/dinput8.cpp
+++ b/source/windows/dinput8.cpp
@@ -12,8 +12,8 @@
 #include "input.hpp"
 
 // It is technically possible to associate these hooks back to a device (cooperative level), but it may not be the same window as ReShade renders on
-extern bool is_blocking_mouse_input(reshade::input::window_handle window = reshade::input::AnyWindow);
-extern bool is_blocking_keyboard_input(reshade::input::window_handle window = reshade::input::AnyWindow);
+extern bool is_blocking_mouse_input(reshade::input::window_handle window = reshade::input::any_window);
+extern bool is_blocking_keyboard_input(reshade::input::window_handle window = reshade::input::any_window);
 
 #define IDirectInputDevice8_SetCooperativeLevel_Impl(vtable_index, encoding) \
 	HRESULT STDMETHODCALLTYPE IDirectInputDevice8##encoding##_SetCooperativeLevel(IDirectInputDevice8##encoding *pDevice, HWND hwnd, DWORD dwFlags) \


### PR DESCRIPTION
# Buffered Raw Input

I have added a new hook on `GetRawInputBuffer (...)` that classifies all input events as keyboard, mouse or gamepad and removes events from the buffer if ReShade is blocking that type of input.

This API does not use `WM_INPUT`, and cannot be captured through a game's message queue. It is intended for devices with high throughput where pulling `WM_INPUT` out of a window's message queue one by one is inefficient.

### On the topic of efficiency

I would really like to see implementations of `is_blocking_mouse_input (...)` and `is_blocking_keyboard_input (...)` that do not acquire a lock. The fast-path to exit `GetRawInputBuffer (...)` when ReShade is not blocking input (99% of the time during gameplay!) is crippled by potential lock contention on an API designed specifically to alleviate locking overhead on extremely high polling rate devices.

# Keyboard APIs (sometimes used for mouse input)

Hooks have also been introduced for `GetAsyncKeyState (...)`, `GetKeyState (...)` and `GetKeyboardState (...)`, since some games use these APIs for checking mouse button state or in lieu of processing keyboard/mouse messages.

# Cursor Position and Clipping Rectangle

I have changed mouse cursor blocking to get the immediate cursor position at the time blocking starts, rather than waiting for the game to call `SetCursorPos (...)` first.

Last, I added a check for an active window when ReShade blocks calls to `ClipCursor (...)`.

* If the calling thread has a window, instead of allowing the cursor to move to secondary monitors, the cursor will be restricted to the window. This makes finding the cursor easier on multi-monitor systems because it won't drift off to a different monitor and when the overlay is first opened, the cursor will automatically be moved inside the window.

This new behavior may be better as a user-configurable parameter, I'll leave that up to you however. _It is how Special K's own UI works (and is not configurable)._