### PR TITLE
Fix issues with the original swapchain desc code:

### DIFF
--- a/source/dxgi/dxgi_swapchain.cpp
+++ b/source/dxgi/dxgi_swapchain.cpp
@@ -347,6 +347,7 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::ResizeBuffers(UINT BufferCount, UINT Wi
 
 	// Handle update of the swap chain description
 #if RESHADE_ADDON
+	DXGI_SWAP_CHAIN_DESC prev_orig_desc = _orig_desc;
 	{
 		g_in_dxgi_runtime = true;
 		DXGI_SWAP_CHAIN_DESC desc = {};
@@ -357,8 +358,10 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::ResizeBuffers(UINT BufferCount, UINT Wi
 			desc.BufferCount = BufferCount;
 		desc.BufferDesc.Width = _orig_desc.BufferDesc.Width = Width;
 		desc.BufferDesc.Height = _orig_desc.BufferDesc.Height = Height;
-		if (NewFormat != DXGI_FORMAT_UNKNOWN)
-			desc.BufferDesc.Format = _orig_desc.BufferDesc.Format = NewFormat;
+		// Restore the format the application originally used, the addon can change it again if it wished so
+		if (NewFormat == DXGI_FORMAT_UNKNOWN)
+			NewFormat = _orig_desc.BufferDesc.Format;
+		desc.BufferDesc.Format = _orig_desc.BufferDesc.Format = NewFormat;
 		desc.Flags = _orig_desc.Flags = SwapChainFlags;
 
 		if (modify_swapchain_desc(_direct3d_version, desc, _sync_interval))
@@ -371,6 +374,7 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::ResizeBuffers(UINT BufferCount, UINT Wi
 			NewFormat = desc.BufferDesc.Format;
 			SwapChainFlags = desc.Flags;
 		}
+		// Disable using the original desc
 		else
 		{
 			_orig_desc.BufferCount = 0;
@@ -380,6 +384,19 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::ResizeBuffers(UINT BufferCount, UINT Wi
 
 	g_in_dxgi_runtime = true;
 	const HRESULT hr = _orig->ResizeBuffers(BufferCount, Width, Height, NewFormat, SwapChainFlags);
+#if RESHADE_ADDON
+	if (SUCCEEDED(hr) && (Width == 0 || Height == 0))
+	{
+		DXGI_SWAP_CHAIN_DESC desc = {};
+		_orig->GetDesc(&desc);
+		_orig_desc.BufferDesc.Width = desc.BufferDesc.Width;
+		_orig_desc.BufferDesc.Height = desc.BufferDesc.Height;
+	}
+	else if (FAILED(hr))
+	{
+		_orig_desc = prev_orig_desc;
+	}
+#endif
 	g_in_dxgi_runtime = was_in_dxgi_runtime;
 	if (SUCCEEDED(hr))
 	{
@@ -430,7 +447,7 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::GetDesc1(DXGI_SWAP_CHAIN_DESC1 *pDesc)
 		pDesc->Width = _orig_desc.BufferDesc.Width;
 		pDesc->Height = _orig_desc.BufferDesc.Height;
 		pDesc->Format = _orig_desc.BufferDesc.Format;
-		pDesc->Stereo = FALSE;
+		pDesc->Stereo = FALSE; // For now we don't carry this information
 		pDesc->SampleDesc = _orig_desc.SampleDesc;
 		pDesc->BufferUsage = _orig_desc.BufferUsage;
 		pDesc->BufferCount = _orig_desc.BufferCount;
@@ -621,6 +638,7 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::ResizeBuffers1(UINT BufferCount, UINT W
 
 	// Handle update of the swap chain description
 #if RESHADE_ADDON
+	DXGI_SWAP_CHAIN_DESC prev_orig_desc = _orig_desc;
 	{
 		g_in_dxgi_runtime = true;
 		HWND hwnd = nullptr;
@@ -636,8 +654,10 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::ResizeBuffers1(UINT BufferCount, UINT W
 			desc.BufferCount = BufferCount;
 		desc.Width = _orig_desc.BufferDesc.Width = Width;
 		desc.Height = _orig_desc.BufferDesc.Height = Height;
-		if (NewFormat != DXGI_FORMAT_UNKNOWN)
-			desc.Format = _orig_desc.BufferDesc.Format = NewFormat;
+		// Restore the format the application originally used, the addon can change it again if it wished so
+		if (NewFormat == DXGI_FORMAT_UNKNOWN)
+			NewFormat = _orig_desc.BufferDesc.Format;
+		desc.Format = _orig_desc.BufferDesc.Format = NewFormat;
 		desc.Flags = _orig_desc.Flags = SwapChainFlags;
 
 		fullscreen_desc.Windowed = !fullscreen;
@@ -652,6 +672,7 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::ResizeBuffers1(UINT BufferCount, UINT W
 			NewFormat = desc.Format;
 			SwapChainFlags = desc.Flags;
 		}
+		// Disable using the original desc
 		else
 		{
 			_orig_desc.BufferCount = 0;
@@ -671,6 +692,19 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::ResizeBuffers1(UINT BufferCount, UINT W
 
 	g_in_dxgi_runtime = true;
 	const HRESULT hr = static_cast<IDXGISwapChain3 *>(_orig)->ResizeBuffers1(BufferCount, Width, Height, NewFormat, SwapChainFlags, pCreationNodeMask, present_queues.p);
+#if RESHADE_ADDON
+	if (SUCCEEDED(hr) && (Width == 0 || Height == 0))
+	{
+		DXGI_SWAP_CHAIN_DESC desc = {};
+		_orig->GetDesc(&desc);
+		_orig_desc.BufferDesc.Width = desc.BufferDesc.Width;
+		_orig_desc.BufferDesc.Height = desc.BufferDesc.Height;
+	}
+	else if (FAILED(hr))
+	{
+		_orig_desc = prev_orig_desc;
+	}
+#endif
 	g_in_dxgi_runtime = was_in_dxgi_runtime;
 	if (SUCCEEDED(hr))
 	{


### PR DESCRIPTION
- The application resizing the buffer to DXGI_FORMAT_UNKNOWN would automatically pick the last format previously overridden by the addon, instead of falling back to the format originally selected by the application, which would be what the application expects (addons can replace the format again if they wished so)
- The application resizing the buffer to a size of 0 would prevent the feature from working, causing a mix of states. We can simply query the new buffer size after resizing the buffers to get the feature to work properly in that case
- If the swapchain resize failed (which can happen) the original desc wouldn't be restored, causing follow up GetDesc to have wrong data