### PR TITLE
Proxy vkd3d device extension interfaces

### DIFF
--- a/source/d3d12/d3d12_device.cpp
+++ b/source/d3d12/d3d12_device.cpp
@@ -122,7 +122,7 @@ HRESULT STDMETHODCALLTYPE D3D12Device::QueryInterface(REFIID riid, void **ppvObj
 	}
 
 #if RESHADE_ADDON >= 2
-	// Hook vkd3d device extension interfaces if they exist, to properly convert descriptor handles
+	// Proxy vkd3d device extension interfaces queried through the ReShade device, so that native callers remain untouched
 	if (riid == IID_ID3D12DeviceExt ||
 		riid == IID_ID3D12DeviceExt1 ||
 		riid == IID_ID3D12DeviceExt2 ||
@@ -130,21 +130,10 @@ HRESULT STDMETHODCALLTYPE D3D12Device::QueryInterface(REFIID riid, void **ppvObj
 		riid == IID_ID3D12DeviceExt4 ||
 		riid == IID_ID3D12DeviceExt5)
 	{
-		const HRESULT hr = _orig->QueryInterface(riid, ppvObj);
-		if (SUCCEEDED(hr))
-		{
-			const auto device_ext = static_cast<IUnknown *>(*ppvObj);
+		if (_device_ext == nullptr)
+			_device_ext = new D3D12DeviceExt(this);
 
-			reshade::hooks::install("ID3D12DeviceExt::GetCudaTextureObject", reshade::hooks::vtable_from_instance(device_ext), 7, &ID3D12DeviceExt_GetCudaTextureObject);
-			reshade::hooks::install("ID3D12DeviceExt::GetCudaSurfaceObject", reshade::hooks::vtable_from_instance(device_ext), 8, &ID3D12DeviceExt_GetCudaSurfaceObject);
-
-			if (riid != IID_ID3D12DeviceExt && riid != IID_ID3D12DeviceExt1)
-			{
-				reshade::hooks::install("ID3D12DeviceExt2::GetCudaTextureObject", reshade::hooks::vtable_from_instance(device_ext), 14, &ID3D12DeviceExt2_GetCudaMergedTextureSamplerObject);
-				reshade::hooks::install("ID3D12DeviceExt2::GetCudaSurfaceObject", reshade::hooks::vtable_from_instance(device_ext), 15, &ID3D12DeviceExt2_GetCudaIndependentDescriptorObject);
-			}
-		}
-		return hr;
+		return _device_ext->QueryInterface(riid, ppvObj);
 	}
 #endif
 
@@ -188,6 +177,11 @@ ULONG   STDMETHODCALLTYPE D3D12Device::Release()
 		_orig->Release();
 		return ref;
 	}
