### PR TITLE
Add DXGI (and DX9) present flags to the present addon function

### DIFF
--- a/examples/09-depth/generic_depth_addon.cpp
+++ b/examples/09-depth/generic_depth_addon.cpp
@@ -846,7 +846,7 @@ static void on_execute_secondary(command_list *cmd_list, command_list *secondary
 	}
 }
 
-static void on_present(command_queue *, swapchain *swapchain, const rect *, const rect *, uint32_t, const rect *, uint32_t *, uint32_t *)
+static bool on_present(command_queue *, swapchain *swapchain, const rect *, const rect *, uint32_t, const rect *, uint32_t *, uint32_t *)
 {
 	device *const device = swapchain->get_device();
 	generic_depth_device_data *const device_data = device->get_private_data<generic_depth_device_data>();
@@ -865,11 +865,11 @@ static void on_present(command_queue *, swapchain *swapchain, const rect *, cons
 
 	// Only update device list if there are any depth-stencils, otherwise this may be a second present call (at which point 'reset_on_present' already cleared out the queue list in the first present call)
 	if (queue_state.counters_per_used_depth_stencil.empty())
-		return;
+		return false;
 
 	// Also skip update when there has been very little activity (special case for emulators like PCSX2 which may present more often than they render a frame)
 	if (queue_state.counters_per_used_depth_stencil.size() == 1 && queue_state.counters_per_used_depth_stencil.begin()->second.total_stats.drawcalls <= 8)
-		return;
+		return false;
 
 	device_data->frame_index++;
 
@@ -917,6 +917,8 @@ static void on_present(command_queue *, swapchain *swapchain, const rect *, cons
 
 		++it;
 	}
+
+	return false;
 }
 
 static void on_begin_render_effects(effect_runtime *runtime, command_list *cmd_list, resource_view, resource_view)

--- a/examples/09-depth/generic_depth_addon.cpp
+++ b/examples/09-depth/generic_depth_addon.cpp
@@ -846,7 +846,7 @@ static void on_execute_secondary(command_list *cmd_list, command_list *secondary
 	}
 }
 
-static void on_present(command_queue *, swapchain *swapchain, const rect *, const rect *, uint32_t, const rect *)
+static void on_present(command_queue *, swapchain *swapchain, const rect *, const rect *, uint32_t, const rect *, uint32_t *, uint32_t *)
 {
 	device *const device = swapchain->get_device();
 	generic_depth_device_data *const device_data = device->get_private_data<generic_depth_device_data>();

--- a/include/reshade.hpp
+++ b/include/reshade.hpp
@@ -11,7 +11,7 @@
 #include <Windows.h>
 
 // Current version of the ReShade API
-#define RESHADE_API_VERSION 17
+#define RESHADE_API_VERSION 18
 
 // Optionally import ReShade API functions when 'RESHADE_API_LIBRARY' is defined instead of using header-only mode
 #if defined(RESHADE_API_LIBRARY) || defined(RESHADE_API_LIBRARY_EXPORT)

--- a/include/reshade_events.hpp
+++ b/include/reshade_events.hpp
@@ -1598,11 +1598,12 @@ namespace reshade
 		/// <item><description>IVRCompositor::Submit</description></item>
 		/// <item><description>xrEndFrame</description></item>
 		/// </list>
-		/// <para>Callback function signature: <c>void (api::command_queue *queue, api::swapchain *swapchain, const api::rect *source_rect, const api::rect *dest_rect, uint32_t dirty_rect_count, const api::rect *dirty_rects, uint32_t* sync_interval, uint32_t* flags)</c></para>
+		/// <para>Callback function signature: <c>bool (api::command_queue *queue, api::swapchain *swapchain, const api::rect *source_rect, const api::rect *dest_rect, uint32_t dirty_rect_count, const api::rect *dirty_rects, uint32_t* sync_interval, uint32_t* flags)</c></para>
 		/// </summary>
 		/// <remarks>
 		/// The source and destination rectangle arguments are optional and may be <see langword="nullptr"/> (which indicates the swap chain is presented in its entirety).
 		/// The <see cref="sync_interval"/> and <see cref="flags"/> parameters can be edited but are per API (DXGI exclusive) and might otherwise be <see langword="nullptr"/>.
+		/// To prevent this from being executed (outside of VR APIs), return <see langword="true"/>, otherwise return <see langword="false"/>.
 		/// </remarks>
 		present,
 
@@ -1861,7 +1862,7 @@ namespace reshade
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::execute_command_list, void, api::command_queue *queue, api::command_list *cmd_list);
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::execute_secondary_command_list, void, api::command_list *cmd_list, api::command_list *secondary_cmd_list);
 
