### PR TITLE
Fixes paths when loading reshade through ASI loader's /plugins, /scripts, and /updates subdirectory

### DIFF
--- a/source/dll_main.cpp
+++ b/source/dll_main.cpp
@@ -142,9 +142,10 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
 			const bool is_dxgi = _wcsicmp(module_name.c_str(), L"dxgi") == 0;
 			const bool is_opengl = _wcsicmp(module_name.c_str(), L"opengl32") == 0;
 			const bool is_dinput = _wcsnicmp(module_name.c_str(), L"dinput", 6) == 0;
+			const bool is_asi = g_reshade_dll_path.extension() == L".asi";
 
 			// UWP apps do not have write access to the application directory, so never default the base path to it for them
-			const bool default_base_to_target_executable_path = !is_d3d && !is_dxgi && !is_opengl && !is_dinput && !is_uwp_app();
+			const bool default_base_to_target_executable_path = !is_d3d && !is_dxgi && !is_opengl && !is_dinput && !is_asi && !is_uwp_app();
 
 			g_reshade_base_path = get_base_path(default_base_to_target_executable_path);
 


### PR DESCRIPTION
Fixes https://reshade.me/forum/troubleshooting/9990-reshade-6-4-1-1965-fails-to-initialize-properly-when-loaded-as-a-asi-file

ASI loader support was only partially working. While ASI loader -could- load reshade.asi fine while it was contained in the same folder as the main executable, asi loader also supports loading .asi files from `/plugins`, `/scripts`, and `/update` subdirectories. 

Reshade was looking for its configuration files in the wrong folder due to `default_base_to_target_executable_path` / the UWP app check missing handling for the .dll being loaded through ASI loader.
https://github.com/crosire/reshade/blob/c5039c0410b5ca57294c9ea28762e540c8df1513/source/dll_main.cpp#L139-L149

