### PR TITLE
Allow add-on controlled effects to render regardless of effects state

### DIFF
--- a/source/runtime_internal.hpp
+++ b/source/runtime_internal.hpp
@@ -196,6 +196,7 @@ namespace reshade
 
 		reshadefx::effect_module module;
 		size_t source_hash = 0;
+		bool is_addonfx = false;
 		std::filesystem::path source_file;
 		std::vector<std::filesystem::path> included_files;
 		std::vector<std::pair<std::string, std::string>> definitions;


### PR DESCRIPTION
This work was to make my screenshot add-on always perform the depth capture.

.addonfx effects will no longer being affected by user choice directly, but you can still make it work like before by using the effects state API.