-	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::present, void, api::command_queue *queue, api::swapchain *swapchain, const api::rect *source_rect, const api::rect *dest_rect, uint32_t dirty_rect_count, const api::rect *dirty_rects, uint32_t *sync_interval, uint32_t *flags);
+	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::present, bool, api::command_queue *queue, api::swapchain *swapchain, const api::rect *source_rect, const api::rect *dest_rect, uint32_t dirty_rect_count, const api::rect *dirty_rects, uint32_t *sync_interval, uint32_t *flags);
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::set_fullscreen_state, bool, api::swapchain *swapchain, bool fullscreen, void *hmonitor);
 
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_present, void, api::effect_runtime *runtime);

--- a/include/reshade_events.hpp
+++ b/include/reshade_events.hpp
@@ -1598,10 +1598,11 @@ namespace reshade
 		/// <item><description>IVRCompositor::Submit</description></item>
 		/// <item><description>xrEndFrame</description></item>
 		/// </list>
-		/// <para>Callback function signature: <c>void (api::command_queue *queue, api::swapchain *swapchain, const api::rect *source_rect, const api::rect *dest_rect, uint32_t dirty_rect_count, const api::rect *dirty_rects)</c></para>
+		/// <para>Callback function signature: <c>void (api::command_queue *queue, api::swapchain *swapchain, const api::rect *source_rect, const api::rect *dest_rect, uint32_t dirty_rect_count, const api::rect *dirty_rects, uint32_t* sync_interval, uint32_t* flags)</c></para>
 		/// </summary>
 		/// <remarks>
 		/// The source and destination rectangle arguments are optional and may be <see langword="nullptr"/> (which indicates the swap chain is presented in its entirety).
+		/// The <see cref="sync_interval"/> and <see cref="flags"/> parameters can be edited but are per API (DXGI exclusive) and might otherwise be <see langword="nullptr"/>.
 		/// </remarks>
 		present,
 
@@ -1860,7 +1861,7 @@ namespace reshade
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::execute_command_list, void, api::command_queue *queue, api::command_list *cmd_list);
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::execute_secondary_command_list, void, api::command_list *cmd_list, api::command_list *secondary_cmd_list);
 
-	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::present, void, api::command_queue *queue, api::swapchain *swapchain, const api::rect *source_rect, const api::rect *dest_rect, uint32_t dirty_rect_count, const api::rect *dirty_rects);
+	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::present, void, api::command_queue *queue, api::swapchain *swapchain, const api::rect *source_rect, const api::rect *dest_rect, uint32_t dirty_rect_count, const api::rect *dirty_rects, uint32_t *sync_interval, uint32_t *flags);
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::set_fullscreen_state, bool, api::swapchain *swapchain, bool fullscreen, void *hmonitor);
 
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_present, void, api::effect_runtime *runtime);

