### PR TITLE
Add a custom fixed RIID/GUID to access the parent proxy object

### DIFF
--- a/source/d3d11/d3d11_command_list.cpp
+++ b/source/d3d11/d3d11_command_list.cpp
@@ -48,6 +48,13 @@ HRESULT STDMETHODCALLTYPE D3D11CommandList::QueryInterface(REFIID riid, void **p
 		return S_OK;
 	}
 
+	if (riid == ID_IDeviceChildParent)
+	{
+		_orig->AddRef();
+		*ppvObj = _orig;
+		return S_OK;
+	}
+
 	return _orig->QueryInterface(riid, ppvObj);
 }
 ULONG   STDMETHODCALLTYPE D3D11CommandList::AddRef()

--- a/source/d3d11/d3d11_device.cpp
+++ b/source/d3d11/d3d11_device.cpp
@@ -141,6 +141,13 @@ HRESULT STDMETHODCALLTYPE D3D11Device::QueryInterface(REFIID riid, void **ppvObj
 		return S_OK;
 	}
 
+	if (riid == ID_IDeviceChildParent)
+	{
+		_orig->AddRef();
+		*ppvObj = _orig;
+		return S_OK;
+	}
+
 	if (riid == __uuidof(ID3D11On12Device) ||
 		riid == __uuidof(ID3D11On12Device1) ||
 		riid == __uuidof(ID3D11On12Device2))

--- a/source/d3d11/d3d11_device_context.cpp
+++ b/source/d3d11/d3d11_device_context.cpp
@@ -100,6 +100,13 @@ HRESULT STDMETHODCALLTYPE D3D11DeviceContext::QueryInterface(REFIID riid, void *
 		return S_OK;
 	}
 
+	if (riid == ID_IDeviceChildParent)
+	{
+		_orig->AddRef();
+		*ppvObj = _orig;
+		return S_OK;
+	}
+
 	// Unimplemented interfaces:
 	//   ID3D11VideoContext  {61F21C45-3C0E-4a74-9CEA-67100D9AD5E4}
 	//   ID3D11VideoContext1 {A7F026DA-A5F8-4487-A564-15E34357651E}

--- a/source/d3d11/d3d11on12_device.cpp
+++ b/source/d3d11/d3d11on12_device.cpp
@@ -72,6 +72,13 @@ HRESULT STDMETHODCALLTYPE D3D11On12Device::QueryInterface(REFIID riid, void **pp
 		return S_OK;
 	}
 
+	if (riid == ID_IDeviceChildParent)
+	{
+		_orig->AddRef();
+		*ppvObj = _orig;
+		return S_OK;
+	}
+
 	return _parent_device_11->QueryInterface(riid, ppvObj);
 }
 ULONG   STDMETHODCALLTYPE D3D11On12Device::AddRef()

--- a/source/dxgi/dxgi_adapter.cpp
+++ b/source/dxgi/dxgi_adapter.cpp
@@ -6,6 +6,7 @@
 #include "dxgi_output.hpp"
 #include "dxgi_factory.hpp"
 #include "dxgi_adapter.hpp"
+#include "dxgi_device.hpp"
 #include "dll_log.hpp"
 #include "com_utils.hpp"
 
@@ -116,6 +117,13 @@ HRESULT STDMETHODCALLTYPE DXGIAdapter::QueryInterface(REFIID riid, void **ppvObj
 	{
 		AddRef();
 		*ppvObj = this;
+		return S_OK;
+	}
+
+	if (riid == ID_IDeviceChildParent)
+	{
+		_orig->AddRef();
+		*ppvObj = _orig;
 		return S_OK;
 	}
 

--- a/source/dxgi/dxgi_device.hpp
+++ b/source/dxgi/dxgi_device.hpp
@@ -7,6 +7,9 @@
 
 #include <dxgi1_5.h>
 
+// Special ID used by ReShade (and possibly other applications) that returns the parent object of a proxy
+inline constexpr GUID ID_IDeviceChildParent = { 0x7f2c9a11, 0x3b4e, 0x4d6a, { 0x81, 0x2f, 0x5e, 0x9c, 0xd3, 0x7a, 0x1b, 0x42 } };
+
 struct DECLSPEC_UUID("CB285C3B-3677-4332-98C7-D6339B9782B1") DXGIDevice : IDXGIDevice4
 {
 	DXGIDevice(IDXGIDevice1 *original);

--- a/source/dxgi/dxgi_factory.cpp
+++ b/source/dxgi/dxgi_factory.cpp
@@ -5,6 +5,7 @@
 
 #include "dxgi_factory.hpp"
 #include "dxgi_adapter.hpp"
+#include "dxgi_device.hpp"
 #include "dll_log.hpp"
 #include "com_utils.hpp"
 
@@ -108,6 +109,13 @@ HRESULT STDMETHODCALLTYPE DXGIFactory::QueryInterface(REFIID riid, void **ppvObj
 	{
 		AddRef();
 		*ppvObj = this;
+		return S_OK;
+	}
+
+	if (riid == ID_IDeviceChildParent)
+	{
+		_orig->AddRef();
+		*ppvObj = _orig;
 		return S_OK;
 	}
 

--- a/source/dxgi/dxgi_output.cpp
+++ b/source/dxgi/dxgi_output.cpp
@@ -5,6 +5,7 @@
 
 #include "dxgi_output.hpp"
 #include "dxgi_adapter.hpp"
+#include "dxgi_device.hpp"
 #include "dll_log.hpp"
 #include "com_utils.hpp"
 
@@ -106,6 +107,13 @@ HRESULT STDMETHODCALLTYPE DXGIOutput::QueryInterface(REFIID riid, void **ppvObj)
 	{
 		AddRef();
 		*ppvObj = this;
+		return S_OK;
+	}
+
+	if (riid == ID_IDeviceChildParent)
+	{
+		_orig->AddRef();
+		*ppvObj = _orig;
 		return S_OK;
 	}
 

--- a/source/dxgi/dxgi_swapchain.cpp
+++ b/source/dxgi/dxgi_swapchain.cpp
@@ -205,6 +205,13 @@ HRESULT STDMETHODCALLTYPE DXGISwapChain::QueryInterface(REFIID riid, void **ppvO
 		return S_OK;
 	}
 
+	if (riid == ID_IDeviceChildParent)
+	{
+		_orig->AddRef();
+		*ppvObj = _orig;
+		return S_OK;
+	}
+
 	if (riid == SKID_IUnwrappedDXGISwapChain)
 	{
 		// Pass through, in case the original object is already proxied by another third party


### PR DESCRIPTION
(or well, child, depending on the point of view) to facilitate applications trying to work around the multiple layers of proxies that we are getting into due to:

Overlays, SpecialK, ReShade, Nvidia Streamline, AMD FidelityFX, other custom hooks, etc etc As of now there's no good way to go up or down the chain.

Additionally, this can be good for ReShade addons that directly work at device level (without passing through the ReShade API) to create resources, and they don't want, or need, ReShade to keep track of the resources they create (the idea would be for these to be confined to the ones originally created by the application).

For now this is just implemented in DX11/DXGI, as I don't use DX10 and 12 and thus can't test it. DX9 uses the same system too so it's a candidate. The idea would be to push the same exact GUID to all the applications listed above, so we can all work around their limitations.