### PR TITLE
get_is_loading api

### DIFF
--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -812,5 +812,11 @@ namespace reshade { namespace api
 		/// </summary>
 		/// <param name="path">File path to the preset to save to.</param>
 		virtual void export_current_preset(const char *path) const = 0;
+
+		/// <summary>
+		/// Gets a boolean indicating whether effects are being loaded.
+		/// </summary>
+		/// <returns><see langword="true"/> if the the effect runtime is loading effects, <see langword="false"/> otherwise.</returns>
+		virtual bool get_is_loading() const = 0;
 	};
 } }

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -171,6 +171,8 @@ namespace reshade
 
 		void reload_effect_next_frame(const char *effect_name) final;
 
+		bool get_is_loading() const final;
+
 	private:
 		static void check_for_update();
 

--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -1559,3 +1559,8 @@ void reshade::runtime::reload_effect_next_frame(const char *effect_name)
 			_reload_required_effects.emplace_back(effect_index, 0u);
 	}
 }
+
+bool reshade::runtime::get_is_loading() const
+{
+	return is_loading();
+}


### PR DESCRIPTION
this is a simple change that introduces a `get_is_loading()` api to the effect runtime that add-ons can use to query the loading state:
```
static void on_present(effect_runtime* runtime)
{
	s_isLoading = runtime->get_is_loading();
}
```

I'm unsure if the API level needs to be incremented for this?