### PR TITLE
Fix D3D12 Static Sampler Border Colors Conversion

### DIFF
--- a/source/d3d12/d3d12_impl_type_convert.cpp
+++ b/source/d3d12/d3d12_impl_type_convert.cpp
@@ -331,14 +331,14 @@ reshade::api::sampler_desc reshade::d3d12::convert_sampler_desc(const D3D12_STAT
 	switch (internal_desc.BorderColor)
 	{
 	case D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK:
+		std::fill_n(desc.border_color, 4, 0.0f);
 		break;
 	case D3D12_STATIC_BORDER_COLOR_OPAQUE_BLACK:
 	case D3D12_STATIC_BORDER_COLOR_OPAQUE_BLACK_UINT:
-		desc.border_color[3] = 1.0f;
+		std::fill_n(desc.border_color, 3, 0.0f);
 		break;
 	case D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE:
 	case D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE_UINT:
-		std::fill_n(desc.border_color, 4, 1.0f);
 		break;
 	}
 


### PR DESCRIPTION
`internal_desc.BorderColor` defaults to all 0 values, not 1.0f. Fixes the conversion.