### PR TITLE
Add reshade::api::display in order to implement HDR display mastering metadata.

### DIFF
--- a/ReShade.vcxproj
+++ b/ReShade.vcxproj
@@ -100,6 +100,7 @@
     <Import Project="deps\utfcpp.props" />
     <Import Project="deps\Vulkan.props" />
     <Import Project="deps\Windows.props" />
+    <Import Project="deps\sk_hdr_png.props" />
   </ImportGroup>
   <PropertyGroup>
     <ExecutablePath>tools;$(ExecutablePath)</ExecutablePath>

--- a/ReShade.vcxproj
+++ b/ReShade.vcxproj
@@ -100,7 +100,6 @@
     <Import Project="deps\utfcpp.props" />
     <Import Project="deps\Vulkan.props" />
     <Import Project="deps\Windows.props" />
-    <Import Project="deps\sk_hdr_png.props" />
   </ImportGroup>
   <PropertyGroup>
     <ExecutablePath>tools;$(ExecutablePath)</ExecutablePath>
@@ -600,6 +599,7 @@
     <ClCompile Include="source\dxgi\dxgi.cpp" />
     <ClCompile Include="source\dxgi\dxgi_d3d10.cpp" />
     <ClCompile Include="source\dxgi\dxgi_device.cpp" />
+    <ClCompile Include="source\dxgi\dxgi_impl_display.cpp" />
     <ClCompile Include="source\dxgi\dxgi_swapchain.cpp" />
     <ClCompile Include="source\hook.cpp" />
     <ClCompile Include="source\hook_manager.cpp" />
@@ -718,6 +718,7 @@
     <ClInclude Include="source\dll_log.hpp" />
     <ClInclude Include="source\dll_resources.hpp" />
     <ClInclude Include="source\dxgi\dxgi_device.hpp" />
+    <ClInclude Include="source\dxgi\dxgi_impl_display.hpp" />
     <ClInclude Include="source\dxgi\dxgi_swapchain.hpp" />
     <ClInclude Include="source\hook.hpp" />
     <ClInclude Include="source\hook_manager.hpp" />

--- a/ReShade.vcxproj.filters
+++ b/ReShade.vcxproj.filters
@@ -79,6 +79,9 @@
     <Filter Include="resources\shaders">
       <UniqueIdentifier>{9232c43b-559d-4435-b309-c8bbf4e6477b}</UniqueIdentifier>
     </Filter>
+    <Filter Include="api\dxgi">
+      <UniqueIdentifier>{e8eebdc2-4ab7-47d5-b053-e2dda568614e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="examples\09-depth\generic_depth_addon.cpp">
@@ -423,6 +426,9 @@
     <ClCompile Include="source\windows\ws2_32.cpp">
       <Filter>hooks\windows</Filter>
     </ClCompile>
+    <ClCompile Include="source\dxgi\dxgi_impl_display.cpp">
+      <Filter>api\dxgi</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\reshade.hpp">
@@ -721,6 +727,9 @@
     </ClInclude>
     <ClInclude Include="source\vulkan\vulkan_impl_type_convert.hpp">
       <Filter>api\vulkan</Filter>
+    </ClInclude>
+    <ClInclude Include="source\dxgi\dxgi_impl_display.hpp">
+      <Filter>api\dxgi</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/deps/sk_hdr_png/include/sk_hdr_png.hpp
+++ b/deps/sk_hdr_png/include/sk_hdr_png.hpp
@@ -26,6 +26,7 @@
 
 #include "reshade_api.hpp"
 #include "reshade_api_display.hpp"
+#include <bitset>
 #include <com_ptr.hpp>
 
 #include <cmath>
@@ -814,6 +815,18 @@ sk_hdr_png::copy_to_clipboard (const wchar_t* image_path)
 bool
 sk_hdr_png::write_image_to_disk (const wchar_t* image_path, unsigned int width, unsigned int height, const void* pixels, int quantization_bits, format fmt, bool use_clipboard, reshade::api::display* display)
 {
+	if (fmt == format::r16g16b16a16_float)
+	{
+		int cpu_info [4] = {  };
+
+		CpuIdEx(cpu_info, 1, 0);	
+		if (!std::bitset<32>(cpu_info[2])[29])
+		{
+			reshade::log::message(reshade::log::level::error, "CPU does not support AVX/F16C, required for scRGB screenshots!");
+			return false;
+		}
+	}
+
 	using namespace DirectX;
 	using namespace DirectX::PackedVector;
 

--- a/deps/sk_hdr_png/include/sk_hdr_png.hpp
+++ b/deps/sk_hdr_png/include/sk_hdr_png.hpp
@@ -25,7 +25,7 @@
 #pragma once
 
 #include "reshade_api.hpp"
-//#include "reshade_api_display.hpp"
+#include "reshade_api_display.hpp"
 #include <com_ptr.hpp>
 
 #include <cmath>
@@ -310,8 +310,8 @@ namespace sk_hdr_png
     };
   };
 
