### PR TITLE
Enable support for push descriptors in Vulkan 1.4 when available.

### DIFF
--- a/source/vulkan/vulkan_hooks_device.cpp
+++ b/source/vulkan/vulkan_hooks_device.cpp
@@ -450,16 +450,35 @@ VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDevi
 	}
 
 	VkPhysicalDeviceHostImageCopyFeatures host_image_copy_features;
+	VkPhysicalDeviceVulkan14Features vulkan_14_features;
+	if (instance.api_version >= VK_API_VERSION_1_4)
+	{
+		VkPhysicalDeviceVulkan14Features supported_vulkan_14_features { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES };
+		VkPhysicalDeviceFeatures2 supported_features { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &supported_vulkan_14_features };
+		instance.dispatch_table.GetPhysicalDeviceFeatures2(physicalDevice, &supported_features);
+
+		push_descriptor_ext = supported_vulkan_14_features.pushDescriptor;
+	}
 	if (const auto existing_vulkan_14_features = find_in_structure_chain<VkPhysicalDeviceVulkan14Features>(
 			pCreateInfo->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES))
 	{
 		assert(instance.api_version >= VK_API_VERSION_1_4);
 
-		push_descriptor_ext = existing_vulkan_14_features->pushDescriptor;
+		if (push_descriptor_ext) {
+			const_cast<VkPhysicalDeviceVulkan14Features *>(existing_vulkan_14_features)->pushDescriptor = VK_TRUE;
+		}
 		host_image_copy_ext = existing_vulkan_14_features->hostImageCopy;
 	}
 	else
 	{
+		if (instance.api_version >= VK_API_VERSION_1_4 && push_descriptor_ext)
+		{
+			vulkan_14_features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES, const_cast<void *>(create_info.pNext) };
+			vulkan_14_features.pushDescriptor = VK_TRUE;
+
+			create_info.pNext = &vulkan_14_features;
+		}
+
 		if (const auto existing_host_image_copy_features = find_in_structure_chain<VkPhysicalDeviceHostImageCopyFeatures>(
 				pCreateInfo->pNext, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES))
 		{


### PR DESCRIPTION
ShadPS4 uses Vulkan 1.4 but enables push descriptors through the extension, not VkPhysicalDeviceVulkan14Features. The PR forces it in either case.