### PR TITLE
Add support for latency markers

### DIFF
--- a/docs/reflex_markers.md
+++ b/docs/reflex_markers.md
@@ -1,0 +1,74 @@
+# Reflex Latency Markers in ReShade
+
+This document explains the six NVIDIA Reflex latency markers and how ReShade exposes corresponding addon callbacks so addons can observe timestamps when they occur. ReShade does not generate Reflex markers; it only notifies when analogous points happen in the rendering loop.
+
+## The six markers
+
+- SIMULATION_START: The game begins simulation for a frame (input sampling, game logic start).
+- SIMULATION_END: The game finishes simulation for a frame.
+- RENDERSUBMIT_START: CPU begins submitting rendering work for the frame.
+- RENDERSUBMIT_END: CPU finishes submitting rendering work for the frame.
+- PRESENT_START: Immediately before the platform present call.
+- PRESENT_END: Immediately after the present call returns.
+
+## How Special-K generates markers (for reference)
+
+Special-K integrates with NVAPI and PCLStats. It intercepts `NvAPI_D3D_SetLatencyMarker` and uses `PCLSTATS_MARKER` to log events. Relevant code:
+
+```deps/SpecialK/src/render/reflex/reflex.cpp
+// PCLSTATS_MARKER (Marker, FrameID) is used to log, e.g. SIMULATION_START, RENDERSUBMIT_START, PRESENT_START, etc.
+```
+
+Special-K maps events:
+- SIMULATION_* markers are invoked when the game (or SK heuristics) identifies game logic boundaries.
+- RENDERSUBMIT_* are around command list submissions.
+- PRESENT_* surround the present call.
+
+## ReShade addon callbacks
+
+ReShade adds six new addon events that mirror these semantics. Each callback includes a high-resolution monotonic timestamp in nanoseconds.
+
+Event signatures:
+- latency_simulation_start(queue, swapchain, timestamp_ns)
+- latency_simulation_end(queue, swapchain, timestamp_ns)
+- latency_rendersubmit_start(queue, swapchain, timestamp_ns)
+- latency_rendersubmit_end(queue, swapchain, timestamp_ns)
+- latency_present_start(queue, swapchain, timestamp_ns)
+- latency_present_end(queue, swapchain, timestamp_ns)
+
+Notes:
+- `queue` is the best available command submission object for the API. For D3D12/Vulkan this is the real queue; for D3D11/D3D10 it is the immediate context/device; for D3D9/OpenGL, it may be null if not applicable.
+- `swapchain` is the active swapchain for the frame if available.
+- `timestamp_ns` is `std::chrono::high_resolution_clock::now()` expressed in nanoseconds. It is intended for relative timing within a process, not cross-process correlation.
+
+## Where ReShade emits these callbacks
+
+- PRESENT_START: Emitted at the top of `DXGISwapChain::Present(...)`, before ReShade’s internal `on_present` handling.
+- PRESENT_END: Emitted immediately after `IDXGISwapChain::Present` returns.
+- RENDERSUBMIT_START/END (D3D12): Emitted in `D3D12CommandQueue::ExecuteCommandLists` before and after calling the original queue submission.
+- RENDERSUBMIT_START/END (D3D11): Emitted in `D3D11DeviceContext::ExecuteCommandList` on the immediate context path, around the underlying `ExecuteCommandList` call.
+- SIMULATION_*: Not emitted yet; these are reserved for future integration (e.g., if ReShade observes NVAPI markers). Addons should not rely on them being called today.
+
+## Addon usage example
+
+```cpp
+static void on_present_start(reshade::api::command_queue *q, reshade::api::swapchain *sc, uint64_t tns) {
+    // record timestamp
+}
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID) {
+    if (reason == DLL_PROCESS_ATTACH) {
+        if (!reshade::register_addon(hModule)) return FALSE;
+        reshade::register_event<reshade::addon_event::latency_present_start>(on_present_start);
+    } else if (reason == DLL_PROCESS_DETACH) {
+        reshade::unregister_addon(hModule);
+    }
+    return TRUE;
+}
+```
+
+## Limitations
+
+- Timestamps are process-local; correlating to GPU hardware timestamps or OS compositor events is out of scope here.
+- SIMULATION_* callbacks are placeholders for now.
+- Exact queuing boundaries vary by API and application.

