### PR TITLE
Fix Mesh Shader Pipelines

### DIFF
--- a/source/d3d12/d3d12_impl_device.cpp
+++ b/source/d3d12/d3d12_impl_device.cpp
@@ -1214,8 +1214,9 @@ bool reshade::d3d12::device_impl::create_pipeline(api::pipeline_layout layout, u
 			struct
 			{
 				D3D12_PIPELINE_STATE_STREAM_ROOT_SIGNATURE root_signature;
-				D3D12_PIPELINE_STATE_STREAM_MS as;
+				D3D12_PIPELINE_STATE_STREAM_AS as;
 				D3D12_PIPELINE_STATE_STREAM_MS ms;
+				D3D12_PIPELINE_STATE_STREAM_PS ps;
 				D3D12_PIPELINE_STATE_STREAM_BLEND_DESC blend_state;
 				D3D12_PIPELINE_STATE_STREAM_SAMPLE_MASK sample_mask;
 				D3D12_PIPELINE_STATE_STREAM_RASTERIZER rasterizer_state;
@@ -1231,6 +1232,8 @@ bool reshade::d3d12::device_impl::create_pipeline(api::pipeline_layout layout, u
 			reshade::d3d12::convert_shader_desc(as_desc, stream_data.as.data);
 			stream_data.ms.type = D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_MS;
 			reshade::d3d12::convert_shader_desc(ms_desc, stream_data.ms.data);
+			stream_data.ps.type = D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_PS;
+			reshade::d3d12::convert_shader_desc(ps_desc, stream_data.ps.data);
 			stream_data.blend_state.type = D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_BLEND;
 			reshade::d3d12::convert_blend_desc(blend_desc, stream_data.blend_state.data);
 			stream_data.sample_mask.type = D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_MASK;
@@ -1250,7 +1253,7 @@ bool reshade::d3d12::device_impl::create_pipeline(api::pipeline_layout layout, u
 
 			D3D12_PIPELINE_STATE_STREAM_DESC stream_desc;
 			stream_desc.pPipelineStateSubobjectStream = &stream_data;
-			stream_desc.SizeInBytes = sizeof(stream_desc);
+			stream_desc.SizeInBytes = sizeof(stream_data);
 
 			if (com_ptr<ID3D12PipelineState> pipeline;
 				SUCCEEDED(device2->CreatePipelineState(&stream_desc, IID_PPV_ARGS(&pipeline))))


### PR DESCRIPTION
I am working on RenoDX and was attempting to use the pipeline to replace mesh shaders, but it would always fail. The root cause turned out to be a shader pipeline issue in ReShade. With these changes, mesh shader replacement now functions as expected.

1. The stream struct was missing the pixel shader entirely. A mesh shader pipeline (AS + MS + PS) needs all three stages, but the struct only had AS and MS. The ps_desc was parsed from the subobjects but never written into the stream. Added D3D12_PIPELINE_STATE_STREAM_PS ps to the struct and the corresponding initialization.

2. The AS member was declared as D3D12_PIPELINE_STATE_STREAM_MS instead of D3D12_PIPELINE_STATE_STREAM_AS. Works by accident since both wrap D3D12_SHADER_BYTECODE and the type field is set explicitly, but it's wrong. Fixed the type.

3. stream_desc.SizeInBytes was set to sizeof(stream_desc) (16 bytes — the size of the descriptor struct itself) instead of sizeof(stream_data) (the actual stream blob). D3D12 would only read the first 16 bytes, which is just the root signature, and miss all other pipeline state. Fixed to sizeof(stream_data).