### PR TITLE
CI: Add Publish jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "*"
   pull_request:
     branches:
       - main
@@ -56,3 +58,28 @@ jobs:
         with:
           name: ReShade Setup
           path: './bin/AnyCPU/Release/ReShade Setup.exe'
+
+      - name: Publish Unstable Release
+        if: github.event_name == 'push' && github.ref_type != 'tag'
+        uses: crowbarmaster/GH-Automatic-Releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: continuous
+          prerelease: true
+          title: "ReShade Unstable"
+          files: |
+            ./bin/Win32/Release/ReShade32.dll
+            ./bin/x64/Release/ReShade64.dll
+            ./bin/AnyCPU/Release/ReShade Setup.exe
+
+      - name: Publish Stable Release
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        uses: crowbarmaster/GH-Automatic-Releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          automatic_release_tag: ${{ github.ref_name }}
+          files: |
+            ./bin/Win32/Release/ReShade32.dll
+            ./bin/x64/Release/ReShade64.dll
+            ./bin/AnyCPU/Release/ReShade Setup.exe


### PR DESCRIPTION
This PR adds two new jobs in the already known steps. Both of them are about publishing releases on the Github Repository to make it easier for users to find and download the resulting compiled binaries.

Here you can find an example of how continuous builds will look like ( these ones will be built for every commit pushed on `main` ):
- Action Run: https://github.com/julianxhokaxhiu/reshade/actions/runs/17025604755
- Release: https://github.com/julianxhokaxhiu/reshade/releases/tag/continuous

While here you can find an example of a stable release ( I had to use `v6.5.2` as an example to mimic the versioning you're using; these ones will be made only on each new tag push ):
- Action Run: https://github.com/julianxhokaxhiu/reshade/actions/runs/17025605711
- Release: https://github.com/julianxhokaxhiu/reshade/releases/tag/v6.5.2

Any question feel free to ask. Thanks again for working on ReShade!