### PR TITLE
Improve support for non-MSVC compilers in addon API

### DIFF
--- a/include/reshade.hpp
+++ b/include/reshade.hpp
@@ -177,7 +177,7 @@ namespace reshade
 		return func(internal::get_current_module_handle(), runtime, section, key, value, value_size);
 #endif
 	}
-#if _HAS_CXX17
+#if _HAS_CXX17 || __cplusplus >= 201703L
 	template <typename T>
 	inline bool get_config_value(api::effect_runtime *runtime, const char *section, const char *key, T &value)
 	{
@@ -215,7 +215,7 @@ namespace reshade
 		func(internal::get_current_module_handle(), runtime, section, key, value);
 #endif
 	}
-#if _HAS_CXX17
+#if _HAS_CXX17 || __cplusplus >= 201703L
 	template <typename T>
 	inline void set_config_value(api::effect_runtime *runtime, const char *section, const char *key, const T &value)
 	{
@@ -313,7 +313,7 @@ namespace reshade
 		static const auto func = reinterpret_cast<void(*)(addon_event, void *)>(
 			GetProcAddress(internal::get_reshade_module_handle(), "ReShadeRegisterEvent"));
 		if (func != nullptr)
-			func(ev, static_cast<void *>(callback));
+			func(ev, reinterpret_cast<void *>(callback));
 #endif
 	}
 	/// <summary>
@@ -330,7 +330,7 @@ namespace reshade
 		static const auto func = reinterpret_cast<void(*)(addon_event, void *)>(
 			GetProcAddress(internal::get_reshade_module_handle(), "ReShadeUnregisterEvent"));
 		if (func != nullptr)
-			func(ev, static_cast<void *>(callback));
+			func(ev, reinterpret_cast<void *>(callback));
 #endif
 	}
 


### PR DESCRIPTION
- The `_HAS_CXX17` macro is undocumented and specific to MSVC - other compilers do not declare it. Using `__cplusplus` by itself is [also insufficient](https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/) depending on compiler options. This means both checks are required :(
- `static_cast`ing a function pointer to `void *` is conditionally supported. MSVC allows it. Clang does not.