--- a/include/reshade_events.hpp
+++ b/include/reshade_events.hpp
@@ -1637,6 +1637,15 @@ namespace reshade
 		/// </remarks>
 		present,
 
+		// Latency marker callbacks (experimental): allow addons to observe timestamps
+		// These mirror NVIDIA Reflex marker semantics
+		//latency_simulation_start ,
+		//latency_simulation_end ,
+		latency_rendersubmit_start = 100,
+		latency_rendersubmit_end = 101,
+		latency_present_start = 102,
+		latency_present_end = 103,
+
 		/// <summary>
 		/// Called before:
 		/// <list type="bullet">
@@ -1772,7 +1781,7 @@ namespace reshade
 		reshade_overlay_technique,
 
 #if RESHADE_ADDON
-		max = 100 // Last value used internally by ReShade to determine number of events in this enum
+		max = 104 // Last value used internally by ReShade to determine number of events in this enum
 #endif
 	};
 
@@ -1898,6 +1907,14 @@ namespace reshade
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::present, void, api::command_queue *queue, api::swapchain *swapchain, const api::rect *source_rect, const api::rect *dest_rect, uint32_t dirty_rect_count, const api::rect *dirty_rects);
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::set_fullscreen_state, bool, api::swapchain *swapchain, bool fullscreen, void *hmonitor);
 
+	// Latency marker callbacks
+	//RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::latency_simulation_start, void, api::command_queue *queue, api::swapchain *swapchain, uint64_t timestamp_ns);
+	//RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::latency_simulation_end, void, api::command_queue *queue, api::swapchain *swapchain, uint64_t timestamp_ns);
+	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::latency_rendersubmit_start, void, api::command_queue *queue, api::swapchain *swapchain, uint64_t timestamp_ns);
+	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::latency_rendersubmit_end, void, api::command_queue *queue, api::swapchain *swapchain, uint64_t timestamp_ns);
+	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::latency_present_start, void, api::command_queue *queue, api::swapchain *swapchain, uint64_t timestamp_ns);
+	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::latency_present_end, void, api::command_queue *queue, api::swapchain *swapchain, uint64_t timestamp_ns);
+	
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_present, void, api::effect_runtime *runtime);
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_begin_effects, void, api::effect_runtime *runtime, api::command_list *cmd_list, api::resource_view rtv, api::resource_view rtv_srgb);
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_finish_effects, void, api::effect_runtime *runtime, api::command_list *cmd_list, api::resource_view rtv, api::resource_view rtv_srgb);

--- a/source/addon_manager.cpp
+++ b/source/addon_manager.cpp
@@ -109,6 +109,12 @@ static const char *addon_event_to_string(reshade::addon_event ev)
 	case addon_event::execute_command_list: return "execute_command_list";
 	case addon_event::execute_secondary_command_list: return "execute_secondary_command_list";
 	case addon_event::present: return "present";
+	case addon_event::latency_rendersubmit_start: return "latency_rendersubmit_start";
+	case addon_event::latency_rendersubmit_end: return "latency_rendersubmit_end";
+	case addon_event::latency_present_start: return "latency_present_start";
+	case addon_event::latency_present_end: return "latency_present_end";
+	case addon_event::latency_simulation_start: return "latency_simulation_start";
+	case addon_event::latency_simulation_end: return "latency_simulation_end";
 	case addon_event::set_fullscreen_state: return "set_fullscreen_state";
 	case addon_event::reshade_present: return "reshade_present";
 	case addon_event::reshade_begin_effects: return "reshade_begin_effects";


### PR DESCRIPTION
Fps limiters such as Reflex / Special-K FPS  limited require latency markers to work properly. This PR adds support for latency markers to reshade to allow for development of more advanced fps limiters as reshade addons.

Currently fps limiters such as renodx/fpslimiter don't have access to those latency markers.