+
+#if RESHADE_ADDON >= 2
+	if (_device_ext != nullptr)
+		delete _device_ext;
+#endif
 
 	if (_downlevel != nullptr)
 	{

--- a/source/d3d12/d3d12_device.hpp
+++ b/source/d3d12/d3d12_device.hpp
@@ -8,6 +8,7 @@
 #include "d3d12_impl_device.hpp"
 
 class D3D12DeviceDownlevel;
+class D3D12DeviceExt;
 
 class DECLSPEC_UUID("2523AFF4-978B-4939-BA16-8EE876A4CB2A") D3D12Device final : public ID3D12Device15, public reshade::d3d12::device_impl
 {
@@ -166,5 +167,8 @@ public:
 	unsigned short _interface_version = 0;
 
 private:
+#if RESHADE_ADDON >= 2
+	D3D12DeviceExt *_device_ext = nullptr;
+#endif
 	D3D12DeviceDownlevel *_downlevel = nullptr;
 };

--- a/source/d3d12/d3d12_extensions.cpp
+++ b/source/d3d12/d3d12_extensions.cpp
@@ -7,65 +7,200 @@
 
 #include "d3d12_device.hpp"
 #include "d3d12_extensions.hpp"
-#include "com_utils.hpp"
-#include "hook_manager.hpp"
+#include "d3d12_impl_type_convert.hpp"
+#include <cstddef>
 
-HRESULT ID3D12DeviceExt_GetCudaTextureObject(IUnknown *device_ext, D3D12_CPU_DESCRIPTOR_HANDLE srv_handle, D3D12_CPU_DESCRIPTOR_HANDLE sampler_handle, UINT32 *cuda_texture_handle)
+namespace
 {
-	com_ptr<ID3D12Device> device;
-	device_ext->QueryInterface(IID_PPV_ARGS(&device));
-	assert(device != nullptr);
-
-	if (const auto device_proxy = get_private_pointer_d3dx<D3D12Device>(device.get()))
+	template <typename T>
+	T get_vtable_entry(IUnknown *object, std::size_t index)
 	{
-		srv_handle = device_proxy->convert_to_original_cpu_descriptor_handle(srv_handle);
-		sampler_handle = device_proxy->convert_to_original_cpu_descriptor_handle(sampler_handle);
+		return reinterpret_cast<T>((*reinterpret_cast<void ***>(object))[index]);
 	}
-
-	return reshade::hooks::call(ID3D12DeviceExt_GetCudaTextureObject, reshade::hooks::vtable_from_instance(device_ext) + 7)(device_ext, srv_handle, sampler_handle, cuda_texture_handle);
 }
 
-HRESULT ID3D12DeviceExt_GetCudaSurfaceObject(IUnknown *device_ext, D3D12_CPU_DESCRIPTOR_HANDLE uav_handle, UINT32 *cuda_surface_handle)
+D3D12DeviceExt::D3D12DeviceExt(D3D12Device *device) :
+	_parent_device(device)
 {
-	com_ptr<ID3D12Device> device;
-	device_ext->QueryInterface(IID_PPV_ARGS(&device));
-	assert(device != nullptr);
-
-	if (const auto device_proxy = get_private_pointer_d3dx<D3D12Device>(device.get()))
-	{
-		uav_handle = device_proxy->convert_to_original_cpu_descriptor_handle(uav_handle);
-	}
-
-	return reshade::hooks::call(ID3D12DeviceExt_GetCudaSurfaceObject, reshade::hooks::vtable_from_instance(device_ext) + 8)(device_ext, uav_handle, cuda_surface_handle);
+	assert(_parent_device != nullptr);
+}
+D3D12DeviceExt::~D3D12DeviceExt()
+{
+	if (_orig != nullptr)
+		_orig->Release();
 }
 
-HRESULT ID3D12DeviceExt2_GetCudaMergedTextureSamplerObject(IUnknown *device_ext, D3D12_GET_CUDA_MERGED_TEXTURE_SAMPLER_OBJECT_PARAMS *params)
+HRESULT D3D12DeviceExt::check_and_upgrade_interface(REFIID riid)
 {
-	com_ptr<ID3D12Device> device;
-	device_ext->QueryInterface(IID_PPV_ARGS(&device));
-	assert(device != nullptr);
+	static constexpr IID iid_lookup[] = {
+		IID_ID3D12DeviceExt,
+		IID_ID3D12DeviceExt1,
+		IID_ID3D12DeviceExt2,
+		IID_ID3D12DeviceExt3,
+		IID_ID3D12DeviceExt4,
+		IID_ID3D12DeviceExt5,
+	};
 
-	if (const auto device_proxy = get_private_pointer_d3dx<D3D12Device>(device.get()))
+	for (unsigned short version = 0; version < sizeof(iid_lookup) / sizeof(iid_lookup[0]); ++version)
 	{
-		params->texDesc = device_proxy->convert_to_original_cpu_descriptor_handle(params->texDesc);
-		params->smpDesc = device_proxy->convert_to_original_cpu_descriptor_handle(params->smpDesc);
+		if (riid != iid_lookup[version])
+			continue;
+
+		if (_orig == nullptr || version > _interface_version)
+		{
+			IUnknown *new_interface = nullptr;
+			const HRESULT hr = _parent_device->_orig->QueryInterface(riid, reinterpret_cast<void **>(&new_interface));
+			if (FAILED(hr))
+				return hr;
+
+			if (_orig != nullptr)
+				_orig->Release();
+
+			_orig = new_interface;
+			_interface_version = version;
+		}
+
+		return S_OK;
 	}
 
-	return reshade::hooks::call(ID3D12DeviceExt2_GetCudaMergedTextureSamplerObject, reshade::hooks::vtable_from_instance(device_ext) + 14)(device_ext, params);
+	return E_NOINTERFACE;
 }
 
-HRESULT ID3D12DeviceExt2_GetCudaIndependentDescriptorObject(IUnknown *device_ext, D3D12_GET_CUDA_INDEPENDENT_DESCRIPTOR_OBJECT_PARAMS *params)
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::QueryInterface(REFIID riid, void **ppvObj)
 {
-	com_ptr<ID3D12Device> device;
-	device_ext->QueryInterface(IID_PPV_ARGS(&device));
-	assert(device != nullptr);
+	if (ppvObj == nullptr)
+		return E_POINTER;
 
-	if (const auto device_proxy = get_private_pointer_d3dx<D3D12Device>(device.get()))
+	if (riid == IID_ID3D12DeviceExt ||
+		riid == IID_ID3D12DeviceExt1 ||
+		riid == IID_ID3D12DeviceExt2 ||
+		riid == IID_ID3D12DeviceExt3 ||
+		riid == IID_ID3D12DeviceExt4 ||
+		riid == IID_ID3D12DeviceExt5)
 	{
-		params->desc = device_proxy->convert_to_original_cpu_descriptor_handle(params->desc);
+		const HRESULT hr = check_and_upgrade_interface(riid);
+		if (FAILED(hr))
+		{
+			*ppvObj = nullptr;
+			return hr;
+		}
+
+		AddRef();
+		*ppvObj = this;
+		return S_OK;
 	}
 
-	return reshade::hooks::call(ID3D12DeviceExt2_GetCudaIndependentDescriptorObject, reshade::hooks::vtable_from_instance(device_ext) + 15)(device_ext, params);
+	// Preserve the identity of the parent D3D12 device proxy for IUnknown and all other interfaces.
+	return _parent_device->QueryInterface(riid, ppvObj);
+}
+ULONG STDMETHODCALLTYPE D3D12DeviceExt::AddRef()
+{
+	return _parent_device->AddRef();
+}
+ULONG STDMETHODCALLTYPE D3D12DeviceExt::Release()
+{
+	return _parent_device->Release();
+}
+
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::GetVulkanHandles(void *vk_instance, void *vk_physical_device, void *vk_device)
+{
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, void *, void *, void *);
+	return get_vtable_entry<function_type>(_orig, 3)(_orig, vk_instance, vk_physical_device, vk_device);
+}
+BOOL STDMETHODCALLTYPE D3D12DeviceExt::GetExtensionSupport(UINT extension)
+{
+	using function_type = BOOL (STDMETHODCALLTYPE *)(IUnknown *, UINT);
+	return get_vtable_entry<function_type>(_orig, 4)(_orig, extension);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::CreateCubinComputeShaderWithName(const void *cubin_data, UINT32 cubin_size, UINT32 block_x, UINT32 block_y, UINT32 block_z, const char *shader_name, void **handle)
+{
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, const void *, UINT32, UINT32, UINT32, UINT32, const char *, void **);
+	return get_vtable_entry<function_type>(_orig, 5)(_orig, cubin_data, cubin_size, block_x, block_y, block_z, shader_name, handle);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::DestroyCubinComputeShader(void *handle)
+{
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, void *);
+	return get_vtable_entry<function_type>(_orig, 6)(_orig, handle);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::GetCudaTextureObject(D3D12_CPU_DESCRIPTOR_HANDLE srv_handle, D3D12_CPU_DESCRIPTOR_HANDLE sampler_handle, UINT32 *cuda_texture_handle)
+{
+	srv_handle = _parent_device->convert_to_original_cpu_descriptor_handle(srv_handle);
+	sampler_handle = _parent_device->convert_to_original_cpu_descriptor_handle(sampler_handle);
+
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, D3D12_CPU_DESCRIPTOR_HANDLE, D3D12_CPU_DESCRIPTOR_HANDLE, UINT32 *);
+	return get_vtable_entry<function_type>(_orig, 7)(_orig, srv_handle, sampler_handle, cuda_texture_handle);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::GetCudaSurfaceObject(D3D12_CPU_DESCRIPTOR_HANDLE uav_handle, UINT32 *cuda_surface_handle)
+{
+	uav_handle = _parent_device->convert_to_original_cpu_descriptor_handle(uav_handle);
+
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, D3D12_CPU_DESCRIPTOR_HANDLE, UINT32 *);
+	return get_vtable_entry<function_type>(_orig, 8)(_orig, uav_handle, cuda_surface_handle);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::CaptureUAVInfo(void *uav_info)
+{
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, void *);
+	return get_vtable_entry<function_type>(_orig, 9)(_orig, uav_info);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::CreateResourceFromBorrowedHandle(const D3D12_RESOURCE_DESC1 *desc, UINT64 vk_handle, ID3D12Resource **resource)
+{
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, const D3D12_RESOURCE_DESC1 *, UINT64, ID3D12Resource **);
+	return get_vtable_entry<function_type>(_orig, 10)(_orig, desc, vk_handle, resource);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::GetVulkanQueueInfoEx(ID3D12CommandQueue *queue, void *vk_queue, UINT32 *vk_queue_index, UINT32 *vk_queue_flags, UINT32 *vk_queue_family)
+{
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, ID3D12CommandQueue *, void *, UINT32 *, UINT32 *, UINT32 *);
+	return get_vtable_entry<function_type>(_orig, 11)(_orig, queue, vk_queue, vk_queue_index, vk_queue_flags, vk_queue_family);
+}
+BOOL STDMETHODCALLTYPE D3D12DeviceExt::SupportsCubin64bit()
+{
+	using function_type = BOOL (STDMETHODCALLTYPE *)(IUnknown *);
+	return get_vtable_entry<function_type>(_orig, 12)(_orig);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::CreateCubinComputeShaderExV2(void *params)
+{
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, void *);
+	return get_vtable_entry<function_type>(_orig, 13)(_orig, params);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::GetCudaMergedTextureSamplerObject(D3D12_GET_CUDA_MERGED_TEXTURE_SAMPLER_OBJECT_PARAMS *params)
+{
+	params->texDesc = _parent_device->convert_to_original_cpu_descriptor_handle(params->texDesc);
+	params->smpDesc = _parent_device->convert_to_original_cpu_descriptor_handle(params->smpDesc);
+
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, D3D12_GET_CUDA_MERGED_TEXTURE_SAMPLER_OBJECT_PARAMS *);
+	return get_vtable_entry<function_type>(_orig, 14)(_orig, params);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::GetCudaIndependentDescriptorObject(D3D12_GET_CUDA_INDEPENDENT_DESCRIPTOR_OBJECT_PARAMS *params)
+{
+	params->desc = _parent_device->convert_to_original_cpu_descriptor_handle(params->desc);
+
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, D3D12_GET_CUDA_INDEPENDENT_DESCRIPTOR_OBJECT_PARAMS *);
+	return get_vtable_entry<function_type>(_orig, 15)(_orig, params);
+}
+BOOL STDMETHODCALLTYPE D3D12DeviceExt::SupportsAGSExtension(UINT ags_extension)
+{
+	using function_type = BOOL (STDMETHODCALLTYPE *)(IUnknown *, UINT);
+	return get_vtable_entry<function_type>(_orig, 16)(_orig, ags_extension);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::SetAGSUAVSlot(UINT uav_slot)
+{
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, UINT);
+	return get_vtable_entry<function_type>(_orig, 17)(_orig, uav_slot);
+}
+BOOL STDMETHODCALLTYPE D3D12DeviceExt::IsNvShaderExtnOpCodeSupported(UINT32 op_code)
+{
+	using function_type = BOOL (STDMETHODCALLTYPE *)(IUnknown *, UINT32);
+	return get_vtable_entry<function_type>(_orig, 18)(_orig, op_code);
+}
+HRESULT STDMETHODCALLTYPE D3D12DeviceExt::SetNvShaderExtnSlotSpace(UINT32 uav_slot, UINT32 uav_space, BOOL local_thread)
+{
+	using function_type = HRESULT (STDMETHODCALLTYPE *)(IUnknown *, UINT32, UINT32, BOOL);
+	return get_vtable_entry<function_type>(_orig, 19)(_orig, uav_slot, uav_space, local_thread);
+}
+BOOL STDMETHODCALLTYPE D3D12DeviceExt::SetCreatePipelineStateFlagsNVAPI(UINT pipeline_state_flags)
+{
+	using function_type = BOOL (STDMETHODCALLTYPE *)(IUnknown *, UINT);
+	return get_vtable_entry<function_type>(_orig, 20)(_orig, pipeline_state_flags);
 }
 
 #endif

