### PR TITLE
Add reset_command_list to DX11 device context given that they might actually get reset to an "empty" state

### DIFF
--- a/include/reshade_events.hpp
+++ b/include/reshade_events.hpp
@@ -1562,14 +1562,13 @@ namespace reshade
 		/// <summary>
 		/// Called before:
 		/// <list type="bullet">
+		/// <item><description>ID3D11DeviceContext::FinishCommandList</description></item>
+		/// <item><description>ID3D11DeviceContext::ExecuteCommandList</description></item>
 		/// <item><description>ID3D12GraphicsCommandList::Reset</description></item>
 		/// <item><description>vkBeginCommandBuffer</description></item>
 		/// </list>
 		/// <para>Callback function signature: <c>void (api::command_list *cmd_list)</c></para>
 		/// </summary>
-		/// <remarks>
-		/// Is not called for immediate command lists (since they cannot be reset).
-		/// </remarks>
 		reset_command_list = 70,
 
 		/// <summary>

--- a/source/d3d11/d3d11_device_context.cpp
+++ b/source/d3d11/d3d11_device_context.cpp
@@ -851,6 +851,13 @@ void    STDMETHODCALLTYPE D3D11DeviceContext::ExecuteCommandList(ID3D11CommandLi
 
 	// Get original command list pointer from proxy object and execute with it
 	_orig->ExecuteCommandList(command_list_proxy->_orig, RestoreContextState);
+
+#if RESHADE_ADDON
+	if (!RestoreContextState)
+	{
+		reshade::invoke_addon_event<reshade::addon_event::reset_command_list>(this);
+	}
+#endif
 }
 void    STDMETHODCALLTYPE D3D11DeviceContext::HSSetShaderResources(UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView *const *ppShaderResourceViews)
 {


### PR DESCRIPTION
This is very useful when dealing with states