--- a/source/d3d12/d3d12_command_queue_downlevel.cpp
+++ b/source/d3d12/d3d12_command_queue_downlevel.cpp
@@ -102,7 +102,9 @@ HRESULT STDMETHODCALLTYPE D3D12CommandQueueDownlevel::Present(ID3D12GraphicsComm
 	if (_back_buffers[0] != nullptr)
 	{
 #if RESHADE_ADDON
-		reshade::invoke_addon_event<reshade::addon_event::present>(_parent_queue, this, nullptr, nullptr, 0, nullptr);
+		uint32_t flags = Flags;
+		reshade::invoke_addon_event<reshade::addon_event::present>(_parent_queue, this, nullptr, nullptr, 0, nullptr, nullptr, &flags);
+		Flags = static_cast<D3D12_DOWNLEVEL_PRESENT_FLAGS>(flags);
 #endif
 
 		reshade::present_effect_runtime(this);

--- a/source/d3d9/d3d9_device.cpp
+++ b/source/d3d9/d3d9_device.cpp
@@ -2260,7 +2260,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice9::PresentEx(const RECT *pSourceRect, co
 	{
 		assert(!_implicit_swapchain->_was_still_drawing_last_frame);
 
-		_implicit_swapchain->on_present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
+		_implicit_swapchain->on_present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion, &dwFlags);
 	}
 
 	const HRESULT hr = static_cast<IDirect3DDevice9Ex *>(_orig)->PresentEx(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion, dwFlags);

--- a/source/d3d9/d3d9_device.cpp
+++ b/source/d3d9/d3d9_device.cpp
@@ -333,7 +333,10 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice9::Reset(D3DPRESENT_PARAMETERS *pPresent
 }
 HRESULT STDMETHODCALLTYPE Direct3DDevice9::Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion)
 {
-	_implicit_swapchain->on_present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
+	if (_implicit_swapchain->on_present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion))
+	{
+		return S_OK; // Pretend it was successful
+	}
 
 	const HRESULT hr = _orig->Present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
 
@@ -2260,7 +2263,10 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice9::PresentEx(const RECT *pSourceRect, co
 	{
 		assert(!_implicit_swapchain->_was_still_drawing_last_frame);
 
-		_implicit_swapchain->on_present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion, &dwFlags);
+		if (_implicit_swapchain->on_present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion, &dwFlags))
+		{
+			return S_OK; // Pretend it was successful
+		}
 	}
 
 	const HRESULT hr = static_cast<IDirect3DDevice9Ex *>(_orig)->PresentEx(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion, dwFlags);

--- a/source/d3d9/d3d9_swapchain.hpp
+++ b/source/d3d9/d3d9_swapchain.hpp
@@ -39,7 +39,7 @@ struct DECLSPEC_UUID("BC52FCE4-1EAC-40C8-84CF-863600BBAA01") Direct3DSwapChain9 
 
 	void on_init(bool resize);
 	void on_reset(bool resize);
-	void on_present(const RECT *source_rect, [[maybe_unused]] const RECT *dest_rect, HWND window_override, [[maybe_unused]] const RGNDATA *dirty_region, DWORD *flags = nullptr);
+	bool on_present(const RECT *source_rect, [[maybe_unused]] const RECT *dest_rect, HWND window_override, [[maybe_unused]] const RGNDATA *dirty_region, DWORD *flags = nullptr);
 	void handle_device_loss(HRESULT hr);
 
 	bool check_and_upgrade_interface(REFIID riid);

--- a/source/d3d9/d3d9_swapchain.hpp
+++ b/source/d3d9/d3d9_swapchain.hpp
@@ -39,7 +39,7 @@ struct DECLSPEC_UUID("BC52FCE4-1EAC-40C8-84CF-863600BBAA01") Direct3DSwapChain9 
 
 	void on_init(bool resize);
 	void on_reset(bool resize);
-	void on_present(const RECT *source_rect, [[maybe_unused]] const RECT *dest_rect, HWND window_override, [[maybe_unused]] const RGNDATA *dirty_region);
+	void on_present(const RECT *source_rect, [[maybe_unused]] const RECT *dest_rect, HWND window_override, [[maybe_unused]] const RGNDATA *dirty_region, DWORD *flags = nullptr);
 	void handle_device_loss(HRESULT hr);
 
 	bool check_and_upgrade_interface(REFIID riid);

