### PR TITLE
Don't fire addon events for swap chains that do not have effect runtimes

### DIFF
--- a/source/d3d9/d3d9_swapchain.cpp
+++ b/source/d3d9/d3d9_swapchain.cpp
@@ -207,13 +207,15 @@ void Direct3DSwapChain9::on_reset(bool resize)
 	if (!_is_initialized)
 		return;
 
-	reshade::reset_effect_runtime(this);
+	if (reshade::reset_effect_runtime(this))
+	{
 
 #if RESHADE_ADDON
-	reshade::invoke_addon_event<reshade::addon_event::destroy_swapchain>(this, resize);
+		reshade::invoke_addon_event<reshade::addon_event::destroy_swapchain>(this, resize);
 #else
-	UNREFERENCED_PARAMETER(resize);
+		UNREFERENCED_PARAMETER(resize);
 #endif
+	}
 
 	_back_buffer.reset();
 

--- a/source/runtime_manager.hpp
+++ b/source/runtime_manager.hpp
@@ -9,10 +9,10 @@
 
 namespace reshade
 {
-	void create_effect_runtime(api::swapchain *swapchain, api::command_queue *graphics_queue, bool is_vr = false);
-	void destroy_effect_runtime(api::swapchain *swapchain);
+	bool create_effect_runtime(api::swapchain *swapchain, api::command_queue *graphics_queue, bool is_vr = false);
+	bool destroy_effect_runtime(api::swapchain *swapchain);
 
-	void init_effect_runtime(api::swapchain *swapchain);
-	void reset_effect_runtime(api::swapchain *swapchain);
-	void present_effect_runtime(api::swapchain *swapchain, api::command_queue *present_queue);
+	bool init_effect_runtime(api::swapchain *swapchain);
+	bool reset_effect_runtime(api::swapchain *swapchain);
+	bool present_effect_runtime(api::swapchain *swapchain, api::command_queue *present_queue);
 }


### PR DESCRIPTION
This change is a bit spooky, its primary goal is to fix a crash in the [ReshadeEffectShaderToggler](https://github.com/4lex4nder/ReshadeEffectShaderToggler) addon caused by multiple windows.

What I've done is suppressed the addon events `init_swapchain` `present` `destroy_swapchain` and  `execute_command_list` for any swapchains that do not have an effect runtime, by returning a bool from the runtime_manager when its updated.

However, a possibly significant change is that the addon events now trigger _after_ the runtime_manager and I'm not sure if that will have and significant issues. I wasn't able to notice anything misbehaving in my somewhat limited testing.

If this is too scary of a change then we can discard it here and I'll try solve the crash in the addon code instead.

