### PR TITLE
Export and forward DXGI's DXGIDisableVBlankVirtualization function

### DIFF
--- a/res/exports.def
+++ b/res/exports.def
@@ -85,6 +85,7 @@ EXPORTS
 
 	CompatValue PRIVATE
 	CompatString PRIVATE
+	DXGIDisableVBlankVirtualization PRIVATE
 	DXGIDumpJournal PRIVATE
 	DXGIDeclareAdapterRemovalSupport PRIVATE
 	DXGIGetDebugInterface1 PRIVATE

--- a/source/dxgi/dxgi_d3d10.cpp
+++ b/source/dxgi/dxgi_d3d10.cpp
@@ -34,6 +34,18 @@ extern "C" BOOL    WINAPI CompatString(LPCSTR szName, ULONG *pSize, LPSTR lpData
 		return FALSE;
 }
 
+extern "C" HRESULT WINAPI DXGIDisableVBlankVirtualization()
+{
+	reshade::hooks::ensure_export_module_loaded();
+	assert(g_export_module_handle != nullptr);
+
+	const FARPROC proc = GetProcAddress(g_export_module_handle, "DXGIDisableVBlankVirtualization");
+	if (proc != nullptr)
+		return reinterpret_cast<decltype(&DXGIDisableVBlankVirtualization)>(proc)();
+	else
+		return E_NOTIMPL;
+}
+
 extern "C" HRESULT WINAPI DXGIDumpJournal(void *pfnCallback)
 {
 	reshade::hooks::ensure_export_module_loaded();

--- a/source/hook_manager.cpp
+++ b/source/hook_manager.cpp
@@ -177,6 +177,7 @@ static bool install_internal(HMODULE target_module, HMODULE replacement_module, 
 		if (it != replacement_exports.cend() &&
 			std::strcmp(symbol.name, "CompatValue") != 0 &&
 			std::strcmp(symbol.name, "CompatString") != 0 &&
+			std::strcmp(symbol.name, "DXGIDisableVBlankVirtualization") != 0 &&
 			std::strcmp(symbol.name, "DXGIDumpJournal") != 0 &&
 			std::strcmp(symbol.name, "DXGIReportAdapterConfiguration") != 0 &&
 			std::strcmp(symbol.name, "DXGID3D10CreateDevice") != 0 &&


### PR DESCRIPTION
As the title says. Windows 11 [introduced the API](https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_6/nf-dxgi1_6-dxgidisablevblankvirtualization) and some Chromium applications [have begun using it](https://source.chromium.org/chromium/chromium/src/+/main:ui/gl/direct_composition_support.cc;l=783?q=DXGIDisableVBLankVirtualization&ss=chromium).