### PR TITLE
Fix reset buttons of preprocessors

### DIFF
--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -4006,7 +4006,8 @@ void reshade::runtime::draw_variable_editor()
 					if (definition_scope == &effect_definitions)
 					{
 						ImGui::SameLine();
-						if (ImGui::SmallButton(ICON_FK_UNDO))
+						const std::string definition_undo_label = ICON_FK_UNDO"##" + definition_it->first;
+						if (ImGui::SmallButton(definition_undo_label.c_str()))
 						{
 							force_reload_effect = true;
 							definition_scope->erase(definition_it);


### PR DESCRIPTION
The labels were not unique before, so sometimes the button did not really reset the content, and the keyboard navigation was also buggy.