### PR TITLE
Use undocumented D3DPOOL(6) for DX9EX Managed textures

### DIFF
--- a/source/d3d9/d3d9_device.cpp
+++ b/source/d3d9/d3d9_device.cpp
@@ -417,7 +417,7 @@ void    STDMETHODCALLTYPE Direct3DDevice9::GetGammaRamp(UINT iSwapChain, D3DGAMM
 HRESULT STDMETHODCALLTYPE Direct3DDevice9::CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture9 **ppTexture, HANDLE *pSharedHandle)
 {
 #if RESHADE_ADDON >= 2
-	modify_pool_for_d3d9ex(Usage, Pool);
+	modify_pool_for_d3d9ex(Pool);
 #endif
 
 #if RESHADE_ADDON
@@ -526,7 +526,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice9::CreateTexture(UINT Width, UINT Height
 HRESULT STDMETHODCALLTYPE Direct3DDevice9::CreateVolumeTexture(UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DVolumeTexture9 **ppVolumeTexture, HANDLE *pSharedHandle)
 {
 #if RESHADE_ADDON >= 2
-	modify_pool_for_d3d9ex(Usage, Pool);
+	modify_pool_for_d3d9ex(Pool);
 #endif
 
 #if RESHADE_ADDON
@@ -610,7 +610,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice9::CreateVolumeTexture(UINT Width, UINT 
 HRESULT STDMETHODCALLTYPE Direct3DDevice9::CreateCubeTexture(UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DCubeTexture9 **ppCubeTexture, HANDLE *pSharedHandle)
 {
 #if RESHADE_ADDON >= 2
-	modify_pool_for_d3d9ex(Usage, Pool);
+	modify_pool_for_d3d9ex(Pool);
 #endif
 
 #if RESHADE_ADDON
@@ -728,7 +728,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice9::CreateVertexBuffer(UINT Length, DWORD
 	if (_use_software_rendering)
 		Usage |= D3DUSAGE_SOFTWAREPROCESSING;
 #if RESHADE_ADDON >= 2
-	modify_pool_for_d3d9ex(Usage, Pool);
+	modify_pool_for_d3d9ex(Pool);
 #endif
 
 #if RESHADE_ADDON
@@ -782,7 +782,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice9::CreateIndexBuffer(UINT Length, DWORD 
 	if (_use_software_rendering)
 		Usage |= D3DUSAGE_SOFTWAREPROCESSING;
 #if RESHADE_ADDON >= 2
-	modify_pool_for_d3d9ex(Usage, Pool);
+	modify_pool_for_d3d9ex(Pool);
 #endif
 
 #if RESHADE_ADDON
@@ -2804,14 +2804,10 @@ void Direct3DDevice9::resize_primitive_up_buffers(UINT vertex_buffer_size, UINT 
 	}
 }
 
-void Direct3DDevice9::modify_pool_for_d3d9ex(DWORD &usage, D3DPOOL &pool) const
+void Direct3DDevice9::modify_pool_for_d3d9ex(D3DPOOL &pool) const
 {
-	if (!_extended_interface)
-		return;
-	if (pool != D3DPOOL_MANAGED)
-		return;
-
-	pool = D3DPOOL_DEFAULT;
-	usage |= D3DUSAGE_DYNAMIC;
+	if (_extended_interface && pool == D3DPOOL_MANAGED) {
+		pool = D3DPOOL_MANAGED_EX;
+	}
 }
 #endif

--- a/source/d3d9/d3d9_device.hpp
+++ b/source/d3d9/d3d9_device.hpp
@@ -168,7 +168,7 @@ struct DECLSPEC_UUID("F1006E9A-1C51-4AF4-ACEF-3605D2D4C8EE") Direct3DDevice9 fin
 #if RESHADE_ADDON >= 2
 	void resize_primitive_up_buffers(UINT vertex_buffer_size, UINT index_buffer_size, UINT index_size);
 
-	void modify_pool_for_d3d9ex(DWORD &usage, D3DPOOL &pool) const;
+	void modify_pool_for_d3d9ex(D3DPOOL &pool) const;
 #endif
 
 	bool check_and_upgrade_interface(REFIID riid);

--- a/source/d3d9/d3d9_impl_command_list.cpp
+++ b/source/d3d9/d3d9_impl_command_list.cpp
@@ -683,7 +683,7 @@ void reshade::d3d9::device_impl::copy_texture_region(api::resource src, uint32_t
 				}
 			}
 
-			assert(dst_desc.Pool == D3DPOOL_DEFAULT && (src_desc.Pool == D3DPOOL_DEFAULT || src_desc.Pool == D3DPOOL_MANAGED));
+			assert(dst_desc.Pool == D3DPOOL_DEFAULT && (src_desc.Pool == D3DPOOL_DEFAULT || src_desc.Pool == D3DPOOL_MANAGED || src_desc.Pool == D3DPOOL_MANAGED_EX));
 
 			if (_copy_state == nullptr)
 				return;

--- a/source/d3d9/d3d9_impl_type_convert.cpp
+++ b/source/d3d9/d3d9_impl_type_convert.cpp
@@ -377,6 +377,7 @@ void reshade::d3d9::convert_d3d_pool_to_memory_heap(D3DPOOL d3d_pool, api::memor
 		heap = api::memory_heap::gpu_only;
 		break;
 	case D3DPOOL_MANAGED:
+	case D3DPOOL_MANAGED_EX:
 		heap = api::memory_heap::unknown;
 		break;
 	case D3DPOOL_SYSTEMMEM:
@@ -488,7 +489,7 @@ void reshade::d3d9::convert_resource_desc(const api::resource_desc &desc, D3DVOL
 
 	assert(desc.texture.samples == 1);
 
-	if (internal_desc.Pool != D3DPOOL_MANAGED)
+	if (internal_desc.Pool != D3DPOOL_MANAGED && internal_desc.Pool != D3DPOOL_MANAGED_EX)
 	{
 		convert_memory_heap_to_d3d_pool(desc.heap, internal_desc.Pool);
 		// Volume textures cannot have render target or depth-stencil usage, so do not call 'convert_resource_usage_to_d3d_usage'
@@ -541,7 +542,7 @@ void reshade::d3d9::convert_resource_desc(const api::resource_desc &desc, D3DSUR
 		internal_desc.MultiSampleQuality = 0;
 	}
 
-	if (internal_desc.Pool != D3DPOOL_MANAGED)
+	if (internal_desc.Pool != D3DPOOL_MANAGED && internal_desc.Pool != D3DPOOL_MANAGED_EX)
 	{
 		convert_memory_heap_to_d3d_pool(desc.heap, internal_desc.Pool);
 		// System memory textures cannot have render target or depth-stencil usage
@@ -604,7 +605,7 @@ void reshade::d3d9::convert_resource_desc(const api::resource_desc &desc, D3DIND
 
 	assert((desc.usage & (api::resource_usage::vertex_buffer | api::resource_usage::index_buffer)) == api::resource_usage::index_buffer);
 
-	if (internal_desc.Pool != D3DPOOL_MANAGED)
+	if (internal_desc.Pool != D3DPOOL_MANAGED && internal_desc.Pool != D3DPOOL_MANAGED_EX)
 	{
 		if (desc.heap == api::memory_heap::gpu_to_cpu)
 		{
@@ -639,7 +640,7 @@ void reshade::d3d9::convert_resource_desc(const api::resource_desc &desc, D3DVER
 
 	assert((desc.usage & (api::resource_usage::vertex_buffer | api::resource_usage::index_buffer)) == api::resource_usage::vertex_buffer);
 
-	if (internal_desc.Pool != D3DPOOL_MANAGED)
+	if (internal_desc.Pool != D3DPOOL_MANAGED && internal_desc.Pool != D3DPOOL_MANAGED_EX)
 	{
 		if (desc.heap == api::memory_heap::gpu_to_cpu)
 		{
@@ -717,7 +718,7 @@ reshade::api::resource_desc reshade::d3d9::convert_resource_desc(const D3DSURFAC
 		desc.heap = api::memory_heap::cpu_to_gpu;
 
 	convert_d3d_usage_to_resource_usage(internal_desc.Usage, desc.usage);
-	if ((internal_desc.Type == D3DRTYPE_TEXTURE || internal_desc.Type == D3DRTYPE_CUBETEXTURE) && (internal_desc.Pool == D3DPOOL_DEFAULT || internal_desc.Pool == D3DPOOL_MANAGED || (internal_desc.Pool == D3DPOOL_SYSTEMMEM && (caps.DevCaps & D3DDEVCAPS_TEXTURESYSTEMMEMORY) != 0)))
+	if ((internal_desc.Type == D3DRTYPE_TEXTURE || internal_desc.Type == D3DRTYPE_CUBETEXTURE) && (internal_desc.Pool == D3DPOOL_DEFAULT || internal_desc.Pool == D3DPOOL_MANAGED || internal_desc.Pool == D3DPOOL_MANAGED_EX || (internal_desc.Pool == D3DPOOL_SYSTEMMEM && (caps.DevCaps & D3DDEVCAPS_TEXTURESYSTEMMEMORY) != 0)))
 	{
 		switch (static_cast<DWORD>(internal_desc.Format))
 		{

--- a/source/d3d9/d3d9_impl_type_convert.hpp
+++ b/source/d3d9/d3d9_impl_type_convert.hpp
@@ -11,6 +11,9 @@
 #include <vector>
 #include <limits>
 
+// Undocumented
+const D3DPOOL D3DPOOL_MANAGED_EX = D3DPOOL(6);
+
 namespace reshade::d3d9
 {
 	static_assert(sizeof(D3DBOX) == sizeof(api::subresource_box));


### PR DESCRIPTION
References: https://github.com/doitsujin/dxvk/blob/8bd72bb2be83d2974c097cfa978b0aade474769d/src/d3d9/d3d9_include.h#L58

https://www.unknowncheats.me/forum/direct3d/179050-fixing-d3dxcreatetexturefromfileinmemory-returning-d3derr_invalidcall.html