--- a/source/dxgi/dxgi_swapchain.cpp
+++ b/source/dxgi/dxgi_swapchain.cpp
@@ -246,7 +246,7 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::GetDevice(REFIID riid, void **ppDevice)
 
 HRESULT STDMETHODCALLTYPE DXGISwapChain::Present(UINT SyncInterval, UINT Flags)
 {
-	on_present(Flags);
+	on_present(SyncInterval, Flags);
 
 #if RESHADE_ADDON
 	if (_sync_interval != UINT_MAX)
@@ -465,7 +465,7 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::GetCoreWindow(REFIID refiid, void **ppU
 }
 HRESULT STDMETHODCALLTYPE DXGISwapChain::Present1(UINT SyncInterval, UINT PresentFlags, const DXGI_PRESENT_PARAMETERS *pPresentParameters)
 {
-	on_present(PresentFlags, pPresentParameters);
+	on_present(SyncInterval, PresentFlags, pPresentParameters);
 
 #if RESHADE_ADDON
 	if (_sync_interval != UINT_MAX)
@@ -788,7 +788,7 @@ void DXGISwapChain::on_reset(bool resize)
 	_is_initialized = false;
 }
 
-void DXGISwapChain::on_present(UINT flags, [[maybe_unused]] const DXGI_PRESENT_PARAMETERS *params)
+void DXGISwapChain::on_present(UINT &sync_interval, UINT &flags, [[maybe_unused]] const DXGI_PRESENT_PARAMETERS *params)
 {
 	// Some D3D11 games test presentation for timing and composition purposes
 	// These calls are not rendering related, but rather a status request for the D3D runtime and as such should be ignored
@@ -822,7 +822,9 @@ void DXGISwapChain::on_present(UINT flags, [[maybe_unused]] const DXGI_PRESENT_P
 			nullptr,
 			nullptr,
 			params != nullptr ? params->DirtyRectsCount : 0,
-			params != nullptr ? reinterpret_cast<const reshade::api::rect *>(params->pDirtyRects) : nullptr);
+			params != nullptr ? reinterpret_cast<const reshade::api::rect *>(params->pDirtyRects) : nullptr,
+			&sync_interval,
+			&flags);
 #endif
 		reshade::present_effect_runtime(_impl);
 		break;
@@ -838,7 +840,9 @@ void DXGISwapChain::on_present(UINT flags, [[maybe_unused]] const DXGI_PRESENT_P
 			nullptr,
 			nullptr,
 			params != nullptr ? params->DirtyRectsCount : 0,
-			params != nullptr ? reinterpret_cast<const reshade::api::rect *>(params->pDirtyRects) : nullptr);
+			params != nullptr ? reinterpret_cast<const reshade::api::rect *>(params->pDirtyRects) : nullptr,
+			&sync_interval,
+			&flags);
 #endif
 		reshade::present_effect_runtime(_impl);
 		break;
@@ -850,7 +854,9 @@ void DXGISwapChain::on_present(UINT flags, [[maybe_unused]] const DXGI_PRESENT_P
 			nullptr,
 			nullptr,
 			params != nullptr ? params->DirtyRectsCount : 0,
-			params != nullptr ? reinterpret_cast<const reshade::api::rect *>(params->pDirtyRects) : nullptr);
+			params != nullptr ? reinterpret_cast<const reshade::api::rect *>(params->pDirtyRects) : nullptr,
+			&sync_interval,
+			&flags);
 #endif
 		reshade::present_effect_runtime(_impl);
 		static_cast<D3D12CommandQueue *>(_direct3d_command_queue)->flush_immediate_command_list();

--- a/source/dxgi/dxgi_swapchain.hpp
+++ b/source/dxgi/dxgi_swapchain.hpp
@@ -85,7 +85,7 @@ struct DECLSPEC_UUID("1F445F9F-9887-4C4C-9055-4E3BADAFCCA8") DXGISwapChain final
 
 	void on_init(bool resize);
 	void on_reset(bool resize);
-	void on_present(UINT &sync_interval, UINT &flags, [[maybe_unused]] const DXGI_PRESENT_PARAMETERS *params = nullptr);
+	bool on_present(UINT &sync_interval, UINT &flags, [[maybe_unused]] const DXGI_PRESENT_PARAMETERS *params = nullptr);
 	void handle_device_loss(HRESULT hr);
 
 	bool check_and_upgrade_interface(REFIID riid);

--- a/source/dxgi/dxgi_swapchain.hpp
+++ b/source/dxgi/dxgi_swapchain.hpp
@@ -85,7 +85,7 @@ struct DECLSPEC_UUID("1F445F9F-9887-4C4C-9055-4E3BADAFCCA8") DXGISwapChain final
 
 	void on_init(bool resize);
 	void on_reset(bool resize);