--- a/source/d3d12/d3d12_extensions.hpp
+++ b/source/d3d12/d3d12_extensions.hpp
@@ -7,6 +7,8 @@
 
 #if RESHADE_ADDON >= 2
 
+class D3D12Device;
+
 struct D3D12_GET_CUDA_MERGED_TEXTURE_SAMPLER_OBJECT_PARAMS
 {
 	void *pNext;
@@ -23,11 +25,52 @@ struct D3D12_GET_CUDA_INDEPENDENT_DESCRIPTOR_OBJECT_PARAMS
 	UINT64 handle;
 };
 
+// ABI-compatible proxy for the vkd3d-proton ID3D12DeviceExt interface family.
 // See https://github.com/HansKristian-Work/vkd3d-proton/blob/master/include/vkd3d_device_vkd3d_ext.idl
-HRESULT ID3D12DeviceExt_GetCudaTextureObject(IUnknown *device_ext, D3D12_CPU_DESCRIPTOR_HANDLE srv_handle, D3D12_CPU_DESCRIPTOR_HANDLE sampler_handle, UINT32 *cuda_texture_handle);
-HRESULT ID3D12DeviceExt_GetCudaSurfaceObject(IUnknown *device_ext, D3D12_CPU_DESCRIPTOR_HANDLE uav_handle, UINT32 *cuda_surface_handle);
+class D3D12DeviceExt final : public IUnknown
+{
+public:
+	explicit D3D12DeviceExt(D3D12Device *device);
+	~D3D12DeviceExt();
 
-HRESULT ID3D12DeviceExt2_GetCudaMergedTextureSamplerObject(IUnknown *device_ext, D3D12_GET_CUDA_MERGED_TEXTURE_SAMPLER_OBJECT_PARAMS *params);
-HRESULT ID3D12DeviceExt2_GetCudaIndependentDescriptorObject(IUnknown *device_ext, D3D12_GET_CUDA_INDEPENDENT_DESCRIPTOR_OBJECT_PARAMS *params);
+	#pragma region IUnknown
+	HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObj) override;
+	ULONG   STDMETHODCALLTYPE AddRef() override;
+	ULONG   STDMETHODCALLTYPE Release() override;
+	#pragma endregion
+
+	// ID3D12DeviceExt
+	virtual HRESULT STDMETHODCALLTYPE GetVulkanHandles(void *vk_instance, void *vk_physical_device, void *vk_device);
+	virtual BOOL    STDMETHODCALLTYPE GetExtensionSupport(UINT extension);
+	virtual HRESULT STDMETHODCALLTYPE CreateCubinComputeShaderWithName(const void *cubin_data, UINT32 cubin_size, UINT32 block_x, UINT32 block_y, UINT32 block_z, const char *shader_name, void **handle);
+	virtual HRESULT STDMETHODCALLTYPE DestroyCubinComputeShader(void *handle);
+	virtual HRESULT STDMETHODCALLTYPE GetCudaTextureObject(D3D12_CPU_DESCRIPTOR_HANDLE srv_handle, D3D12_CPU_DESCRIPTOR_HANDLE sampler_handle, UINT32 *cuda_texture_handle);
+	virtual HRESULT STDMETHODCALLTYPE GetCudaSurfaceObject(D3D12_CPU_DESCRIPTOR_HANDLE uav_handle, UINT32 *cuda_surface_handle);
+	virtual HRESULT STDMETHODCALLTYPE CaptureUAVInfo(void *uav_info);
+
+	// ID3D12DeviceExt1
+	virtual HRESULT STDMETHODCALLTYPE CreateResourceFromBorrowedHandle(const D3D12_RESOURCE_DESC1 *desc, UINT64 vk_handle, ID3D12Resource **resource);
+	virtual HRESULT STDMETHODCALLTYPE GetVulkanQueueInfoEx(ID3D12CommandQueue *queue, void *vk_queue, UINT32 *vk_queue_index, UINT32 *vk_queue_flags, UINT32 *vk_queue_family);
+
+	// ID3D12DeviceExt2
+	virtual BOOL    STDMETHODCALLTYPE SupportsCubin64bit();
+	virtual HRESULT STDMETHODCALLTYPE CreateCubinComputeShaderExV2(void *params);
+	virtual HRESULT STDMETHODCALLTYPE GetCudaMergedTextureSamplerObject(D3D12_GET_CUDA_MERGED_TEXTURE_SAMPLER_OBJECT_PARAMS *params);
+	virtual HRESULT STDMETHODCALLTYPE GetCudaIndependentDescriptorObject(D3D12_GET_CUDA_INDEPENDENT_DESCRIPTOR_OBJECT_PARAMS *params);
+
+	// ID3D12DeviceExt3-5
+	virtual BOOL    STDMETHODCALLTYPE SupportsAGSExtension(UINT ags_extension);
+	virtual HRESULT STDMETHODCALLTYPE SetAGSUAVSlot(UINT uav_slot);
+	virtual BOOL    STDMETHODCALLTYPE IsNvShaderExtnOpCodeSupported(UINT32 op_code);
+	virtual HRESULT STDMETHODCALLTYPE SetNvShaderExtnSlotSpace(UINT32 uav_slot, UINT32 uav_space, BOOL local_thread);
+	virtual BOOL    STDMETHODCALLTYPE SetCreatePipelineStateFlagsNVAPI(UINT pipeline_state_flags);
+
+private:
+	HRESULT check_and_upgrade_interface(REFIID riid);
+
+	D3D12Device *const _parent_device;
+	IUnknown *_orig = nullptr;
+	unsigned short _interface_version = 0;
+};
 
 #endif


