### PR TITLE
Add HDR hiding support for DX11/DX12 overlays

### DIFF
--- a/examples/18-hdr_hide/README.md
+++ b/examples/18-hdr_hide/README.md
@@ -1,0 +1,42 @@
+# HDR Hide Addon
+
+This example addon demonstrates how to use the `reshade_overlay_check_color_space_support` event to hide HDR color space support when auto-enabled.
+
+## Features
+
+- **HDR Hiding**: Automatically hides HDR10 ST2084 and HDR10 HLG color spaces from overlay color space support checks
+- **Toggle Control**: Provides a checkbox in the overlay to enable/disable HDR hiding
+- **Visual Feedback**: Shows the current state (HDR hidden/visible) with colored text
+
+## How It Works
+
+The addon registers for the `reshade_overlay_check_color_space_support` event, which is called whenever ReShade checks if a color space is supported for overlay rendering. When this event is triggered:
+
+1. The addon checks if HDR hiding is enabled
+2. If enabled and the color space is HDR10 ST2084 or HDR10 HLG, it sets `supported` to `false`
+3. Returns `true` to indicate it has overridden the result
+4. For all other color spaces or when hiding is disabled, it returns `false` to let ReShade handle the check normally
+
+## Usage
+
+1. Build the addon using Visual Studio or MSBuild
+2. Copy the generated `.addon32` or `.addon64` file to your ReShade addons directory
+3. Load the addon in ReShade
+4. Use the checkbox in the overlay to toggle HDR hiding on/off
+
+## Technical Details
+
+- **Event**: `reshade_overlay_check_color_space_support`
+- **Target APIs**: D3D11 and D3D12 (only APIs that support HDR through DXGI)
+- **Color Spaces Affected**: `hdr10_st2084`, `hdr10_hlg`
+- **Purpose**: Prevents HDR from being automatically enabled for overlays
+
+## Building
+
+This addon can be built as part of the Examples solution or individually using MSBuild:
+
+```cmd
+msbuild examples\18-hdr_hide\hdr_hide.vcxproj /p:Configuration=Release /p:Platform=x64
+```
+
+The output will be `hdr_hide.addon64` in the `bin\x64\Release Examples\` directory.

--- a/examples/18-hdr_hide/hdr_hide.vcxproj
+++ b/examples/18-hdr_hide/hdr_hide.vcxproj
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)'&gt;='16.0'">10.0</WindowsTargetPlatformVersion>
+    <ProjectName>18-hdr_hide</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='Debug'">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='Release'">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup>
+    <OutDir>..\..\bin\$(Platform)\$(Configuration) Examples\</OutDir>
+    <IntDir>..\..\intermediate\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>hdr_hide</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='Win32'">
+    <TargetExt>.addon32</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='x64'">
+    <TargetExt>.addon64</TargetExt>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;ImTextureID=ImU64;_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\include;..\..\deps\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;ImTextureID=ImU64;_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\include;..\..\deps\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;ImTextureID=ImU64;_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\include;..\..\deps\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;ImTextureID=ImU64;_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\include;..\..\deps\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="hdr_hide_addon.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/examples/18-hdr_hide/hdr_hide_addon.cpp
+++ b/examples/18-hdr_hide/hdr_hide_addon.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 ReShade Contributors
+ * SPDX-License-Identifier: BSD-3-Clause OR MIT
+ */
+
+#include <imgui.h>
+#include <reshade.hpp>
+
+static bool s_hide_hdr_when_auto_enabled = true;
+
+static bool on_check_color_space_support(reshade::api::effect_runtime *runtime, reshade::api::color_space color_space, bool *supported)
+{
+	// Only hide HDR color spaces when auto-enabled
+	if (s_hide_hdr_when_auto_enabled)
+	{
+		// Check if this is an HDR color space
+		if (color_space == reshade::api::color_space::hdr10_st2084 ||
+		    color_space == reshade::api::color_space::hdr10_hlg)
+		{
+			// Hide HDR support by setting supported to false
+			*supported = false;
+			return true; // Return true to indicate we've overridden the result
+		}
+	}
+
+	// For all other color spaces or when hiding is disabled, don't override
+	return false;
+}
+
+static void draw_settings(reshade::api::effect_runtime *)
+{
+	ImGui::Checkbox("Hide HDR when auto-enabled", &s_hide_hdr_when_auto_enabled);
+	ImGui::SetItemTooltip("When enabled, HDR color spaces (HDR10 ST2084 and HDR10 HLG) will be hidden from overlay color space support checks.\nThis prevents HDR from being automatically enabled for overlays.");
+
+	if (s_hide_hdr_when_auto_enabled)
+	{
+		ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.0f, 1.0f), "HDR color spaces are currently hidden");
+	}
+	else
+	{
+		ImGui::TextColored(ImVec4(0.0f, 0.7f, 0.0f, 1.0f), "HDR color spaces are visible");
+	}
+}
+
+extern "C" __declspec(dllexport) const char *NAME = "HDR Hide";
+extern "C" __declspec(dllexport) const char *DESCRIPTION = "Example add-on that hides HDR color space support when auto-enabled, preventing HDR from being automatically enabled for overlays.";
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
+{
+	switch (fdwReason)
+	{
+	case DLL_PROCESS_ATTACH:
+		if (!reshade::register_addon(hModule))
+			return FALSE;
+		reshade::register_event<reshade::addon_event::reshade_overlay_check_color_space_support>(on_check_color_space_support);
+		reshade::register_overlay(nullptr, draw_settings);
+		break;
+	case DLL_PROCESS_DETACH:
+		reshade::unregister_addon(hModule);
+		break;
+	}
+
+	return TRUE;
+}

--- a/examples/Examples.sln
+++ b/examples/Examples.sln
@@ -37,6 +37,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "16-swapchain_override", "16
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "17-screenshot_to_clipboard", "17-screenshot_to_clipboard\screenshot_to_clipboard.vcxproj", "{FA7C3430-EB2D-448E-B802-0976890021C1}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "18-hdr_hide", "18-hdr_hide\hdr_hide.vcxproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -165,6 +167,14 @@ Global
 		{FA7C3430-EB2D-448E-B802-0976890021C1}.Release|Win32.Build.0 = Release|Win32
 		{FA7C3430-EB2D-448E-B802-0976890021C1}.Release|x64.ActiveCfg = Release|x64
 		{FA7C3430-EB2D-448E-B802-0976890021C1}.Release|x64.Build.0 = Release|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Win32.ActiveCfg = Debug|Win32
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Win32.Build.0 = Debug|Win32
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Win32.ActiveCfg = Release|Win32
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Win32.Build.0 = Release|Win32
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.ActiveCfg = Release|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/include/reshade_events.hpp
+++ b/include/reshade_events.hpp
@@ -1787,8 +1787,18 @@ namespace reshade
 		/// </remarks>
 		reshade_overlay_technique,
 
+		/// <summary>
+		/// Called when checking overlay color space support.
+		/// Can be used to hide HDR support or modify color space behavior for overlays.
+		/// <para>Callback function signature: <c>bool (api::effect_runtime *runtime, api::color_space color_space, bool *supported)</c></para>
+		/// </summary>
+		/// <remarks>
+		/// To override the color space support result, modify <c>supported</c> and return <see langword="true"/>, otherwise return <see langword="false"/>.
+		/// </remarks>
+		reshade_overlay_check_color_space_support,
+
 #if RESHADE_ADDON
-		max = 101 // Last value used internally by ReShade to determine number of events in this enum
+		max = 102 // Last value used internally by ReShade to determine number of events in this enum
 #endif
 	};
 
@@ -1935,5 +1945,6 @@ namespace reshade
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_open_overlay, bool, api::effect_runtime *runtime, bool open, api::input_source source);
 
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_overlay_uniform_variable, bool, api::effect_runtime *runtime, api::effect_uniform_variable variable);
+	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_overlay_check_color_space_support, bool, api::effect_runtime *runtime, api::color_space color_space, bool *supported);
 	RESHADE_DEFINE_ADDON_EVENT_TRAITS(addon_event::reshade_overlay_technique, bool, api::effect_runtime *runtime, api::effect_technique technique);
 }

--- a/source/d3d11/d3d11_impl_swapchain.cpp
+++ b/source/d3d11/d3d11_impl_swapchain.cpp
@@ -43,6 +43,15 @@ bool reshade::d3d11::swapchain_impl::check_color_space_support(api::color_space 
 	if (color_space == api::color_space::unknown)
 		return false;
 
+#if RESHADE_ADDON
+	bool supported = false;
+	if (reshade::has_addon_event<reshade::addon_event::reshade_overlay_check_color_space_support>())
+	{
+		if (reshade::invoke_addon_event<reshade::addon_event::reshade_overlay_check_color_space_support>(_runtime, color_space, &supported))
+			return supported;
+	}
+#endif
+
 	com_ptr<IDXGISwapChain3> swapchain3;
 	if (FAILED(_orig->QueryInterface(&swapchain3)))
 		return color_space == api::color_space::srgb_nonlinear;

--- a/source/d3d12/d3d12_impl_swapchain.cpp
+++ b/source/d3d12/d3d12_impl_swapchain.cpp
@@ -61,6 +61,15 @@ bool reshade::d3d12::swapchain_impl::check_color_space_support(api::color_space 
 	if (color_space == api::color_space::unknown)
 		return false;
 
+#if RESHADE_ADDON
+	bool supported = false;
+	if (reshade::has_addon_event<reshade::addon_event::reshade_overlay_check_color_space_support>())
+	{
+		if (reshade::invoke_addon_event<reshade::addon_event::reshade_overlay_check_color_space_support>(_runtime, color_space, &supported))
+			return supported;
+	}
+#endif
+
 	UINT support;
 	return SUCCEEDED(_orig->CheckColorSpaceSupport(convert_color_space(color_space), &support)) && (support & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT) != 0;
 }


### PR DESCRIPTION
Adds addon event support to hide HDR color space support for overlays in DX11/DX12 games.

**Changes:**
- Add `reshade_overlay_check_color_space_support` event to allow addons to override color space support checks
- Implement event invocation in D3D11 and D3D12 swapchain implementations  
- Add example addon that hides HDR10 color spaces when auto-enabled
- Only affects DX11/DX12 as these are the only APIs supporting HDR through DXGI

**Example Addon:**
- `18-hdr_hide`: Demonstrates hiding HDR10 ST2084 and HDR10 HLG color spaces
- Provides toggle control and visual feedback in overlay
- Prevents HDR from being automatically enabled for overlays