### PR TITLE
Feature/hide hdr

### DIFF
--- a/examples/19-set_hide_hdr/set_hide_hdr.vcxproj
+++ b/examples/19-set_hide_hdr/set_hide_hdr.vcxproj
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{33D7E8D2-7F71-4B8B-8D99-7D9E6C5ACB22}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)'&gt;='16.0'">10.0</WindowsTargetPlatformVersion>
+    <ProjectName>19-set_hide_hdr</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='Debug'">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='Release'">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup>
+    <OutDir>..\..\bin\$(Platform)\$(Configuration) Examples\</OutDir>
+    <IntDir>..\..\intermediate\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>set_hide_hdr</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='Win32'">
+    <TargetExt>.addon32</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='x64'">
+    <TargetExt>.addon64</TargetExt>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="set_hide_hdr_addon.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>
+
+

--- a/examples/19-set_hide_hdr/set_hide_hdr_addon.cpp
+++ b/examples/19-set_hide_hdr/set_hide_hdr_addon.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025
+ * SPDX-License-Identifier: BSD-3-Clause OR MIT
+ */
+
+#include <imgui.h>
+#include <reshade.hpp>
+
+using namespace reshade::api;
+
+static bool s_hide_hdr = false;
+
+static void on_init(effect_runtime *runtime)
+{
+    // Load config once (global) and apply to each runtime on init
+    static bool s_config_loaded = false;
+    if (!s_config_loaded)
+    {
+        if (!reshade::get_config_value(nullptr, "ADDON", "HideHDR", s_hide_hdr))
+            reshade::set_config_value(nullptr, "ADDON", "HideHDR", 0);
+        s_config_loaded = true;
+    }
+
+    runtime->set_hide_hdr(s_hide_hdr);
+}
+
+static void draw_overlay(effect_runtime *runtime)
+{
+    bool hide_hdr = s_hide_hdr;
+    if (ImGui::Checkbox("Hide HDR (force SDR reporting)", &hide_hdr))
+    {
+        s_hide_hdr = hide_hdr;
+        reshade::set_config_value(nullptr, "ADDON", "HideHDR", hide_hdr ? 1 : 0);
+        runtime->set_hide_hdr(hide_hdr);
+    }
+}
+
+#ifndef BUILTIN_ADDON
+
+extern "C" __declspec(dllexport) const char *NAME = "Hide HDR";
+extern "C" __declspec(dllexport) const char *DESCRIPTION =
+    "Adds a setting to hide HDR from applications by forcing SDR reporting via DXGI.\n\n"
+    "Configured via ReShade.ini:\n"
+    "[ADDON]\n"
+    "HideHDR=<0/1>\n";
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
+{
+    switch (fdwReason)
+    {
+    case DLL_PROCESS_ATTACH:
+        if (!reshade::register_addon(hModule))
+            return FALSE;
+        reshade::register_overlay(nullptr, draw_overlay);
+        reshade::register_event<reshade::addon_event::init_effect_runtime>(on_init);
+        break;
+    case DLL_PROCESS_DETACH:
+        reshade::unregister_event<reshade::addon_event::init_effect_runtime>(on_init);
+        reshade::unregister_addon(hModule);
+        break;
+    }
+
+    return TRUE;
+}
+
+#endif
+
+

--- a/examples/Examples.sln
+++ b/examples/Examples.sln
@@ -37,6 +37,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "16-swapchain_override", "16
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "17-screenshot_to_clipboard", "17-screenshot_to_clipboard\screenshot_to_clipboard.vcxproj", "{FA7C3430-EB2D-448E-B802-0976890021C1}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "19-set_hide_hdr", "19-set_hide_hdr\set_hide_hdr.vcxproj", "{33D7E8D2-7F71-4B8B-8D99-7D9E6C5ACB22}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -165,6 +167,14 @@ Global
 		{FA7C3430-EB2D-448E-B802-0976890021C1}.Release|Win32.Build.0 = Release|Win32
 		{FA7C3430-EB2D-448E-B802-0976890021C1}.Release|x64.ActiveCfg = Release|x64
 		{FA7C3430-EB2D-448E-B802-0976890021C1}.Release|x64.Build.0 = Release|x64