-  bool         write_image_to_disk          (const wchar_t* image_path, unsigned int width, unsigned int height, const void*  pixels,          int quantization_bits, format fmt, bool use_clipboard);//, reshade::api::display* display);
-  bool         write_hdr_chunks             (const wchar_t* image_path, unsigned int width, unsigned int height, const float* luminance_array, int quantization_bits);//,                                 reshade::api::display* display);
+  bool         write_image_to_disk          (const wchar_t* image_path, unsigned int width, unsigned int height, const void*  pixels,          int quantization_bits, format fmt, bool use_clipboard, reshade::api::display* display);
+  bool         write_hdr_chunks             (const wchar_t* image_path, unsigned int width, unsigned int height, const float* luminance_array, int quantization_bits,                                 reshade::api::display* display);
   cLLi_Payload calculate_content_light_info (const float*   luminance,  unsigned int width, unsigned int height);
   bool         copy_to_clipboard            (const wchar_t* image_path);
   bool         remove_chunk                 (const char*    chunk_name, void* data, size_t& size);
@@ -586,7 +586,7 @@ sk_hdr_png::remove_chunk (const char* chunk_name, void* data, size_t& size)
 }
 
 bool
-sk_hdr_png::write_hdr_chunks (const wchar_t* image_path, unsigned int width, unsigned int height, const float* luminance, int quantization_bits)//, reshade::api::display* display)
+sk_hdr_png::write_hdr_chunks (const wchar_t* image_path, unsigned int width, unsigned int height, const float* luminance, int quantization_bits, reshade::api::display* display)
 {
 	if (image_path == nullptr || width == 0 || height == 0 || quantization_bits < 6)
 	{
@@ -706,7 +706,6 @@ sk_hdr_png::write_hdr_chunks (const wchar_t* image_path, unsigned int width, uns
 		sbit_chunk.write(fPNG);
 		chrm_chunk.write(fPNG);
 
-#if 0
 		///
 		/// Mastering metadata can be added, provided you are able to read this info
 		/// from the user's EDID.
@@ -744,7 +743,6 @@ sk_hdr_png::write_hdr_chunks (const wchar_t* image_path, unsigned int width, uns
 			Chunk mdcv_chunk = {sizeof(mdcv_data),    {'m','D','C','v'}, &mdcv_data};
 			mdcv_chunk.write(fPNG);
 		}
-#endif
 
 		// Write the remainder of the original file
 		fwrite(insert_ptr, size - insert_pos, 1, fPNG);
@@ -814,7 +812,7 @@ sk_hdr_png::copy_to_clipboard (const wchar_t* image_path)
 }
 
 bool
-sk_hdr_png::write_image_to_disk (const wchar_t* image_path, unsigned int width, unsigned int height, const void* pixels, int quantization_bits, format fmt, bool use_clipboard)//, reshade::api::display* display)
+sk_hdr_png::write_image_to_disk (const wchar_t* image_path, unsigned int width, unsigned int height, const void* pixels, int quantization_bits, format fmt, bool use_clipboard, reshade::api::display* display)
 {
 	using namespace DirectX;
 	using namespace DirectX::PackedVector;
@@ -988,7 +986,7 @@ sk_hdr_png::write_image_to_disk (const wchar_t* image_path, unsigned int width, 
 	if (SUCCEEDED(hr)) hr = encoder->Commit();
 	if (SUCCEEDED(hr))
 	{
-		hr = write_hdr_chunks(image_path, width, height, luminance, quantization_bits/*, display*/) ? S_OK : E_FAIL;
+		hr = write_hdr_chunks(image_path, width, height, luminance, quantization_bits, display) ? S_OK : E_FAIL;
 
 		if (SUCCEEDED(hr))
 		{

--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -31,6 +31,8 @@ namespace reshade { namespace api
 	/// </remarks>
 	RESHADE_DEFINE_HANDLE(effect_uniform_variable);
 
+	struct display;
+
 	/// <summary>
 	/// Input source for events triggered by user input.
 	/// </summary>
@@ -806,5 +808,10 @@ namespace reshade { namespace api
 		/// </summary>
 		/// <param name="effect_name">File name of the effect file that should be reloaded.</param>
 		virtual void reload_effect_next_frame(const char *effect_name) = 0;
+
+		/// <summary>
+		/// Gets the active display, which may change between frames or return nullptr if the swapchain is offscreen.
+		/// </summary>
+		virtual display* get_active_display() const = 0;
 	};
 } }

--- a/include/reshade_api_device.hpp
+++ b/include/reshade_api_device.hpp
@@ -250,6 +250,7 @@ namespace reshade { namespace api
 		/// For <see cref="command_list"/> this will be a pointer to a 'ID3D11DeviceContext' (when recording), 'ID3D11CommandList' (when executing) or 'ID3D12GraphicsCommandList' object or a 'VkCommandBuffer' handle.<br/>
 		/// For <see cref="command_queue"/> this will be a pointer to a 'ID3D11DeviceContext' or 'ID3D12CommandQueue' object or a 'VkQueue' handle.<br/>
 		/// For <see cref="swapchain"/> this will be a pointer to a 'IDirect3DSwapChain9' or 'IDXGISwapChain' object or a 'HDC' or 'VkSwapchainKHR' handle.
+		/// For <see cref="display"/> this will be a pointer to a 'IDXGIOutput'; DXGI is used even for runtimes that do not have a DXGI-based swapchain.
 		/// </remarks>
 		virtual uint64_t get_native() const = 0;
 

--- a/include/reshade_api_display.hpp
+++ b/include/reshade_api_display.hpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2024 Patrick Mours
+ * SPDX-License-Identifier: BSD-3-Clause OR MIT
+ */
+
+#pragma once
+
+#include "reshade_api_device.hpp"
+#include <unordered_map>
+#include <memory>
+
+namespace reshade { namespace api
+{
+	/// <summary>
+	/// Describes quantities defined precisely as the ratio of two integers, such as refresh rates.
+	/// </summary>
+	struct rational
+	{
+		uint32_t numerator = 0;
+		uint32_t denomenator = 0;
+
+		constexpr float as_float() const { return denomenator != 0 ? static_cast <float>(numerator)/static_cast<float>(denomenator) : 0.0f; }
+	};
+
+	/// <summary>
+	/// Describes the colorimetry of a colorspace.
+	/// </summary>
+	struct colorimetry
+	{
+		float red [2] = { 0.0f, 0.0f };
+		float green [2] = { 0.0f, 0.0f };
+		float blue [2] = { 0.0f, 0.0f };
+		float white [2] = { 0.0f, 0.0f };
+	};
+
+	/// <summary>
+	/// Describes the dynamic range of a display or image.
+	/// </summary>
+	struct luminance_levels
+	{
+		float min_nits = 0.0f;
+		float max_nits = 0.0f;
+		float max_avg_nits = 0.0f;
+	};
+
+	/// <summary>
+	/// An output display.
+	/// <para>Functionally equivalent to a 'IDXGIOutput'.</para>
+	/// </summary>
+	struct __declspec(novtable) display : public api_object
+	{
+		/// <summary>
+		/// Indicates if cached properties are valid or potentially stale (i.e. refresh rate or resolution have changed).
+		/// </summary>
+		/// <remarks>
+		/// If this returns false, wait one frame and call runtime::get_active_display() to get updated data.
+		/// </remarks>
+		virtual bool is_current() const = 0;
+
+		using monitor = void*;
+
+		/// <summary>
+		/// Gets the handle of the monitor this display encapsulates.
+		/// </summary>
+		virtual monitor get_monitor() const = 0;
+
+		/// <summary>
+		/// Gets the (GDI) device name (i.e. \\DISPLAY1) of the the monitor; do not use this as a persistent display identifier!
+		/// </summary>
+		/// <remarks>
+		/// This device name is not valid as a persistent display identifier for storage in configuration files, it may not refer to the same display device after a reboot.
+		/// </remarks>
+		virtual const wchar_t* get_device_name() const = 0;
+
+		/// <summary>
+		/// Gets the device path (i.e. \\?\DISPLAY#DELA1E4#5&d93f871&0&UID33025#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}) of the the monitor.
+		/// </summary>
+		/// <remarks>
+		/// The device path uniquely identifies a specific monitor (down to its serial number and the port it is attached to) and remains valid across system reboots.
+		/// This identifier is suitable for persistent user-defined display configuration, partial name matches can be used to identify instances of the same monitor when the port it attaches to is unimportant.
+		/// </remarks>
+		virtual const wchar_t* get_device_path() const = 0;
+
+		/// <summary>
+		/// Gets the human readable name (i.e. Dell AW3423DW) of the the monitor.
+		/// </summary>
+		virtual const wchar_t* get_display_name() const = 0;
+
+		/// <summary>
+		/// Gets the size and location of the display on the desktop.
+		/// </summary>
+		virtual rect get_desktop_coords() const = 0;
+
+		/// <summary>
+		/// Gets the current color depth of the display.
+		/// </summary>
+		virtual uint32_t get_color_depth() const = 0;
+
+		/// <summary>
+		/// Gets the current refresh rate of the display.
+		/// </summary>
+		virtual rational get_refresh_rate() const = 0;
+
+		/// <summary>
+		/// Gets the current color space used for desktop composition.
+		/// </summary>
+		/// <remarks>
+		/// This is independent from swap chain colorspace, it identifies a display as HDR capable even when not rendering in HDR.
+		/// </remarks>
+		virtual color_space get_color_space() const = 0;
+
+		/// <summary>
+		/// Gets the display's reported native colorimetry (the data provided are often invalid or placeholders).
+		/// </summary>
+		/// <remarks>
+		/// Users running Windows 11 or newer are encouraged to run "Windows HDR Calibration" to ensure the values reported to ReShade and games are accurate.
+		/// </remarks>
+		virtual colorimetry get_colorimetry() const = 0;
+
+		/// <summary>
+		/// Gets the display's light output capabilities (the data provided are often invalid or placeholders).
+		/// </summary>
+		/// <remarks>
+		/// Users running Windows 11 or newer are encouraged to run "Windows HDR Calibration" to ensure the values reported to ReShade and games are accurate.
+		/// </remarks>
+		virtual luminance_levels get_luminance_caps() const = 0;
+
+		/// <summary>
+		/// Gets the desktop compositor's whitelevel for mapping SDR content to HDR.
+		/// </summary>
+		virtual float get_sdr_white_nits() const = 0;
+
+		/// <summary>
+		/// Checks if HDR is supported on the display, even if it is not currently enabled.
+		/// </summary>
+		virtual bool is_hdr_supported() const = 0;
+
+		/// <summary>
+		/// Checks if HDR is enabled on the display.
+		/// </summary>
+		virtual bool is_hdr_enabled() const = 0;
+
+		/// <summary>
+		/// Enables HDR on the display.
+		/// </summary>
+		/// <remarks>
+		/// Be aware that this is a global display setting, and will not automatically revert to its original state when the application exits.
+		/// </remarks>
+		virtual bool enable_hdr(bool enable) = 0;
+	};
+
+	using display_cache = std::unordered_map<display::monitor, std::unique_ptr<display>>;
+} }

--- a/include/reshade_events.hpp
+++ b/include/reshade_events.hpp
@@ -1705,8 +1705,14 @@ namespace reshade
 		/// </remarks>
 		reshade_overlay_technique,
 
+		/// <summary>
+		/// Called when the active display changes for a runtime.
+		/// <para>Callback function signature: <c>void (api::effect_runtime *runtime, api::display *display)</c></para>
+		/// </summary>
+		display_change = 95,
+
 #if RESHADE_ADDON
-		max = 95 // Last value used internally by ReShade to determine number of events in this enum
+		max = 96 // Last value used internally by ReShade to determine number of events in this enum
 #endif
 	};
 
@@ -1848,4 +1854,6 @@ namespace reshade
 
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_overlay_uniform_variable, bool, api::effect_runtime *runtime, api::effect_uniform_variable variable);
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_overlay_technique, bool, api::effect_runtime *runtime, api::effect_technique technique);
+
+	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::display_change, void, api::effect_runtime *runtime, api::display *display);
 }

--- a/source/dxgi/dxgi_impl_display.cpp
+++ b/source/dxgi/dxgi_impl_display.cpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2024 Patrick Mours
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "dxgi_impl_display.hpp"
+
+reshade::dxgi::display_impl::display_impl(IDXGIOutput6 *output, DISPLAYCONFIG_PATH_TARGET_INFO *target) :
+	api_object_impl(output)
+{
+	assert(output != nullptr && target != nullptr);
+
+	if (output == nullptr || target == nullptr)
+		return;
+
+	_target_info = *target;
+
+	com_ptr<IDXGIAdapter> adapter;
+	com_ptr<IDXGIFactory> factory;
+
+	if (SUCCEEDED(output->GetParent(IID_IDXGIAdapter,reinterpret_cast<void**>(&adapter))) &&
+		SUCCEEDED(adapter->GetParent(IID_IDXGIFactory,reinterpret_cast<void**>(&factory))))
+	{
+		factory->QueryInterface<IDXGIFactory1>(&_parent);
+	}
+
+	_output = output;
+	output->GetDesc1(&_desc);
+
+	_refresh_rate = {
+		_target_info.refreshRate.Numerator,
+		_target_info.refreshRate.Denominator
+	};
+
+	DISPLAYCONFIG_TARGET_DEVICE_NAME
+	target_name                  = {};
+	target_name.header.adapterId = _target_info.adapterId;
+	target_name.header.id        = _target_info.id;
+	target_name.header.type      = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+	target_name.header.size      = sizeof  (DISPLAYCONFIG_TARGET_DEVICE_NAME);
+
+	if (ERROR_SUCCESS == DisplayConfigGetDeviceInfo(&target_name.header))
+	{
+		_name = target_name.monitorFriendlyDeviceName;
+		_path = target_name.monitorDevicePath;
+	}
+
+	DISPLAYCONFIG_SDR_WHITE_LEVEL
+	sdr_white_level                  = {};
+	sdr_white_level.header.adapterId = _target_info.adapterId;
+	sdr_white_level.header.id        = _target_info.id;
+	sdr_white_level.header.type      = DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL;
+	sdr_white_level.header.size      = sizeof         (DISPLAYCONFIG_SDR_WHITE_LEVEL);
+
+	if (ERROR_SUCCESS == DisplayConfigGetDeviceInfo(&sdr_white_level.header))
+	{
+		_sdr_nits = (static_cast<float>(sdr_white_level.SDRWhiteLevel) / 1000.0f) * 80.0f;
+	}
+
+#if (NTDDI_VERSION >= NTDDI_WIN11_GA)
+	// Prefer this API if the build environment and current OS support it, it can distinguish WCG from HDR
+	DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_2
+	get_color_info2                  = {};
+	get_color_info2.header.type      = DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO_2;
+	get_color_info2.header.size      = sizeof     (DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_2);
+	get_color_info2.header.adapterId = _target_info.adapterId;
+	get_color_info2.header.id        = _target_info.id;
+
+	if (ERROR_SUCCESS == DisplayConfigGetDeviceInfo(&get_color_info2.header))
+	{
+		_hdr_supported = get_color_info2.highDynamicRangeSupported && !get_color_info2.advancedColorLimitedByPolicy;
+		_hdr_enabled   = get_color_info2.advancedColorActive && get_color_info2.highDynamicRangeUserEnabled && get_color_info2.activeColorMode == DISPLAYCONFIG_ADVANCED_COLOR_MODE_HDR;
+	}
+
+	else
+#endif
+	{
+		DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO
+		get_color_info                  = {};
+		get_color_info.header.type      = DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO;
+		get_color_info.header.size      = sizeof     (DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO);
+		get_color_info.header.adapterId = _target_info.adapterId;
+		get_color_info.header.id        = _target_info.id;
+
+		if (ERROR_SUCCESS == DisplayConfigGetDeviceInfo(&get_color_info.header))
+		{
+			_hdr_supported = get_color_info.advancedColorSupported;
+			_hdr_enabled   = get_color_info.advancedColorEnabled;
+		}
+	}
+};
+
+const wchar_t* reshade::dxgi::display_impl::get_device_name() const
+{
+	return _desc.DeviceName;
+};
+
+const wchar_t* reshade::dxgi::display_impl::get_device_path() const
+{
+	return _path.c_str();
+};
+
+const wchar_t* reshade::dxgi::display_impl::get_display_name() const
+{
+	return _name.c_str();
+};
+
+reshade::api::display::monitor reshade::dxgi::display_impl::get_monitor() const
+{
+	return _desc.Monitor;
+};
+
+reshade::api::rect reshade::dxgi::display_impl::get_desktop_coords() const
+{
+	return { _desc.DesktopCoordinates.left,  _desc.DesktopCoordinates.top,
+			 _desc.DesktopCoordinates.right, _desc.DesktopCoordinates.bottom };
+};
+
+uint32_t reshade::dxgi::display_impl::get_color_depth() const
+{
+	return _desc.BitsPerColor;
+};
+
+reshade::api::rational reshade::dxgi::display_impl::get_refresh_rate() const
+{
+	return _refresh_rate;
+};
+
+reshade::api::color_space reshade::dxgi::display_impl::get_color_space() const
+{
+	switch (_desc.ColorSpace)
+	{
+	case DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709:
+		return api::color_space::srgb_nonlinear;
+	case DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709:
+		return api::color_space::extended_srgb_linear;
+	case DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020:
+		return api::color_space::hdr10_st2084;
+	case DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P2020:
+		return api::color_space::hdr10_hlg;
+	default:
+		return api::color_space::unknown;
+	}
+};
+
+reshade::api::colorimetry reshade::dxgi::display_impl::get_colorimetry() const
+{
+	return api::colorimetry {
+		_desc.RedPrimary[0], _desc.RedPrimary[1],
+		_desc.GreenPrimary[0], _desc.GreenPrimary[1],
+		_desc.BluePrimary[0], _desc.BluePrimary[1],
+		_desc.WhitePoint[0], _desc.WhitePoint[1]
+	};
+};
+
+reshade::api::luminance_levels reshade::dxgi::display_impl::get_luminance_caps() const
+{
+	return api::luminance_levels {
+		_desc.MinLuminance,
+		_desc.MaxLuminance,
+		_desc.MaxFullFrameLuminance
+	};
+};
+
+float reshade::dxgi::display_impl::get_sdr_white_nits() const
+{
+	return _sdr_nits;
+}
+
+bool reshade::dxgi::display_impl::is_current() const
+{
+	return _parent->IsCurrent();
+}
+
+bool reshade::dxgi::display_impl::is_hdr_supported() const
+{
+	return _hdr_supported;
+}
+
+bool reshade::dxgi::display_impl::is_hdr_enabled() const
+{
+	return _hdr_enabled;
+}
+
+bool reshade::dxgi::display_impl::enable_hdr(bool enable)
+{
+	if (!_hdr_supported)
+		return false;
+
+#if (NTDDI_VERSION >= NTDDI_WIN11_GA)
+	// Prefer this API if the build environment and current OS support it, it can distinguish WCG from HDR
+	DISPLAYCONFIG_SET_HDR_STATE
+	set_hdr_state                  = {};
+	set_hdr_state.header.type      = DISPLAYCONFIG_DEVICE_INFO_SET_HDR_STATE;
+	set_hdr_state.header.size      = sizeof     (DISPLAYCONFIG_SET_HDR_STATE);
+	set_hdr_state.header.adapterId = _target_info.adapterId;
+	set_hdr_state.header.id        = _target_info.id;
+
+	set_hdr_state.enableHdr = enable;
+
+	if (ERROR_SUCCESS == DisplayConfigSetDeviceInfo(&set_hdr_state.header))
+	{
+		_hdr_enabled = set_hdr_state.enableHdr;
+		return true;
+	}
+
+	else
+#endif
+	{
+		DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE
+		set_advanced_color_state                  = {};
+		set_advanced_color_state.header.type      = DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE;
+		set_advanced_color_state.header.size      = sizeof     (DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE);
+		set_advanced_color_state.header.adapterId = _target_info.adapterId;
+		set_advanced_color_state.header.id        = _target_info.id;
+
+		set_advanced_color_state.enableAdvancedColor = enable;
+
+		if (ERROR_SUCCESS == DisplayConfigSetDeviceInfo(&set_advanced_color_state.header))
+		{
+			_hdr_enabled = set_advanced_color_state.enableAdvancedColor;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void reshade::dxgi::display_impl::flush_cache(reshade::api::display_cache& displays)
+{
+	// Detect spurious cache flushes to eliminate sending false display change events to add-ons.
+	bool flush_required = displays.empty();
+	if (!flush_required)
+	{
+		for (const auto &display : displays)
+			if (flush_required = !display.second->is_current())
+				break;
+
+		// If nothing has actually changed, then we are done here...
+		if (!flush_required)
+			return;
+	}
+
+	displays.clear();
+
+	std::vector<DISPLAYCONFIG_PATH_INFO> paths;
+	std::vector<DISPLAYCONFIG_MODE_INFO> modes;
+	UINT32 flags = QDC_ONLY_ACTIVE_PATHS | QDC_VIRTUAL_MODE_AWARE | QDC_VIRTUAL_REFRESH_RATE_AWARE;
+	LONG result = ERROR_SUCCESS;
+
+	do
+	{
+		UINT32 pathCount, modeCount;
+		if (GetDisplayConfigBufferSizes(flags, &pathCount, &modeCount) != ERROR_SUCCESS)
+			break;
+
+		paths.resize(pathCount);
+		modes.resize(modeCount);
+
+		result = QueryDisplayConfig(flags, &pathCount, paths.data(), &modeCount, modes.data(), nullptr);
+
+		paths.resize(pathCount);
+		modes.resize(modeCount);
+	} while (result == ERROR_INSUFFICIENT_BUFFER);
+
+	const auto CreateDXGIFactory1 = reinterpret_cast<HRESULT(WINAPI *)(REFIID riid, void **ppFactory)>(
+	GetProcAddress(GetModuleHandleW(L"dxgi.dll"), "CreateDXGIFactory1"));
+
+	if (CreateDXGIFactory1 == nullptr)
+		return;
+
+	com_ptr<IDXGIFactory> factory;
+	CreateDXGIFactory1(IID_IDXGIFactory, reinterpret_cast<void**>(&factory));
+
+	if (factory != nullptr)
+	{
+		com_ptr<IDXGIAdapter> adapter;
+		UINT adapter_idx = 0;
+		while (SUCCEEDED(factory->EnumAdapters(adapter_idx++, &adapter)))
+		{
+			com_ptr<IDXGIOutput> output;
+			UINT output_idx = 0;
+			while (SUCCEEDED(adapter->EnumOutputs(output_idx++, &output)))
+			{
+				com_ptr<IDXGIOutput6> output6;
+				if (SUCCEEDED(output->QueryInterface<IDXGIOutput6>(&output6)))
+				{
+					DXGI_OUTPUT_DESC1 desc = {};
+					output6->GetDesc1(&desc);
+
+					for (auto &path : paths)
+					{
+						DISPLAYCONFIG_SOURCE_DEVICE_NAME
+						source_name                  = {};
+						source_name.header.adapterId = path.sourceInfo.adapterId;
+						source_name.header.id        = path.sourceInfo.id;
+						source_name.header.type      = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+						source_name.header.size      = sizeof  (DISPLAYCONFIG_SOURCE_DEVICE_NAME);
+
+						if (DisplayConfigGetDeviceInfo(&source_name.header) != ERROR_SUCCESS)
+							continue;
+
+						if (_wcsicmp(desc.DeviceName, source_name.viewGdiDeviceName))
+							continue;
+
+						displays.emplace(desc.Monitor,
+							std::make_unique<reshade::dxgi::display_impl>(output6.get(),&path.targetInfo));
+
+						break;
+					}
+				}
+				output.reset();
+			}
+			adapter.reset();
+		}
+	}
+}

--- a/source/dxgi/dxgi_impl_display.hpp
+++ b/source/dxgi/dxgi_impl_display.hpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2024 Patrick Mours
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+
+#include <dxgi1_6.h>
+#include <xstring>
+#include "com_ptr.hpp"
+#include "reshade_api_object_impl.hpp"
+#include "reshade_api_display.hpp"
+
+namespace reshade::dxgi
+{
+	class display_impl : public api::api_object_impl<IDXGIOutput6 *, api::display>
+	{
+	public:
+		explicit display_impl(IDXGIOutput6 *output, DISPLAYCONFIG_PATH_TARGET_INFO *target);
+
+		/// <summary>
+		/// Indicates if cached properties are valid or potentially stale (i.e. refresh rate or resolution have changed).
+		/// </summary>
+		/// <remarks>
+		/// If this returns false, wait one frame and call runtime::get_active_display() to get updated data.
+		/// </remarks>
+		virtual bool is_current() const final;
+
+		/// <summary>
+		/// Gets the handle of the monitor this display encapsulates.
+		/// </summary>
+		virtual monitor get_monitor() const final;
+
+		/// <summary>
+		/// Gets the (GDI) device name (i.e. \\DISPLAY1) of the the monitor; do not use this as a persistent display identifier!
+		/// </summary>
+		/// <remarks>
+		/// This device name is not valid as a persistent display identifier for storage in configuration files, it may not refer to the same display device after a reboot.
+		/// </remarks>
+		virtual const wchar_t* get_device_name() const final;
+
+		/// <summary>
+		/// Gets the device path (i.e. \\?\DISPLAY#DELA1E4#5&d93f871&0&UID33025#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}) of the the monitor.
+		/// </summary>
+		/// <remarks>
+		/// The device path uniquely identifies a specific monitor (down to its serial number and the port it is attached to) and remains valid across system reboots.
+		/// This identifier is suitable for persistent user-defined display configuration, partial name matches can be used to identify instances of the same monitor when the port it attaches to is unimportant.
+		/// </remarks>
+		virtual const wchar_t* get_device_path() const final;
+
+		/// <summary>
+		/// Gets the human readable name (i.e. Dell AW3423DW) of the the monitor.
+		/// </summary>
+		virtual const wchar_t* get_display_name() const final;
+
+		/// <summary>
+		/// Gets the size and location of the display on the desktop.
+		/// </summary>
+		virtual api::rect get_desktop_coords() const final;
+
+		/// <summary>
+		/// Gets the current color depth of the display.
+		/// </summary>
+		virtual uint32_t get_color_depth() const final;
+
+		/// <summary>
+		/// Gets the current refresh rate of the display.
+		/// </summary>
+		virtual api::rational get_refresh_rate() const final;
+
+		/// <summary>
+		/// Gets the current color space used for desktop composition.
+		/// </summary>
+		/// <remarks>
+		/// This is independent from swap chain colorspace, it identifies a display as HDR capable even when not rendering in HDR.
+		/// </remarks>
+		virtual api::color_space get_color_space() const final;
+
+		/// <summary>
+		/// Gets the display's reported native colorimetry (the data provided are often invalid or placeholders).
+		/// </summary>
+		/// <remarks>
+		/// Users running Windows 11 or newer are encouraged to run "Windows HDR Calibration" to ensure the values reported to ReShade and games are accurate.
+		/// </remarks>
+		virtual api::colorimetry get_colorimetry() const final;
+
+		/// <summary>
+		/// Gets the display's light output capabilities (the data provided are often invalid or placeholders).
+		/// </summary>
+		/// <remarks>
+		/// Users running Windows 11 or newer are encouraged to run "Windows HDR Calibration" to ensure the values reported to ReShade and games are accurate.
+		/// </remarks>
+		virtual api::luminance_levels get_luminance_caps() const final;
+
+		/// <summary>
+		/// Gets the desktop compositor's whitelevel for mapping SDR content to HDR.
+		/// </summary>
+		virtual float get_sdr_white_nits() const final;
+
+		/// <summary>
+		/// Checks if HDR is supported on the display, even if it is not currently enabled.
+		/// </summary>
+		virtual bool is_hdr_supported() const final;
+
+		/// <summary>
+		/// Checks if HDR is enabled on the display.
+		/// </summary>
+		virtual bool is_hdr_enabled() const final;
+
+		/// <summary>
+		/// Enables HDR on the display.
+		/// </summary>
+		/// <remarks>
+		/// Be aware that this is a global display setting, and will not revert to its original state when the application exits.
+		/// </remarks>
+		virtual bool enable_hdr(bool enable) final;
+
+		static void flush_cache(reshade::api::display_cache& displays);
+
+	protected:
+		DISPLAYCONFIG_PATH_TARGET_INFO _target_info = {};
+		com_ptr<IDXGIFactory1> _parent;
+		com_ptr<IDXGIOutput6> _output;
+		DXGI_OUTPUT_DESC1 _desc;
+		std::wstring _name = L"";
+		std::wstring _path = L"";
+		bool _hdr_supported = false;
+		bool _hdr_enabled = false;
+		float _sdr_nits = 0.0f;
+		api::rational _refresh_rate = {0};
+	};
+};

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -35,7 +35,7 @@
 #include <stb_image_resize2.h>
 #include <d3dcompiler.h>
 #include <dxgi/dxgi_impl_display.hpp>
-#include <../deps/sk_hdr_png/include/sk_hdr_png.hpp> // Something broke and now it has to be included this way
+#include <sk_hdr_png.hpp>
 
 bool resolve_path(std::filesystem::path &path, std::error_code &ec)
 {

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "reshade_api.hpp"
+#include "reshade_api_display.hpp"
 #include "state_block.hpp"
 #include "imgui_code_editor.hpp"
 #include <chrono>
@@ -36,6 +37,7 @@ namespace reshade
 		bool on_init();
 		void on_reset();
 		void on_present(api::command_queue *present_queue);
+		void on_display_change();
 
 		uint64_t get_native() const final { return _swapchain->get_native(); }
 
@@ -170,6 +172,8 @@ namespace reshade
 
 		void reload_effect_next_frame(const char *effect_name) final;
 
+		api::display* get_active_display() const final { return _containing_output; }
+
 	private:
 		static void check_for_update();
 
@@ -252,6 +256,11 @@ namespace reshade
 		uint16_t _back_buffer_samples = 1;
 		api::format _back_buffer_format = api::format::unknown;
 		api::color_space _back_buffer_color_space = api::color_space::unknown;
+		api::display* _containing_output = nullptr; // The display that currently owns the swapchain
+		api::display_cache _displays; // Cached mapping of all monitors attached to the desktop and their display properties
+		std::atomic_uint32_t _last_desktop_change = 0; // Invalidate the display cache when necessary
+		int _last_desktop_x = 0;
+		int _last_desktop_y = 0;
 		bool _is_vr = false;
 
 #if RESHADE_ADDON


### PR DESCRIPTION
In order to finish HDR PNG screenshot integration, the capabilities of the display the image is captured on are required.

Thus, I have added `reshade::api::display` as a new api object to encapsulate display devices (its current implementation has a backing `IDXGIOutput` that exposes most of its functionality) and an event for AddOns to subscribe to so that they can be notified when display settings change or when the SwapChain's window moves to a different display.

Display Change is detected by checking the position of the SwapChain's window each frame for movement, and checking the associated monitor for the HWND on any frame where the window moves.

There is a broader indication of display change, sent to all top-level windows in the form of `WM_DISPLAYCHANGE`. It does not indicate which display has changed, but it is a signal that at least one display on the desktop has changed and any cached display data should be invalidated.

 * I handled `WM_DISPLAYCHANGE` from **input.cpp** since it is the only code in ReShade that is actually processing Window Messages, I hope that is not a problem.