Log showing that reshade's now working as intended from the `\plugins` subdirectory:
```
20:22:47:957 [38672] | INFO  | Initializing crosire's ReShade version '0.0.0.2' (64-bit) loaded from 'G:\Steam\steamapps\common\MGS2\plugins\ReShade64.asi' into 'G:\Steam\steamapps\common\MGS2\METAL GEAR SOLID2.exe' (0x29958522) ...
20:22:48:119 [38672] | INFO  | Registering hooks for 'user32.dll' ...
20:22:48:119 [38672] | INFO  | > Libraries loaded.
20:22:48:120 [38672] | INFO  | > Found 21 match(es). Installing ...
20:22:48:264 [38672] | INFO  | Registering hooks for 'C:\WINDOWS\system32\dinput.dll' ...
20:22:48:264 [38672] | INFO  | > Delayed.
20:22:48:264 [38672] | INFO  | Registering hooks for 'C:\WINDOWS\system32\dinput8.dll' ...
20:22:48:265 [38672] | INFO  | > Delayed.
20:22:48:265 [38672] | INFO  | Registering hooks for 'C:\WINDOWS\system32\d2d1.dll' ...
20:22:48:265 [38672] | INFO  | > Delayed.
20:22:48:265 [38672] | INFO  | Registering hooks for 'C:\WINDOWS\system32\d3d9.dll' ...
20:22:48:266 [38672] | INFO  | > Delayed.
20:22:48:266 [38672] | INFO  | Registering hooks for 'C:\WINDOWS\system32\d3d10.dll' ...
20:22:48:266 [38672] | INFO  | > Delayed.
20:22:48:266 [38672] | INFO  | Registering hooks for 'C:\WINDOWS\system32\d3d10_1.dll' ...
20:22:48:267 [38672] | INFO  | > Delayed.
20:22:48:267 [38672] | INFO  | Registering hooks for 'C:\WINDOWS\system32\d3d11.dll' ...
20:22:48:267 [38672] | INFO  | > Libraries loaded.
20:22:48:267 [38672] | INFO  | > Found 3 match(es). Installing ...
20:22:48:409 [38672] | INFO  | Registering hooks for 'C:\WINDOWS\system32\d3d12.dll' ...
20:22:48:409 [38672] | INFO  | > Delayed.
20:22:48:409 [38672] | INFO  | Registering hooks for 'C:\WINDOWS\system32\dxgi.dll' ...
20:22:48:409 [38672] | INFO  | > Libraries loaded.
20:22:48:409 [38672] | INFO  | > Found 5 match(es). Installing ...
20:22:48:549 [38672] | INFO  | Registering hooks for 'C:\WINDOWS\system32\opengl32.dll' ...
20:22:48:549 [38672] | INFO  | > Delayed.
20:22:48:550 [38672] | INFO  | Registering hooks for 'openvr_api.dll' ...
20:22:48:550 [38672] | INFO  | > Delayed.
20:22:48:550 [38672] | INFO  | Initialized.
20:22:48:591 [38672] | INFO  | Redirecting RegisterClassExW(lpWndClassEx = 000000E4BE4FF440 { "SteamWinsockInitFakeClass_1", style = 0 }) ...
20:22:48:751 [38672] | INFO  | Redirecting RegisterClassExA(lpWndClassEx = 000000E4BE4FFC40 { "CSD3DWND", style = 0x40 }) ...
20:22:48:779 [38672] | INFO  | Redirecting CreateDXGIFactory1(riid = {7B7166EC-21C7-44AE-B21A-C9AE321AE369}, ppFactory = 0000028B946E8D50) ...
20:22:48:787 [38672] | INFO  | Redirecting D3D11CreateDevice(pAdapter = 0000028B946F0990, DriverType = 0, Software = 0000000000000000, Flags = 0, pFeatureLevels = 000000E4BE4FFB30, FeatureLevels = 1, SDKVersion = 7, ppDevice = 0000028B946E8D58, pFeatureLevel = 000000E4BE4FFB38, ppImmediateContext = 0000028B946E8D60) ...
20:22:48:787 [38672] | INFO  | > Passing on to D3D11CreateDeviceAndSwapChain:
20:22:48:787 [38672] | INFO  | Redirecting D3D11CreateDeviceAndSwapChain(pAdapter = 0000028B946F0990, DriverType = 0, Software = 0000000000000000, Flags = 0, pFeatureLevels = 000000E4BE4FFB30, FeatureLevels = 1, SDKVersion = 7, pSwapChainDesc = 0000000000000000, ppSwapChain = 0000000000000000, ppDevice = 0000028B946E8D58, pFeatureLevel = 000000E4BE4FFB38, ppImmediateContext = 0000028B946E8D60) ...
20:22:48:788 [38672] | INFO  | Searching for add-ons (*.addon, *.addon64) in 'G:\Steam\steamapps\common\MGS2\plugins' ...
20:22:48:788 [38672] | INFO  | Loading add-on from 'G:\Steam\steamapps\common\MGS2\plugins\swapchain_override.addon64' ...
20:22:48:789 [38672] | INFO  | Registered add-on "Swap chain override" v0.0.0.0 using ReShade API version 16.
20:22:49:044 [38672] | INFO  | Using feature level b100.
20:22:49:044 [38672] | INFO  | Redirecting IDXGIFactory::CreateSwapChain(this = 0000028B946EE0B0, pDevice = 0000028B9C8F3A18, pDesc = 0000028B946E8D08, ppSwapChain = 0000028B946E8D70) ...
20:22:49:045 [38672] | INFO  | > Dumping swap chain description:
20:22:49:045 [38672] | INFO  |   +-----------------------------------------+-----------------------------------------+
20:22:49:045 [38672] | INFO  |   | Parameter                               | Value                                   |
20:22:49:045 [38672] | INFO  |   +-----------------------------------------+-----------------------------------------+
20:22:49:045 [38672] | INFO  |   | Width                                   | 3840                                    |
20:22:49:045 [38672] | INFO  |   | Height                                  | 2160                                    |
20:22:49:045 [38672] | INFO  |   | RefreshRate                             | 60                  1                   |
20:22:49:046 [38672] | INFO  |   | Format                                  | DXGI_FORMAT_B8G8R8A8_UNORM              |
20:22:49:046 [38672] | INFO  |   | ScanlineOrdering                        | 0                                       |
20:22:49:046 [38672] | INFO  |   | Scaling                                 | 0                                       |
20:22:49:046 [38672] | INFO  |   | SampleCount                             | 1                                       |
20:22:49:046 [38672] | INFO  |   | SampleQuality                           | 0                                       |
20:22:49:046 [38672] | INFO  |   | BufferUsage                             | 0x20                                    |
20:22:49:047 [38672] | INFO  |   | BufferCount                             | 3                                       |
20:22:49:047 [38672] | INFO  |   | OutputWindow                            | 00000000002F27BC                        |
20:22:49:047 [38672] | INFO  |   | Windowed                                | TRUE                                    |
20:22:49:047 [38672] | INFO  |   | SwapEffect                              | 4                                       |
20:22:49:047 [38672] | INFO  |   | Flags                                   | 0                                       |
20:22:49:047 [38672] | INFO  |   +-----------------------------------------+-----------------------------------------+
20:22:49:052 [38672] | INFO  | Running on NVIDIA GeForce RTX 3080 Driver 572.83.
20:22:49:311 [38672] | INFO  | Recreated runtime environment on runtime 0000028B9CB903F0 ('G:\Steam\steamapps\common\MGS2\plugins\ReShade.ini').
20:22:49:480 [57572] | WARN  | Ignoring LoadLibrary('api-ms-win-appmodel-runtime-l1-1-2') call to avoid possible deadlock.
20:22:49:481 [30524] | WARN  | Ignoring LoadLibrary('api-ms-win-appmodel-runtime-l1-1-2') call to avoid possible deadlock.
20:22:49:482 [61124] | WARN  | Ignoring LoadLibrary('api-ms-win-appmodel-runtime-l1-1-2') call to avoid possible deadlock.
20:22:49:484 [41720] | WARN  | Ignoring LoadLibrary('api-ms-win-appmodel-runtime-l1-1-2') call to avoid possible deadlock.
20:22:49:484 [45912] | WARN  | Ignoring LoadLibrary('api-ms-win-appmodel-runtime-l1-1-2') call to avoid possible deadlock.
20:22:49:486 [63612] | WARN  | Ignoring LoadLibrary('api-ms-win-appmodel-runtime-l1-1-2') call to avoid possible deadlock.
20:22:49:487 [  576] | WARN  | Ignoring LoadLibrary('api-ms-win-appmodel-runtime-l1-1-2') call to avoid possible deadlock.
20:22:49:489 [17780] | WARN  | Ignoring LoadLibrary('api-ms-win-appmodel-runtime-l1-1-2') call to avoid possible deadlock.
20:22:49:506 [57572] | INFO  | Successfully compiled 'G:\Steam\steamapps\common\MGS2\plugins\reshade-shaders\Shaders\AstrayFX\Trails.fx' in 0.025000 s.
20:22:49:507 [25216] | INFO  | Successfully compiled 'G:\Steam\steamapps\common\MGS2\plugins\reshade-shaders\Shaders\Insane-Shaders\Mouse.fx' in 0.026000 s.
```