### PR DESCRIPTION
**Updated:**
ReShade currently hooks the shared vtable of VKD3D-Proton's `ID3D12DeviceExt*` interfaces in order to translate ReShade virtual CPU descriptor handles before forwarding CUDA descriptor operations.

Since this modifies the native VKD3D extension object's vtable, the hooks also affect callers that intentionally use the original D3D12 device, for example add-ons using `get_native()`. Those callers create and pass native descriptor handles, which must not be passed through `convert_to_original_cpu_descriptor_handle()`.

This can result in either an invalid descriptor heap dereference inside ReShade or a native descriptor being translated through an unrelated ReShade descriptor heap before being passed to VKD3D.

This change replaces the shared `ID3D12DeviceExt*` vtable hooks with an extension proxy returned when the interface is queried through ReShade's `D3D12Device` proxy.

The proxy forwards the VKD3D extension interfaces through `ID3D12DeviceExt5` and only converts descriptor handles for the descriptor-bearing methods:

* `GetCudaTextureObject`
* `GetCudaSurfaceObject`
* `GetCudaMergedTextureSamplerObject`
* `GetCudaIndependentDescriptorObject`

All other extension methods are forwarded unchanged.

Calls that query an extension interface through ReShade's D3D12 device therefore continue to receive descriptor translation. Calls that obtain the native device first and query the extension interface from that device receive VKD3D's native extension object directly and bypass ReShade.

