### PR TITLE
Fix height match on depth addon

### DIFF
--- a/examples/09-depth/generic_depth_addon.cpp
+++ b/examples/09-depth/generic_depth_addon.cpp
@@ -359,7 +359,7 @@ static bool check_aspect_ratio(float width_to_check, float height_to_check, floa
 	if (s_aspect_ratio_heuristic == aspect_ratio_heuristic::match_resolution_exactly || (s_aspect_ratio_heuristic == aspect_ratio_heuristic::match_custom_resolution_exactly && s_custom_resolution_filtering[0] == 0 && s_custom_resolution_filtering[1] == 0))
 		return width_to_check == width && height_to_check == height;
 	if (s_aspect_ratio_heuristic == aspect_ratio_heuristic::match_custom_resolution_exactly)
-		return width_to_check == s_custom_resolution_filtering[0] && width_to_check == s_custom_resolution_filtering[1];
+		return width_to_check == s_custom_resolution_filtering[0] && height_to_check == s_custom_resolution_filtering[1];
 
 	float w_ratio = width / width_to_check;
 	float h_ratio = height / height_to_check;


### PR DESCRIPTION
Hello,

Found a tiny little bug when I tried to select a specific depth buffer.

In the depth addon when "Match custom width and height exactly" is selected, the height filter is applied to the width