### PR TITLE
Fix DXGI flip-model crash when addons force VSync with tearing enabled

### DIFF
--- a/source/dxgi/dxgi.cpp
+++ b/source/dxgi/dxgi.cpp
@@ -98,6 +98,16 @@ bool modify_swapchain_desc(reshade::api::device_api api, DXGI_SWAP_CHAIN_DESC &i
 		assert(desc.sync_interval <= 4 || desc.sync_interval == UINT_MAX);
 		sync_interval = desc.sync_interval;
 
+		// If an add-on forces SyncInterval > 0, make sure tearing capability is not requested on the swapchain
+#if defined(DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING)
+		if (sync_interval != UINT_MAX && sync_interval > 0)
+			internal_desc.Flags &= ~DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+#else
+		// 0x00000800 is DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING
+		if (sync_interval != UINT_MAX && sync_interval > 0)
+			internal_desc.Flags &= ~0x00000800u;
+#endif
+
 		return true;
 	}
 
@@ -170,6 +180,16 @@ bool modify_swapchain_desc(reshade::api::device_api api, DXGI_SWAP_CHAIN_DESC1 &
 
 		assert(desc.sync_interval <= 4 || desc.sync_interval == UINT_MAX);
 		sync_interval = desc.sync_interval;
+
+		// If an add-on forces SyncInterval > 0, make sure tearing capability is not requested on the swapchain
+#if defined(DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING)
+		if (sync_interval != UINT_MAX && sync_interval > 0)
+			internal_desc.Flags &= ~DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+#else
+		// 0x00000800 is DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING
+		if (sync_interval != UINT_MAX && sync_interval > 0)
+			internal_desc.Flags &= ~0x00000800u;
+#endif
 
 		if (fullscreen_desc != nullptr)
 		{

--- a/source/dxgi/dxgi_swapchain.cpp
+++ b/source/dxgi/dxgi_swapchain.cpp
@@ -304,6 +304,16 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::Present(UINT SyncInterval, UINT Flags)
 		SyncInterval = _sync_interval;
 #endif
 
+	// If an add-on forces SyncInterval > 0, ensure tearing is not requested during Present
+#if defined(DXGI_PRESENT_ALLOW_TEARING)
+	if (SyncInterval > 0)
+		Flags &= ~DXGI_PRESENT_ALLOW_TEARING;
+#else
+	// 0x00000200 is DXGI_PRESENT_ALLOW_TEARING
+	if (SyncInterval > 0)
+		Flags &= ~0x00000200u;
+#endif
+
 	assert(!g_in_dxgi_runtime);
 	g_in_dxgi_runtime = true;
 	const HRESULT hr = _orig->Present(SyncInterval, Flags);
@@ -561,6 +571,16 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::Present1(UINT SyncInterval, UINT Presen
 #if RESHADE_ADDON
 	if (_sync_interval != UINT_MAX)
 		SyncInterval = _sync_interval;
+#endif
+
+	// If an add-on forces SyncInterval > 0, ensure tearing is not requested during Present1
+#if defined(DXGI_PRESENT_ALLOW_TEARING)
+	if (SyncInterval > 0)
+		PresentFlags &= ~DXGI_PRESENT_ALLOW_TEARING;
+#else
+	// 0x00000200 is DXGI_PRESENT_ALLOW_TEARING
+	if (SyncInterval > 0)
+		PresentFlags &= ~0x00000200u;
 #endif
 
 	assert(_interface_version >= 1);


### PR DESCRIPTION
Problem
When ReShade addons force SyncInterval > 0 (VSync ON) on DXGI flip-model swapchains, the combination with DXGI_PRESENT_ALLOW_TEARING or DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING creates an invalid Present call that can crash DX11 applications.

Root Cause
DXGI flip-model swapchains require SyncInterval == 0 when tearing is enabled. Addons can override the sync interval during swapchain creation, but ReShade doesn't sanitize the tearing flags, leading to invalid Present combinations.

Solution
Present/Present1 safety: Strip DXGI_PRESENT_ALLOW_TEARING from present flags when SyncInterval > 0
Swapchain creation safety: Clear DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING from creation flags when addon sets sync_interval > 0

Changes
dxgi_swapchain.cpp: Added tearing flag sanitization in Present() and Present1() methods
dxgi.cpp: Added tearing capability clearing in modify_swapchain_desc() functions

Impact
Prevents crashes when addons force VSync on DXGI flip-model swapchains