`convert_to_original_cpu_descriptor_handle()` remains unchanged.

### Testing

Tested with a full add-on Release build on D3D12 through VKD3D-Proton using stock DXVK-NVAPI.

Kingdom Come: Deliverance II was tested with four configurations:

1. Stock ReShade 6.8.0.2155 + RenoDX DLSS5 v4.6: reproduces the original `EXCEPTION_ACCESS_VIOLATION` during the NR path.
2. ReShade with this proxy change + the same RenoDX v4.6 build: NR initializes and evaluates successfully without the crash.
3. ReShade with this proxy change + the older RenoDX v4.1.5 build that previously worked: NR still initializes and evaluates successfully, confirming that the ReShade descriptor conversion path continues to work.
4. ReShade with this proxy change + current RenoDX v5.0: NR initializes and evaluates successfully.

The proxy implementation was also rebuilt and retested against current ReShade `main` without regression.

<del>
ReShade currently assumes that every `D3D12_CPU_DESCRIPTOR_HANDLE` passed to `convert_to_original_cpu_descriptor_handle()` is one of its own virtual descriptor handles.

This is not necessarily true for private D3D12 extension interfaces. In particular, the VKD3D-Proton CUDA descriptor extension functions may pass native CPU descriptor handles through ReShade's hooks.