-	void on_present(UINT flags, [[maybe_unused]] const DXGI_PRESENT_PARAMETERS *params = nullptr);
+	void on_present(UINT &sync_interval, UINT &flags, [[maybe_unused]] const DXGI_PRESENT_PARAMETERS *params = nullptr);
 	void handle_device_loss(HRESULT hr);
 
 	bool check_and_upgrade_interface(REFIID riid);

--- a/source/opengl/opengl_hooks_wgl.cpp
+++ b/source/opengl/opengl_hooks_wgl.cpp
@@ -346,7 +346,7 @@ public:
 		// Behave as if immediate command list is flushed
 		reshade::invoke_addon_event<reshade::addon_event::execute_command_list>(context, context);
 
-		reshade::invoke_addon_event<reshade::addon_event::present>(context, this, nullptr, nullptr, 0, nullptr);
+		reshade::invoke_addon_event<reshade::addon_event::present>(context, this, nullptr, nullptr, 0, nullptr, nullptr, nullptr);
 #endif
 
 		// Assume that the correct OpenGL context is still current here

--- a/source/openvr/openvr_impl_swapchain.cpp
+++ b/source/openvr/openvr_impl_swapchain.cpp
@@ -255,7 +255,7 @@ bool reshade::openvr::swapchain_impl::on_vr_submit(vr::EVREye eye, api::resource
 
 #if RESHADE_ADDON
 	const reshade::api::rect eye_rect = get_eye_rect(eye);
-	invoke_addon_event<reshade::addon_event::present>(_graphics_queue, this, &eye_rect, &eye_rect, 0, nullptr);
+	invoke_addon_event<reshade::addon_event::present>(_graphics_queue, this, &eye_rect, &eye_rect, 0, nullptr, nullptr, nullptr);
 #endif
 
 	if (eye == vr::Eye_Right)

--- a/source/openxr/openxr_impl_swapchain.cpp
+++ b/source/openxr/openxr_impl_swapchain.cpp
@@ -141,7 +141,7 @@ void reshade::openxr::swapchain_impl::on_present(uint32_t view_count, const api:
 		cmd_list->barrier(view_textures[0], before_state, api::resource_usage::present);
 
 #if RESHADE_ADDON
-		invoke_addon_event<addon_event::present>(_graphics_queue, this, nullptr, nullptr, 0, nullptr);
+		invoke_addon_event<addon_event::present>(_graphics_queue, this, nullptr, nullptr, 0, nullptr, nullptr, nullptr);
 #endif
 
 		present_effect_runtime(this);
@@ -195,7 +195,7 @@ void reshade::openxr::swapchain_impl::on_present(uint32_t view_count, const api:
 		cmd_list->barrier(_side_by_side_texture, api::resource_usage::copy_dest, api::resource_usage::present);
 
 #if RESHADE_ADDON
-		invoke_addon_event<addon_event::present>(_graphics_queue, this, nullptr, nullptr, 0, nullptr);
+		invoke_addon_event<addon_event::present>(_graphics_queue, this, nullptr, nullptr, 0, nullptr, nullptr, nullptr);
 #endif
 
 		present_effect_runtime(this);

--- a/source/vulkan/vulkan_hooks_device.cpp
+++ b/source/vulkan/vulkan_hooks_device.cpp
@@ -1386,7 +1386,9 @@ VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPr
 			display_present_info != nullptr ? &source_rect : nullptr,
 			display_present_info != nullptr ? &dest_rect : nullptr,
 			dirty_rect_count,
-			dirty_rect_count != 0 ? dirty_rects.p : nullptr);
+			dirty_rect_count != 0 ? dirty_rects.p : nullptr,
+			nullptr,
+			nullptr);
 #endif
 
 		reshade::present_effect_runtime(swapchain_impl);


### PR DESCRIPTION
This is required to properly add VRR support to games.

Addon developers can tell the actual flags based on the swapchain/device API.
The present interval param also needs to be added as the allow tearing flag gives an error if set when the interval isn't 0, and while ReShade already allows forcing a specific interval, ideally we'd make the whole thing dynamic and allow the game to engage v-sync if it wanted it (from its own settings), without forcing it to ever be off or on through ReShade.

A second (optional) commit further changes the API in a breaking way, but adds functionality to skip calling the original present call. This should be useful when we override the original swapchain with a new one, for games cross API presentation, e.g. DX9 to DX11, VK to DX12 etc.