### PR TITLE
Add support for `partially_bound` descriptor range flag

### DIFF
--- a/include/reshade_api_pipeline.hpp
+++ b/include/reshade_api_pipeline.hpp
@@ -131,6 +131,7 @@ namespace reshade::api
 		data_volatile = 0x2,
 		data_static_while_set_at_execute = 0x4,
 		data_static = 0x8,
+		partially_bound = 0x10,
 	};
 	RESHADE_DEFINE_ENUM_FLAG_OPERATORS(descriptor_range_flags);
 

--- a/source/vulkan/vulkan_hooks_device.cpp
+++ b/source/vulkan/vulkan_hooks_device.cpp
@@ -340,6 +340,23 @@ VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDevi
 	}
 	else
 	{
+#if VK_EXT_descriptor_indexing
+		if (const auto existing_descriptor_indexing_features = find_in_structure_chain<VkPhysicalDeviceDescriptorIndexingFeatures>(
+				pCreateInfo->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES))
+		{
+			descriptor_indexing_ext = existing_descriptor_indexing_features->descriptorBindingPartiallyBound ||
+				existing_descriptor_indexing_features->descriptorBindingUniformBufferUpdateAfterBind ||
+				existing_descriptor_indexing_features->descriptorBindingSampledImageUpdateAfterBind ||
+				existing_descriptor_indexing_features->descriptorBindingStorageImageUpdateAfterBind ||
+				existing_descriptor_indexing_features->descriptorBindingStorageBufferUpdateAfterBind ||
+				existing_descriptor_indexing_features->descriptorBindingUniformTexelBufferUpdateAfterBind ||
+				existing_descriptor_indexing_features->descriptorBindingStorageTexelBufferUpdateAfterBind ||
+				existing_descriptor_indexing_features->descriptorBindingUpdateUnusedWhilePending ||
+				existing_descriptor_indexing_features->descriptorBindingVariableDescriptorCount ||
+				existing_descriptor_indexing_features->runtimeDescriptorArray;
+		}
+#endif
+
 		if (const auto existing_buffer_device_address_features = find_in_structure_chain<VkPhysicalDeviceBufferDeviceAddressFeatures>(
 				pCreateInfo->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES))
 		{
@@ -2013,9 +2030,9 @@ VkResult VKAPI_CALL vkCreatePipelineLayout(VkDevice device, const VkPipelineLayo
 	}
 
 #if RESHADE_ADDON >= 2
-	reshade::vulkan::object_data<VK_OBJECT_TYPE_PIPELINE_LAYOUT> &data = *device_impl->register_object<VK_OBJECT_TYPE_PIPELINE_LAYOUT>(*pPipelineLayout);
-	data.set_layouts.assign(pCreateInfo->pSetLayouts, pCreateInfo->pSetLayouts + pCreateInfo->setLayoutCount);
-	data.owns_set_layouts = false;
+		reshade::vulkan::object_data<VK_OBJECT_TYPE_PIPELINE_LAYOUT> &data = *device_impl->register_object<VK_OBJECT_TYPE_PIPELINE_LAYOUT>(*pPipelineLayout);
+		data.set_layouts.assign(pCreateInfo->pSetLayouts, pCreateInfo->pSetLayouts + pCreateInfo->setLayoutCount);
+		data.owns_set_layouts = false;
 
 	reshade::invoke_addon_event<reshade::addon_event::init_pipeline_layout>(device_impl, param_count, param_data, reshade::api::pipeline_layout { (uint64_t)*pPipelineLayout });
 #endif

--- a/source/vulkan/vulkan_hooks_device.cpp
+++ b/source/vulkan/vulkan_hooks_device.cpp
@@ -2030,9 +2030,9 @@ VkResult VKAPI_CALL vkCreatePipelineLayout(VkDevice device, const VkPipelineLayo
 	}
 
 #if RESHADE_ADDON >= 2
-		reshade::vulkan::object_data<VK_OBJECT_TYPE_PIPELINE_LAYOUT> &data = *device_impl->register_object<VK_OBJECT_TYPE_PIPELINE_LAYOUT>(*pPipelineLayout);
-		data.set_layouts.assign(pCreateInfo->pSetLayouts, pCreateInfo->pSetLayouts + pCreateInfo->setLayoutCount);
-		data.owns_set_layouts = false;
+	reshade::vulkan::object_data<VK_OBJECT_TYPE_PIPELINE_LAYOUT> &data = *device_impl->register_object<VK_OBJECT_TYPE_PIPELINE_LAYOUT>(*pPipelineLayout);
+	data.set_layouts.assign(pCreateInfo->pSetLayouts, pCreateInfo->pSetLayouts + pCreateInfo->setLayoutCount);
+	data.owns_set_layouts = false;
 
 	reshade::invoke_addon_event<reshade::addon_event::init_pipeline_layout>(device_impl, param_count, param_data, reshade::api::pipeline_layout { (uint64_t)*pPipelineLayout });
 #endif

--- a/source/vulkan/vulkan_impl_type_convert.cpp
+++ b/source/vulkan/vulkan_impl_type_convert.cpp
@@ -2411,6 +2411,8 @@ auto reshade::vulkan::convert_descriptor_range_flags(api::descriptor_range_flags
 		result |= VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT;
 	if ((value & api::descriptor_range_flags::data_static_while_set_at_execute) != 0)
 		result |= VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT;
+	if ((value & api::descriptor_range_flags::partially_bound) != 0)
+		result |= VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
 
 	return result;
 }
@@ -2421,6 +2423,8 @@ auto reshade::vulkan::convert_descriptor_range_flags(VkDescriptorBindingFlags va
 		result |= api::descriptor_range_flags::descriptors_volatile | api::descriptor_range_flags::data_volatile;
 	if ((value & VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT) != 0)
 		result |= api::descriptor_range_flags::data_static_while_set_at_execute;
+	if ((value & VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT) != 0)
+		result |= api::descriptor_range_flags::partially_bound;
 
 	return result;
 }


### PR DESCRIPTION
BG3 crashes if an addon registers create_pipeline_layout event without these (Because it creates pipeline through reshade's function)