A native descriptor can coincidentally contain bits that decode to an existing ReShade descriptor heap index. The current implementation then treats it as a ReShade virtual handle and translates it using the wrong descriptor heap.

I observed two failure modes while debugging this:

* If the apparent heap index does not refer to a live ReShade heap, ReShade can dereference an invalid/null heap entry.
* If it happens to refer to a live heap, the native descriptor can instead be incorrectly translated and the corrupted descriptor is then passed to the underlying D3D12 implementation.

ReShade's virtual CPU descriptor handles already encode enough information to distinguish them more reliably: the heap type/flags are stored in the lower three bits, and the descriptor offset must fall within the referenced heap.

This change therefore only converts a handle when:

1. The encoded heap index refers to a live ReShade heap.
2. The lower metadata bits match that heap's virtual base handle.
3. The encoded descriptor offset is within the descriptor heap.

Otherwise the original handle is returned unchanged.

### Testing

Tested with a full add-on Release build on D3D12 through VKD3D-Proton using DXVK-NVAPI.

The reproducer was a ReShade add-on using VKD3D's `ID3D12DeviceExt2` CUDA descriptor interfaces. Before this change, enabling the relevant rendering path reliably caused an access violation. With this change and otherwise stock DXVK-NVAPI, the same path initializes and renders correctly.

Existing ReShade virtual descriptor handling also remains functional in the tested workload.
</del>