+		{33D7E8D2-7F71-4B8B-8D99-7D9E6C5ACB22}.Debug|Win32.ActiveCfg = Debug|Win32
+		{33D7E8D2-7F71-4B8B-8D99-7D9E6C5ACB22}.Debug|Win32.Build.0 = Debug|Win32
+		{33D7E8D2-7F71-4B8B-8D99-7D9E6C5ACB22}.Debug|x64.ActiveCfg = Debug|x64
+		{33D7E8D2-7F71-4B8B-8D99-7D9E6C5ACB22}.Debug|x64.Build.0 = Debug|x64
+		{33D7E8D2-7F71-4B8B-8D99-7D9E6C5ACB22}.Release|Win32.ActiveCfg = Release|Win32
+		{33D7E8D2-7F71-4B8B-8D99-7D9E6C5ACB22}.Release|Win32.Build.0 = Release|Win32
+		{33D7E8D2-7F71-4B8B-8D99-7D9E6C5ACB22}.Release|x64.ActiveCfg = Release|x64
+		{33D7E8D2-7F71-4B8B-8D99-7D9E6C5ACB22}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -795,6 +795,13 @@ namespace reshade { namespace api
 		virtual void set_color_space(color_space color_space) = 0;
 
 		/// <summary>
+		/// Enables or disables HDR hiding behavior in the underlying runtime.
+		/// When enabled, ReShade will mask HDR capabilities from D3D11 applications.
+		/// </summary>
+		/// <param name="enabled">Set to true to hide HDR, or false to restore normal behavior.</param>
+		virtual void set_hide_hdr(bool enabled) = 0;
+
+		/// <summary>
 		/// Resets the value of the specified uniform <paramref name="variable"/>.
 		/// </summary>
 		/// <param name="variable">Opaque handle to the uniform variable.</param>

--- a/source/dll_main.cpp
+++ b/source/dll_main.cpp
@@ -126,7 +126,7 @@ std::filesystem::path get_module_path(HMODULE module)
 #ifndef RESHADE_TEST_APPLICATION
 
 // Provide storage for the global flag
-namespace reshade { int hide_hdr = 0; }
+namespace reshade { int hide_hdr = 1; }
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
 {

--- a/source/dll_main.cpp
+++ b/source/dll_main.cpp
@@ -8,6 +8,7 @@
 #include "ini_file.hpp"
 #include "hook_manager.hpp"
 #include "addon_manager.hpp"
+#include "hide_hdr.hpp"
 #include <Windows.h>
 #include <Psapi.h>
 #ifndef NDEBUG
@@ -124,12 +125,17 @@ std::filesystem::path get_module_path(HMODULE module)
 
 #ifndef RESHADE_TEST_APPLICATION
 
+// Provide storage for the global flag
+namespace reshade { int hide_hdr = 0; }
+
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
 {
 	switch (fdwReason)
 	{
 		case DLL_PROCESS_ATTACH:
 		{
+			// Default hide_hdr to 0 unless overridden elsewhere
+			reshade::hide_hdr = 1;
 			// Do NOT call 'DisableThreadLibraryCalls', since we are linking against the static CRT, which requires the thread notifications to work properly
 			// It does not do anything when static TLS is used anyway, which is the case (see https://docs.microsoft.com/windows/win32/api/libloaderapi/nf-libloaderapi-disablethreadlibrarycalls)
 			g_module_handle = hModule;

--- a/source/dll_main.cpp
+++ b/source/dll_main.cpp
@@ -126,7 +126,7 @@ std::filesystem::path get_module_path(HMODULE module)
 #ifndef RESHADE_TEST_APPLICATION
 
 // Provide storage for the global flag
-namespace reshade { int hide_hdr = 1; }
+namespace reshade { int hide_hdr = 0; }
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
 {
@@ -135,7 +135,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
 		case DLL_PROCESS_ATTACH:
 		{
 			// Default hide_hdr to 0 unless overridden elsewhere
-			reshade::hide_hdr = 1;
+			reshade::hide_hdr = 0;
 			// Do NOT call 'DisableThreadLibraryCalls', since we are linking against the static CRT, which requires the thread notifications to work properly
 			// It does not do anything when static TLS is used anyway, which is the case (see https://docs.microsoft.com/windows/win32/api/libloaderapi/nf-libloaderapi-disablethreadlibrarycalls)
 			g_module_handle = hModule;

--- a/source/dxgi/dxgi_swapchain.cpp
+++ b/source/dxgi/dxgi_swapchain.cpp
@@ -652,7 +652,7 @@ UINT    STDMETHODCALLTYPE DXGISwapChain::GetCurrentBackBufferIndex()
 HRESULT STDMETHODCALLTYPE DXGISwapChain::CheckColorSpaceSupport(DXGI_COLOR_SPACE_TYPE ColorSpace, UINT *pColorSpaceSupport)
 {
 	assert(_interface_version >= 3);
-	if (reshade::hide_hdr != 0 && _direct3d_version == reshade::api::device_api::d3d11)
+	if (reshade::hide_hdr != 0)
 	{
 		switch (ColorSpace)
 		{
@@ -702,7 +702,7 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::SetColorSpace1(DXGI_COLOR_SPACE_TYPE Co
 
 	assert(_interface_version >= 3);
 	assert(!g_in_dxgi_runtime);
-	if (reshade::hide_hdr != 0 && _direct3d_version == reshade::api::device_api::d3d11)
+	if (reshade::hide_hdr != 0)
 	{
 		switch (ColorSpace)
 		{

--- a/source/hide_hdr.hpp
+++ b/source/hide_hdr.hpp
@@ -1,0 +1,11 @@
+/*
+ * Simple global flag to control HDR masking.
+ */
+#pragma once
+
+namespace reshade {
+	// 0 = disabled, non-zero = enabled
+	extern int hide_hdr;
+}
+
+

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -35,6 +35,7 @@
 #include <stb_image_resize2.h>
 #include <d3dcompiler.h>
 #include <sk_hdr_png.hpp>
+#include "hide_hdr.hpp"
 
 bool resolve_path(std::filesystem::path &path, std::error_code &ec)
 {
@@ -1028,6 +1029,11 @@ void reshade::runtime::save_config() const
 #if RESHADE_GUI
 	save_config_gui(config);
 #endif
+}
+
+void reshade::runtime::set_hide_hdr(bool enabled)
+{
+	reshade::hide_hdr = enabled ? 1 : 0;
 }
 
 void reshade::runtime::load_current_preset()

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -169,6 +169,9 @@ namespace reshade
 
 		void set_color_space(api::color_space color_space) final;
 
+		// Allow add-ons to enable/disable HDR masking at runtime
+		void set_hide_hdr(bool enabled) final;
+
 		void reload_effect_next_frame(const char *effect_name) final;
 
 	private:


### PR DESCRIPTION
## Summary
This PR adds a new feature to hide HDR capabilities from D3D11 applications, preventing them from detecting and enabling HDR rendering.
