### PR TITLE
Add save_screenshot API method to effect_runtime interface

### DIFF
--- a/include/reshade_api.hpp
+++ b/include/reshade_api.hpp
@@ -102,6 +102,12 @@ namespace reshade { namespace api
 		virtual bool capture_screenshot(void *pixels) = 0;
 
 		/// <summary>
+		/// Captures a screenshot of the current back buffer resource and saves it to an image file on disk.
+		/// </summary>
+		/// <param name="postfix">Optional string to append to the screenshot filename, or <see langword="nullptr"/> for no postfix.</param>
+		virtual void save_screenshot(const char *postfix = nullptr) = 0;
+
+		/// <summary>
 		/// Gets the current buffer dimensions of the swap chain.
 		/// </summary>
 		virtual void get_screenshot_width_and_height(uint32_t *out_width, uint32_t *out_height) const = 0;

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -67,6 +67,7 @@ namespace reshade
 		/// </summary>
 		void save_screenshot(const std::string_view postfix = std::string_view());
 		bool capture_screenshot(void *pixels) final { return get_texture_data(_back_buffer_resolved != 0 ? _back_buffer_resolved : _swapchain->get_current_back_buffer(), _back_buffer_resolved != 0 ? api::resource_usage::render_target : api::resource_usage::present, static_cast<uint8_t *>(pixels)); }
+		void save_screenshot(const char *postfix = nullptr) final { save_screenshot(postfix ? std::string_view(postfix) : std::string_view()); }
 
 		void get_screenshot_width_and_height(uint32_t *out_width, uint32_t *out_height) const final { *out_width = _width; *out_height = _height; }
 


### PR DESCRIPTION
Adds a new `save_screenshot(const char *postfix = nullptr)` method to the `effect_runtime` interface for C-style API compatibility.

**Changes:**
- Added virtual method in `include/reshade_api.hpp`
- Implemented in `source/runtime.hpp` to call existing `save_screenshot(std::string_view)` method
- Uses `char*` parameter type for easier integration with C-based libraries

**Usage:**
```cpp
runtime->save_screenshot();           // No postfix
runtime->save_screenshot("custom");   // With postfix
```
```

**Context:** This change enables implementing screenshot functionality through XInput controller chord combinations.