### PR TITLE
Invoke addon events from API calls made by a different addon

### DIFF
--- a/source/runtime_api.cpp
+++ b/source/runtime_api.cpp
@@ -1015,7 +1015,7 @@ void reshade::runtime::set_technique_state(api::effect_technique handle, bool en
 
 #if RESHADE_ADDON
 	const bool was_is_in_api_call = _is_in_api_call;
-	_is_in_api_call = true;
+	// _is_in_api_call = true;
 #endif
 
 	if (enabled)


### PR DESCRIPTION
I ran into an issue where when one addon toggles techniques on/off, other addons aren't notified, leading to them losing track of technique states. As a proof of concept, d77b9b663c30fe0484617d7dbaf4d8c779612e62 is what I quickly changed to make my setup work. I don't expect that to be merged. Instead, I want to first discuss how this should be implemented before writing a patch. Or, if you want to write it yourself, I wouldn't mind that either.

Looking at the code, it's clear that it prevents an infinite loop when an addon's event callback uses an API function that would invoke that same callback. Are there any other reasons for it that I'm not aware of?

A fix that first comes to mind is tracking `_is_in_api_call` separately for each addon, maybe also for each API function. What are your thoughts on this?

Another improvement would be to inform the user when a callback is skipped, meaning some addons might not work as intended. Of course that doesn't actually fix the issue, but it would have helped me when I was trying to figure out why my setup wasn't working. 